### PR TITLE
Add particle controls and shimmer to R2 mapping demo

### DIFF
--- a/src/animations/R2MappingDemo/README.md
+++ b/src/animations/R2MappingDemo/README.md
@@ -3,5 +3,7 @@
 A minimal example demonstrating the generic `R2Mapping` class. A grid of points
 is coloured and animated using a selectable complex mapping. Use the small menu
 to choose between several functions such as `sqrt`, `exp`, or `sin`.
+The menu also lets you pick the particle layout (grid, circle, spiral, random, or ring).
+Additional sliders control the number of particles, their size, opacity, colour intensity and a shimmer effect. A hue shift slider allows fine tuning of the colour map.
 
 Open `/#/r2mapping` on the deployed site to view this demo.


### PR DESCRIPTION
## Summary
- add particle count/size/intensity/opacity sliders
- introduce shimmer and hue shift uniforms
- expose controls in R2MappingDemo menu
- document new controls in README

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6840c9e9dc108329b30c760503dac8cf