### PR TITLE
Add particle controls to ComplexParticles

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -26,7 +26,14 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
     const idx = functionNames.indexOf(selectedFunction);
     return idx >= 0 ? idx : 0;
   });
+  const [particleCount, setParticleCount] = useState(count);
+  const [size, setSize] = useState(1);
+  const [opacity, setOpacity] = useState(0.9);
+  const [intensity, setIntensity] = useState(1);
+  const [shimmer, setShimmer] = useState(0);
+  const [hueShift, setHueShift] = useState(0);
   const materialRef = useRef<THREE.ShaderMaterial>();
+  const geometryRef = useRef<THREE.BufferGeometry>();
   const onMount = React.useCallback(
     (ctx: {
       scene: THREE.Scene;
@@ -36,37 +43,41 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
       const { scene, camera, renderer } = ctx;
       camera.position.z = 5;
 
-    const particleMaterial = new THREE.ShaderMaterial({
-      uniforms: {
-        time: { value: 0 },
-        opacity: { value: 0.9 },
-        functionType: { value: functionIndex },
-        saturation: { value: saturation }
-      },
-      vertexShader,
-      fragmentShader,
-      transparent: true,
-      depthWrite: false,
-      blending: THREE.AdditiveBlending,
-      vertexColors: true
-    });
+      const particleMaterial = new THREE.ShaderMaterial({
+        uniforms: {
+          time: { value: 0 },
+          opacity: { value: opacity },
+          functionType: { value: functionIndex },
+          globalSize: { value: size },
+          intensity: { value: intensity },
+          shimmerAmp: { value: shimmer },
+          hueShift: { value: hueShift },
+          saturation: { value: saturation }
+        },
+        vertexShader,
+        fragmentShader,
+        transparent: true,
+        depthWrite: false,
+        blending: THREE.AdditiveBlending,
+        vertexColors: true
+      });
 
-    const side = Math.sqrt(count);
-    const geometry = new THREE.BufferGeometry();
-    const positions = new Float32Array(count * 3);
-    const sizes = new Float32Array(count);
-    let i = 0;
-    for (let ix = 0; ix < side; ix++) {
-      for (let iz = 0; iz < side; iz++) {
-        positions[3 * i] = (ix / side - 0.5) * 4;
-        positions[3 * i + 1] = 0;
-        positions[3 * i + 2] = (iz / side - 0.5) * 4;
-        sizes[i] = 1;
-        i++;
+      const side = Math.sqrt(particleCount);
+      const geometry = new THREE.BufferGeometry();
+      geometryRef.current = geometry;
+      const positions = new Float32Array(particleCount * 3);
+      const sizes = new Float32Array(particleCount).fill(1);
+      let i = 0;
+      for (let ix = 0; ix < side; ix++) {
+        for (let iz = 0; iz < side; iz++) {
+          positions[3 * i] = (ix / side - 0.5) * 4;
+          positions[3 * i + 1] = 0;
+          positions[3 * i + 2] = (iz / side - 0.5) * 4;
+          i++;
+        }
       }
-    }
-    geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
-    geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+      geometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+      geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
 
     materialRef.current = particleMaterial;
     const particles = new THREE.Points(geometry, particleMaterial);
@@ -80,7 +91,7 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
       requestAnimationFrame(animate);
     };
     animate();
-    }, [count]);
+    }, [particleCount, functionIndex]);
 
   useEffect(() => {
     if (materialRef.current) {
@@ -90,9 +101,59 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
 
   useEffect(() => {
     if (materialRef.current) {
+      materialRef.current.uniforms.opacity.value = opacity;
+    }
+  }, [opacity]);
+
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.globalSize.value = size;
+    }
+  }, [size]);
+
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.intensity.value = intensity;
+    }
+  }, [intensity]);
+
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.shimmerAmp.value = shimmer;
+    }
+  }, [shimmer]);
+
+  useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.hueShift.value = hueShift;
+    }
+  }, [hueShift]);
+
+  useEffect(() => {
+    if (materialRef.current) {
       materialRef.current.uniforms.functionType.value = functionIndex;
     }
   }, [functionIndex]);
