### PR TITLE
Add R2 mapping utility and demo

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -4,3 +4,5 @@
 2. Add `requirements.txt` for potential Python tools (currently empty placeholder).
 3. Add `/run/setup.sh` script to demonstrate environment setup.
 4. Document the installation steps in `AGENTS.md` and ensure the script can be run with `pip install -r requirements.txt && npm install && ./run/setup.sh`.
+5. Introduce a generic `R2Mapping` utility for mapping ℝ² → ℝ².
+6. Provide a demo component using selectable mappings and adjustable appearance.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,13 @@
 import React from 'react';
 import ComplexParticles from './animations/ComplexParticles/ComplexParticles';
+import R2MappingDemo from './animations/R2MappingDemo/R2MappingDemo';
 
 export default function App() {
-  return <ComplexParticles />;
+  return (
+    <>
+      <ComplexParticles />
+      {/* Uncomment to view the R2 mapping demo */}
+      {/* <R2MappingDemo /> */}
+    </>
+  );
 }

--- a/src/animations/R2MappingDemo/AGENTS.md
+++ b/src/animations/R2MappingDemo/AGENTS.md
@@ -1,0 +1,5 @@
+# AGENTS Instructions for R2MappingDemo
+
+- Keep this demo simple and self-contained.
+- Additional mappings should be defined in `src/lib/R2Mapping.ts`.
+- Use the provided `Canvas3D` wrapper for Three.js setup.

--- a/src/animations/R2MappingDemo/R2MappingDemo.tsx
+++ b/src/animations/R2MappingDemo/R2MappingDemo.tsx
@@ -1,0 +1,69 @@
+import React, { useEffect, useState, useRef } from 'react';
+import * as THREE from 'three';
+import Canvas3D from '../../components/Canvas3D';
+import { R2Mapping, R2Functions, Vec2 } from '../../lib/R2Mapping';
+
+interface DemoProps {
+  count?: number;
+}
+
+const mappings: { [key: string]: R2Mapping } = {
+  identity: new R2Mapping(R2Functions.identity),
+  square: new R2Mapping(R2Functions.complexSquare),
+  sqrt: new R2Mapping(R2Functions.complexSqrt),
+  swirl: new R2Mapping(R2Functions.swirl)
+};
+
+export default function R2MappingDemo({ count = 10000 }: DemoProps) {
+  const [mappingName, setMappingName] = useState<keyof typeof mappings>('identity');
+  const materialRef = useRef<THREE.PointsMaterial>();
+  const geomRef = useRef<THREE.BufferGeometry>();
+
+  useEffect(() => {
+    if (!geomRef.current) return;
+    const geometry = geomRef.current;
+    const side = Math.sqrt(count);
+    const positions = new Float32Array(count * 3);
+    let i = 0;
+    for (let ix = 0; ix < side; ix++) {
+      for (let iy = 0; iy < side; iy++) {
+        const x = (ix / side - 0.5) * 4;
+        const y = (iy / side - 0.5) * 4;
+        const mapped = mappings[mappingName].map({ x, y });
+        positions[3 * i] = mapped.x;
+        positions[3 * i + 1] = 0;
+        positions[3 * i + 2] = mapped.y;
+        i++;
+      }
+    }
+    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+    geometry.attributes.position.needsUpdate = true;
+  }, [mappingName, count]);
+
+  const onMount = React.useCallback((ctx: { scene: THREE.Scene; camera: THREE.PerspectiveCamera; renderer: THREE.WebGLRenderer; }) => {
+    const { scene, camera } = ctx;
+    camera.position.z = 5;
+
+    const geometry = new THREE.BufferGeometry();
+    geomRef.current = geometry;
+
+    const material = new THREE.PointsMaterial({ color: '#00ffaa', size: 0.05 });
+    materialRef.current = material;
+
+    const points = new THREE.Points(geometry, material);
+    scene.add(points);
+  }, []);
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <Canvas3D onMount={onMount} />
+      <div style={{ position: 'absolute', top: 10, left: 10, color: 'white', fontFamily: 'monospace' }}>
+        <select value={mappingName} onChange={e => setMappingName(e.target.value as any)}>
+          {Object.keys(mappings).map(name => (
+            <option key={name} value={name}>{name}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/animations/R2MappingDemo/README.md
+++ b/src/animations/R2MappingDemo/README.md
@@ -1,0 +1,3 @@
+# R2 Mapping Demo
+
+A minimal example demonstrating the generic `R2Mapping` class. A grid of points is transformed by a selected mapping and displayed with Three.js.

--- a/src/lib/R2Mapping.ts
+++ b/src/lib/R2Mapping.ts
@@ -1,0 +1,43 @@
+export type Vec2 = { x: number; y: number };
+
+export type MappingFunction = (p: Vec2) => Vec2;
+
+/**
+ * Generic R^2 -> R^2 mapping.
+ * The class simply stores a mapping function and exposes a `map` method.
+ */
+export class R2Mapping {
+  func: MappingFunction;
+  constructor(func: MappingFunction = (p) => ({ ...p })) {
+    this.func = func;
+  }
+  map(p: Vec2): Vec2 {
+    return this.func(p);
+  }
+}
+
+// A small library of common mappings
+export const R2Functions = {
+  /** Identity mapping */
+  identity: (p: Vec2): Vec2 => ({ x: p.x, y: p.y }),
+
+  /** Treat (x,y) as complex number and return its square */
+  complexSquare: (p: Vec2): Vec2 => ({ x: p.x * p.x - p.y * p.y, y: 2 * p.x * p.y }),
+
+  /** Square root in the complex plane (principal branch) */
+  complexSqrt: (p: Vec2): Vec2 => {
+    const r = Math.hypot(p.x, p.y);
+    const theta = Math.atan2(p.y, p.x) * 0.5;
+    const sr = Math.sqrt(r);
+    return { x: sr * Math.cos(theta), y: sr * Math.sin(theta) };
+  },
+
+  /** Swirling deformation depending on radius */
+  swirl: (p: Vec2): Vec2 => {
+    const r = Math.hypot(p.x, p.y);
+    const angle = r;
+    const c = Math.cos(angle);
+    const s = Math.sin(angle);
+    return { x: p.x * c - p.y * s, y: p.x * s + p.y * c };
+  }
+};


### PR DESCRIPTION
## Summary
- create a `R2Mapping` class and common functions
- add new `R2MappingDemo` animation to demonstrate selectable mappings
- wire component in `App.tsx` (commented out by default)
- document new tasks in `PLAN.md`
- include instructions for the demo via AGENTS

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684090ad733483298b62b0422914dc7d