### PR TITLE
Adjust animation timing

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -150,8 +150,8 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
     let tCurrent = 0;
     const animate = () => {
       const elapsed = clock.getElapsedTime();
-      const targetT = realViewRef.current ? 0 : elapsed;
-      tCurrent += (targetT - tCurrent) * 0.05;
+      const targetT = realViewRef.current ? 0 : elapsed * 0.5;
+      tCurrent += (targetT - tCurrent) * 0.005;
       particleMaterial.uniforms.time.value = tCurrent;
 
 


### PR DESCRIPTION
## Summary
- slow the real-view transition speed
- slow overall animation speed by half

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68411234c8fc8329a4e0a98125eb576f