### PR TITLE
Add particle layout selector to R2 mapping demo

### DIFF
--- a/src/animations/R2MappingDemo/README.md
+++ b/src/animations/R2MappingDemo/README.md
@@ -3,5 +3,6 @@
 A minimal example demonstrating the generic `R2Mapping` class. A grid of points
 is coloured and animated using a selectable complex mapping. Use the small menu
 to choose between several functions such as `sqrt`, `exp`, or `sin`.
+The menu also lets you pick the particle layout (grid, circle, spiral, random, or ring).
 
 Open `/#/r2mapping` on the deployed site to view this demo.


### PR DESCRIPTION
## Summary
- allow user to pick particle layout in **R2MappingDemo**
- document new layouts (grid, circle, spiral, random, ring) in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840c9e9dc108329b30c760503dac8cf