### PR TITLE
Add saturation slider control

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import Canvas3D from '../../components/Canvas3D';
 import { vertexShader, fragmentShader } from './shaders';
@@ -9,6 +9,8 @@ export interface ComplexParticlesProps {
 }
 
 export default function ComplexParticles({ count = 40000, selectedFunction = 'sqrt' }: ComplexParticlesProps) {
+  const [saturation, setSaturation] = useState(1);
+  const materialRef = useRef<THREE.ShaderMaterial>();
   const onMount = (ctx: { scene: THREE.Scene; camera: THREE.PerspectiveCamera; renderer: THREE.WebGLRenderer }) => {
     const { scene, camera, renderer } = ctx;
     camera.position.z = 5;
@@ -17,7 +19,8 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
       uniforms: {
         time: { value: 0 },
         opacity: { value: 0.9 },
-        functionType: { value: 0 }
+        functionType: { value: 0 },
+        saturation: { value: saturation }
       },
       vertexShader,
       fragmentShader,
@@ -44,6 +47,7 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
     geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
     geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
 
+    materialRef.current = particleMaterial;
     const particles = new THREE.Points(geometry, particleMaterial);
     scene.add(particles);
 
@@ -57,5 +61,28 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
     animate();
   };
 
-  return <Canvas3D onMount={onMount} />;
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.saturation.value = saturation;
+    }
+  }, [saturation]);
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <Canvas3D onMount={onMount} />
+      <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
+        <label>
+          Saturation:
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={saturation}
+            onChange={(e) => setSaturation(parseFloat(e.target.value))}
+          />
+        </label>
+      </div>
+    </div>
+  );
 }

--- a/src/animations/ComplexParticles/README.md
+++ b/src/animations/ComplexParticles/README.md
@@ -1,3 +1,3 @@
 # Complex Particles
 
-Visualises a complex map `z -> f(z)` using domain colouring in four dimensions. The vertex shader computes colours while the fragment shader renders round glowing points. Rename from the earlier `ComplexSqrtParticles` to reflect that any analytic function can be displayed.
+Visualises a complex map `z -> f(z)` using domain colouring in four dimensions. The vertex shader computes colours while the fragment shader renders round glowing points. Rename from the earlier `ComplexSqrtParticles` to reflect that any analytic function can be displayed. A saturation slider lets you tweak the colour intensity in real time.

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -2,6 +2,7 @@ export const vertexShader = `
 // DOMAIN–COLORING VERTEX SHADER
 uniform float time;
 uniform int   functionType;
+uniform float saturation;
 attribute float size;
 varying vec3 vColor;
 
@@ -18,7 +19,7 @@ mat4 rotXW(float a){float c=cos(a),s=sin(a);return mat4(c,0,0,s, 0,1,0,0, 0,0,1,
 mat4 rotYZ(float a){float c=cos(a),s=sin(a);return mat4(1,0,0,0, 0,c,-s,0, 0,s,c,0, 0,0,0,1);} 
 mat4 rotXY(float a){float c=cos(a),s=sin(a);return mat4(c,-s,0,0, s,c,0,0, 0,0,1,0, 0,0,0,1);} 
 vec3 hsv2rgb(vec3 c){vec4 K = vec4(1., 2./3., 1./3., 3.);vec3 p = abs(fract(c.xxx + K.xyz)*6. - K.www);return c.z * mix(K.xxx, clamp(p-K.xxx, 0., 1.), c.y);} 
-void main(){vec2 z = vec2(position.x, position.z);vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec4 p4 = vec4(z.x, z.y, f.x, f.y);float t = time*0.3;p4 = rotXW(t) * rotYZ(t*0.7) * rotXY(t*0.5) * p4;float w = 3. + p4.w;vec3 pos3 = p4.xyz / w * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * (80. / -mv.z);float hue = fract((atan(f.y, f.x) / 6.28318530718) + 1.);float logMag = log(length(f) + 1e-6);float val    = 0.5 * (1. + tanh(logMag));float stripes = sin(6.28318530718 * logMag);val = mix(val, clamp(val * (0.75 + 0.25*stripes), 0., 1.), 0.5);vColor = hsv2rgb(vec3(hue, 1., val));}`;
+void main(){vec2 z = vec2(position.x, position.z);vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec4 p4 = vec4(z.x, z.y, f.x, f.y);float t = time*0.3;p4 = rotXW(t) * rotYZ(t*0.7) * rotXY(t*0.5) * p4;float w = 3. + p4.w;vec3 pos3 = p4.xyz / w * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * (80. / -mv.z);float hue = fract((atan(f.y, f.x) / 6.28318530718) + 1.);float logMag = log(length(f) + 1e-6);float val    = 0.5 * (1. + tanh(logMag));float stripes = sin(6.28318530718 * logMag);val = mix(val, clamp(val * (0.75 + 0.25*stripes), 0., 1.), 0.5);vColor = hsv2rgb(vec3(hue, saturation, val));}`;
 
 export const fragmentShader = `
 uniform float opacity;


### PR DESCRIPTION
## Summary
- allow adjusting color saturation for ComplexParticles
- include new uniform in shader
- document the new slider in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68407ec407fc8329adb2e041d2f99934