+
+  useEffect(() => {
+    if (geometryRef.current) {
+      const side = Math.sqrt(particleCount);
+      const pos = new Float32Array(particleCount * 3);
+      const sizes = new Float32Array(particleCount).fill(1);
+      let i = 0;
+      for (let ix = 0; ix < side; ix++) {
+        for (let iz = 0; iz < side; iz++) {
+          pos[3 * i] = (ix / side - 0.5) * 4;
+          pos[3 * i + 1] = 0;
+          pos[3 * i + 2] = (iz / side - 0.5) * 4;
+          i++;
+        }
+      }
+      geometryRef.current.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+      geometryRef.current.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+      geometryRef.current.setDrawRange(0, particleCount);
+    }
+  }, [particleCount]);
 
   return (
     <div style={{ position: 'relative' }}>
@@ -122,6 +183,78 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
               step={0.01}
               value={saturation}
               onChange={(e) => setSaturation(parseFloat(e.target.value))}
+            />
+          </label>
+          <br />
+          <label>
+            Particles:
+            <input
+              type="range"
+              min={1000}
+              max={80000}
+              step={1000}
+              value={particleCount}
+              onChange={(e) => setParticleCount(parseInt(e.target.value, 10))}
+            />
+          </label>
+          <br />
+          <label>
+            Size:
+            <input
+              type="range"
+              min={0.2}
+              max={5}
+              step={0.1}
+              value={size}
+              onChange={(e) => setSize(parseFloat(e.target.value))}
+            />
+          </label>
+          <br />
+          <label>
+            Opacity:
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={opacity}
+              onChange={(e) => setOpacity(parseFloat(e.target.value))}
+            />
+          </label>
+          <br />
+          <label>
+            Intensity:
+            <input
+              type="range"
+              min={0.5}
+              max={2}
+              step={0.05}
+              value={intensity}
+              onChange={(e) => setIntensity(parseFloat(e.target.value))}
+            />
+          </label>
+          <br />
+          <label>
+            Shimmer:
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={shimmer}
+              onChange={(e) => setShimmer(parseFloat(e.target.value))}
+            />
+          </label>
+          <br />
+          <label>
+            Hue Shift:
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={hueShift}
+              onChange={(e) => setHueShift(parseFloat(e.target.value))}
             />
           </label>
         </div>

--- a/src/animations/ComplexParticles/README.md
+++ b/src/animations/ComplexParticles/README.md
@@ -1,3 +1,3 @@
 # Complex Particles
 
-Visualises a complex map `z -> f(z)` using domain colouring in four dimensions. The vertex shader computes colours while the fragment shader renders round glowing points. Rename from the earlier `ComplexSqrtParticles` to reflect that any analytic function can be displayed. A small menu lets you pick the function and a saturation slider tweaks the colour intensity in real time.
+Visualises a complex map `z -> f(z)` using domain colouring in four dimensions. The vertex shader computes colours while the fragment shader renders round glowing points. Rename from the earlier `ComplexSqrtParticles` to reflect that any analytic function can be displayed. A small menu lets you pick the function and a saturation slider tweaks the colour intensity in real time. Additional sliders control the particle count, size, opacity, colour intensity, a shimmer amount, and a hue shift.

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -2,6 +2,10 @@ export const vertexShader = `
 // DOMAIN–COLORING VERTEX SHADER
 uniform float time;
 uniform int   functionType;
+uniform float globalSize;
+uniform float intensity;
+uniform float shimmerAmp;
+uniform float hueShift;
 uniform float saturation;
 attribute float size;
 varying vec3 vColor;
@@ -19,7 +23,7 @@ mat4 rotXW(float a){float c=cos(a),s=sin(a);return mat4(c,0,0,s, 0,1,0,0, 0,0,1,
 mat4 rotYZ(float a){float c=cos(a),s=sin(a);return mat4(1,0,0,0, 0,c,-s,0, 0,s,c,0, 0,0,0,1);} 
 mat4 rotXY(float a){float c=cos(a),s=sin(a);return mat4(c,-s,0,0, s,c,0,0, 0,0,1,0, 0,0,0,1);} 
 vec3 hsv2rgb(vec3 c){vec4 K = vec4(1., 2./3., 1./3., 3.);vec3 p = abs(fract(c.xxx + K.xyz)*6. - K.www);return c.z * mix(K.xxx, clamp(p-K.xxx, 0., 1.), c.y);} 
-void main(){vec2 z = vec2(position.x, position.z);vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec4 p4 = vec4(z.x, z.y, f.x, f.y);float t = time*0.3;p4 = rotXW(t) * rotYZ(t*0.7) * rotXY(t*0.5) * p4;float w = 3. + p4.w;vec3 pos3 = p4.xyz / w * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * (80. / -mv.z);float hue = fract((atan(f.y, f.x) / 6.28318530718) + 1.);float logMag = log(length(f) + 1e-6);float val    = 0.5 * (1. + tanh(logMag));float stripes = sin(6.28318530718 * logMag);val = mix(val, clamp(val * (0.75 + 0.25*stripes), 0., 1.), 0.5);vColor = hsv2rgb(vec3(hue, saturation, val));}`;
+void main(){vec2 z = vec2(position.x, position.z);vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec4 p4 = vec4(z.x, z.y, f.x, f.y);float t = time*0.3;p4 = rotXW(t) * rotYZ(t*0.7) * rotXY(t*0.5) * p4;float w = 3. + p4.w;vec3 pos3 = p4.xyz / w * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);float hue = fract((atan(f.y, f.x) / 6.28318530718) + hueShift);float logMag = log(length(f) + 1e-6);float val    = 0.5 * (1. + tanh(logMag));float stripes = sin(6.28318530718 * logMag);val = mix(val, clamp(val * (0.75 + 0.25*stripes), 0., 1.), 0.5);float shimmer = sin(time*5.0 + position.x*4.0 + position.z*7.0);val = clamp(val * intensity * (1.0 + shimmerAmp * shimmer), 0., 1.);vColor = hsv2rgb(vec3(hue, saturation, val));}`;
 
 export const fragmentShader = `
 uniform float opacity;


### PR DESCRIPTION
## Summary
- extend ComplexParticles shader with size, intensity, shimmer and hue controls
- expose particle count and rendering parameters in ComplexParticles UI
- describe new controls in README

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6840dc86a7548329bdc2602964d58119