### PR TITLE
Switch GitHub Pages deploy to manual

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,7 @@
 name: Deploy demo
 
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ npx serve dist  # quick sanity check
 
 Node ≥ 20, npm ≥ 10 recommended.
 
+To publish the live demo on GitHub Pages, trigger the `Deploy demo` workflow
+manually from the repository's Actions tab.
+
 ---
 
 ## 4 Repository layout


### PR DESCRIPTION
## Summary
- change deploy workflow trigger to `workflow_dispatch`
- document manual deployment in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68407a2209d083299f8d6ded17365a5f