### PR TITLE
Add GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy demo
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v2
+

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 > *Animated mathematics for curious minds* — a modular, browser-based toolkit for creating, sharing, and exploring mathematical animations and generative art.
 
 <p align="center">
-  <!-- Example animation GIF or PNG goes here -->
-  <em>(demo placeholder)</em>
+  <!-- Update USERNAME to your GitHub account -->
+  <a href="https://USERNAME.github.io/animath/">Live demo</a>
 </p>
 
 ---

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 
 export default defineConfig({
+  base: '/animath/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- link the README demo section to GitHub Pages
- configure Vite base path for Pages
- add a workflow to build and deploy to GitHub Pages

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684050e87b448329a6f3b9bcfc3d44c1