### PR TITLE
Add function selector menu to ComplexParticles

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import Canvas3D from '../../components/Canvas3D';
+import ToggleMenu from '../../components/ToggleMenu';
 import { vertexShader, fragmentShader } from './shaders';
 
 export interface ComplexParticlesProps {
@@ -8,8 +9,23 @@ export interface ComplexParticlesProps {
   selectedFunction?: string;
 }
 
+const functionNames = [
+  'sqrt',
+  'square',
+  'ln',
+  'exp',
+  'sin',
+  'cos',
+  'tan',
+  'inverse'
+];
+
 export default function ComplexParticles({ count = 40000, selectedFunction = 'sqrt' }: ComplexParticlesProps) {
   const [saturation, setSaturation] = useState(1);
+  const [functionIndex, setFunctionIndex] = useState(() => {
+    const idx = functionNames.indexOf(selectedFunction);
+    return idx >= 0 ? idx : 0;
+  });
   const materialRef = useRef<THREE.ShaderMaterial>();
   const onMount = React.useCallback(
     (ctx: {
@@ -24,7 +40,7 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
       uniforms: {
         time: { value: 0 },
         opacity: { value: 0.9 },
-        functionType: { value: 0 },
+        functionType: { value: functionIndex },
         saturation: { value: saturation }
       },
       vertexShader,
@@ -72,22 +88,44 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
     }
   }, [saturation]);
 
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.functionType.value = functionIndex;
+    }
+  }, [functionIndex]);
+
   return (
     <div style={{ position: 'relative' }}>
       <Canvas3D onMount={onMount} />
-      <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
-        <label>
-          Saturation:
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={saturation}
-            onChange={(e) => setSaturation(parseFloat(e.target.value))}
-          />
-        </label>
-      </div>
+      <ToggleMenu title="Menu">
+        <div style={{ color: 'white' }}>
+          <label>
+            Function:
+            <select
+              value={functionIndex}
+              onChange={(e) => setFunctionIndex(parseInt(e.target.value, 10))}
+            >
+              {functionNames.map((name, idx) => (
+                <option key={name} value={idx}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <br />
+          <label>
+            Saturation:
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={saturation}
+              onChange={(e) => setSaturation(parseFloat(e.target.value))}
+            />
+          </label>
+        </div>
+      </ToggleMenu>
     </div>
   );
 }

--- a/src/animations/ComplexParticles/README.md
+++ b/src/animations/ComplexParticles/README.md
@@ -1,3 +1,3 @@
 # Complex Particles
 
-Visualises a complex map `z -> f(z)` using domain colouring in four dimensions. The vertex shader computes colours while the fragment shader renders round glowing points. Rename from the earlier `ComplexSqrtParticles` to reflect that any analytic function can be displayed. A saturation slider lets you tweak the colour intensity in real time.
+Visualises a complex map `z -> f(z)` using domain colouring in four dimensions. The vertex shader computes colours while the fragment shader renders round glowing points. Rename from the earlier `ComplexSqrtParticles` to reflect that any analytic function can be displayed. A small menu lets you pick the function and a saturation slider tweaks the colour intensity in real time.

--- a/src/components/ToggleMenu.tsx
+++ b/src/components/ToggleMenu.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+
+export interface ToggleMenuProps {
+  title: string;
+  children: React.ReactNode;
+}
+
+/**
+ * A simple widget that can show or hide its children.
+ * Useful for overlay menus.
+ */
+export default function ToggleMenu({ title, children }: ToggleMenuProps) {
+  const [visible, setVisible] = useState(true);
+  return (
+    <div style={{ position: 'absolute', top: 10, left: 10 }}>
+      <button onClick={() => setVisible(v => !v)}>
+        {visible ? 'Hide' : 'Show'} {title}
+      </button>
+      {visible && (
+        <div
+          style={{
+            marginTop: 8,
+            padding: 6,
+            background: 'rgba(0,0,0,0.5)',
+            color: 'white',
+            borderRadius: 4
+          }}
+        >
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- create a reusable `ToggleMenu` component for overlay menus
- let ComplexParticles choose complex function via dropdown
- update ComplexParticles readme

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840be401cb083299894bde0f0327202