### PR TITLE
Add AGENTS instructions and setup scaffold

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,38 @@
+# AGENTS Instructions
+
+This repository contains `animath`, a modular browser-based toolkit for creating mathematical animations using TypeScript/React and WebGL (Three.js).
+
+## Development Quick Start
+
+1. Install dependencies and start the Vite dev server:
+   ```bash
+   npm run dev
+   ```
+   which serves the application at <http://localhost:5173>.
+
+2. For a production build and simple preview:
+   ```bash
+   npm run build   # outputs files to dist/
+   npx serve dist  # preview
+   ```
+
+Node 20+ and npm 10+ are recommended.
+
+## Creating New Animations
+
+The project is designed to allow small, self-contained React components for individual animations. A typical workflow is:
+
+1. Create a new folder inside `src/animations/`.
+2. Implement a React component (e.g. `<MyCoolThing/>`) extending the `Canvas3D` wrapper.
+3. Add a route entry in `src/index.tsx` so the animation is accessible.
+4. Provide a `README.md` inside the animation folder explaining the maths.
+
+Shader code can be kept inline or loaded with `vite-plugin-glsl`.
+
+## Contribution Checks
+
+Before opening a pull request, run `npm run build` to ensure the project compiles. There are currently no automated tests.
+
+---
+
+These instructions apply repository-wide.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,6 @@
+# Plan
+
+1. Create `AGENTS.md` summarizing repository guidelines derived from `README.md`.
+2. Add `requirements.txt` for potential Python tools (currently empty placeholder).
+3. Add `/run/setup.sh` script to demonstrate environment setup.
+4. Document the installation steps in `AGENTS.md` and ensure the script can be run with `pip install -r requirements.txt && npm install && ./run/setup.sh`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+# Placeholder for Python dependencies

--- a/run/setup.sh
+++ b/run/setup.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+# Placeholder setup script
+# Add additional initialization steps here
+
+echo "Running setup.sh..."


### PR DESCRIPTION
## Summary
- add AGENTS guidelines derived from README
- outline future work in PLAN.md
- create empty requirements.txt
- add run/setup.sh placeholder

## Testing
- `npm run build` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68404005e93c832995872bb6c885da43