### PR TITLE
Simplify R2Mapping demo

### DIFF
--- a/src/animations/R2MappingDemo/R2MappingDemo.tsx
+++ b/src/animations/R2MappingDemo/R2MappingDemo.tsx
@@ -1,94 +1,104 @@
-import React, { useEffect, useState, useRef } from 'react';
+import React, { useRef } from 'react';
 import * as THREE from 'three';
 import Canvas3D from '../../components/Canvas3D';
-import { R2Mapping, R2Functions, Vec2 } from '../../lib/R2Mapping';
 
 interface DemoProps {
   count?: number;
 }
 
-const mappings: { [key: string]: R2Mapping } = {
-  identity: new R2Mapping(R2Functions.identity),
-  square: new R2Mapping(R2Functions.complexSquare),
-  sqrt: new R2Mapping(R2Functions.complexSqrt),
-  ln: new R2Mapping(R2Functions.complexLn),
-  exp: new R2Mapping(R2Functions.complexExp),
-  sin: new R2Mapping(R2Functions.complexSin),
-  cos: new R2Mapping(R2Functions.complexCos),
-  tan: new R2Mapping(R2Functions.complexTan),
-  inverse: new R2Mapping(R2Functions.complexInverse),
-  swirl: new R2Mapping(R2Functions.swirl)
-};
+// Shaders copied from the ComplexParticles demo but fixed to the
+// complex exponential mapping and full saturation.
+const vertexShader = `
+uniform float time;
+attribute float size;
+varying vec3 vColor;
 
-export default function R2MappingDemo({ count = 10000 }: DemoProps) {
-  const [mappingName, setMappingName] = useState<keyof typeof mappings>('identity');
-  const [color, setColor] = useState('#00ffaa');
-  const materialRef = useRef<THREE.PointsMaterial>();
-  const geomRef = useRef<THREE.BufferGeometry>();
+vec2 complexExp(vec2 z){float ex=exp(z.x);return vec2(ex*cos(z.y),ex*sin(z.y));}
+mat4 rotXW(float a){float c=cos(a),s=sin(a);return mat4(c,0,0,s, 0,1,0,0, 0,0,1,0,-s,0,0,c);}
+mat4 rotYZ(float a){float c=cos(a),s=sin(a);return mat4(1,0,0,0, 0,c,-s,0, 0,s,c,0, 0,0,0,1);}
+mat4 rotXY(float a){float c=cos(a),s=sin(a);return mat4(c,-s,0,0, s,c,0,0, 0,0,1,0, 0,0,0,1);}
+vec3 hsv2rgb(vec3 c){vec4 K = vec4(1.,2./3.,1./3.,3.);vec3 p = abs(fract(c.xxx+K.xyz)*6.-K.www);return c.z*mix(K.xxx,clamp(p-K.xxx,0.,1.),c.y);}
 
-  useEffect(() => {
-    if (!geomRef.current) return;
-    const geometry = geomRef.current;
-    const side = Math.sqrt(count);
-    const positions = new Float32Array(count * 3);
-    let i = 0;
-    for (let ix = 0; ix < side; ix++) {
-      for (let iy = 0; iy < side; iy++) {
-        const x = (ix / side - 0.5) * 4;
-        const y = (iy / side - 0.5) * 4;
-        const mapped = mappings[mappingName].map({ x, y });
-        positions[3 * i] = mapped.x;
-        positions[3 * i + 1] = 0;
-        positions[3 * i + 2] = mapped.y;
-        i++;
-      }
-    }
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geometry.attributes.position.needsUpdate = true;
-    if (materialRef.current) {
-      materialRef.current.color.set(color);
-    }
-  }, [mappingName, count, color]);
+void main(){
+  vec2 z = vec2(position.x, position.z);
+  vec2 f = complexExp(z);
+  if(length(f) > 1e3) f = normalize(f)*1e3;
+  vec4 p4 = vec4(z.x, z.y, f.x, f.y);
+  float t = time*0.3;
+  p4 = rotXW(t) * rotYZ(t*0.7) * rotXY(t*0.5) * p4;
+  float w = 3. + p4.w;
+  vec3 pos3 = p4.xyz / w * 1.5;
+  vec4 mv  = modelViewMatrix * vec4(pos3,1.);
+  gl_Position = projectionMatrix * mv;
+  gl_PointSize = size * (80. / -mv.z);
+  float hue = fract((atan(f.y,f.x)/6.28318530718)+1.);
+  float logMag = log(length(f)+1e-6);
+  float val = 0.5*(1.+tanh(logMag));
+  float stripes = sin(6.28318530718*logMag);
+  val = mix(val, clamp(val*(0.75+0.25*stripes),0.,1.),0.5);
+  vColor = hsv2rgb(vec3(hue,1.,val));
+}`;
+
+const fragmentShader = `
+uniform float opacity;
+varying vec3 vColor;
+void main(){vec2 d=gl_PointCoord-vec2(0.5);float r2=dot(d,d);if(r2>0.25) discard;float a=(1.-smoothstep(0.2,0.5,sqrt(r2)))*opacity;gl_FragColor=vec4(vColor,a);}`;
+
+export default function R2MappingDemo({ count = 40000 }: DemoProps) {
 
   const onMount = React.useCallback(
     (ctx: { scene: THREE.Scene; camera: THREE.PerspectiveCamera; renderer: THREE.WebGLRenderer }) => {
       const { scene, camera, renderer } = ctx;
       camera.position.z = 5;
 
+      const particleMaterial = new THREE.ShaderMaterial({
+        uniforms: {
+          time: { value: 0 },
+          opacity: { value: 0.9 }
+        },
+        vertexShader,
+        fragmentShader,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        vertexColors: true
+      });
+
+      const side = Math.sqrt(count);
       const geometry = new THREE.BufferGeometry();
-      geomRef.current = geometry;
+      const positions = new Float32Array(count * 3);
+      const sizes = new Float32Array(count);
+      let i = 0;
+      for (let ix = 0; ix < side; ix++) {
+        for (let iz = 0; iz < side; iz++) {
+          positions[3 * i] = (ix / side - 0.5) * 4;
+          positions[3 * i + 1] = 0;
+          positions[3 * i + 2] = (iz / side - 0.5) * 4;
+          sizes[i] = 1;
+          i++;
+        }
+      }
+      geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
 
-      const material = new THREE.PointsMaterial({ color, size: 0.05 });
-      materialRef.current = material;
+      const particles = new THREE.Points(geometry, particleMaterial);
+      scene.add(particles);
 
-      const points = new THREE.Points(geometry, material);
-      scene.add(points);
-
+      const clock = new THREE.Clock();
       const animate = () => {
+        const t = clock.getElapsedTime();
+        particleMaterial.uniforms.time.value = t;
         renderer.render(scene, camera);
         requestAnimationFrame(animate);
       };
       animate();
     },
-    [color]
+    [count]
   );
 
   return (
     <div style={{ position: 'relative' }}>
       <Canvas3D onMount={onMount} />
-      <div style={{ position: 'absolute', top: 10, left: 10, color: 'white', fontFamily: 'monospace' }}>
-        <select value={mappingName} onChange={e => setMappingName(e.target.value as any)}>
-          {Object.keys(mappings).map(name => (
-            <option key={name} value={name}>{name}</option>
-          ))}
-        </select>
-        <input
-          type="color"
-          value={color}
-          onChange={e => setColor(e.target.value)}
-          style={{ marginLeft: '0.5rem' }}
-        />
-      </div>
     </div>
   );
 }

--- a/src/animations/R2MappingDemo/README.md
+++ b/src/animations/R2MappingDemo/README.md
@@ -1,5 +1,7 @@
 # R2 Mapping Demo
 
-A minimal example demonstrating the generic `R2Mapping` class. A grid of points is transformed by a selected mapping and displayed with Three.js. Choose from several complex functions and adjust the point colour.
+A minimal example demonstrating the generic `R2Mapping` class. A grid of points
+is coloured and animated using the complex exponential mapping. The look mirrors
+the `ComplexParticles` demo but without any UI controls.
 
 Open `/#/r2mapping` on the deployed site to view this demo.


### PR DESCRIPTION
## Summary
- update the R2 mapping example to mirror the ComplexParticles look
- remove mapping dropdown and colour picker
- color and animate points using the complex exponential

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840b4b63c408329a7c61178056bd73a