### PR TITLE
Add library of reusable Three.js materials

### DIFF
--- a/src/materials/README.md
+++ b/src/materials/README.md
@@ -1,1 +1,18 @@
-# Material Presets\n\nReusable Three.js materials for animations.
+# Material Presets
+
+Reusable Three.js materials for animations. Import any of the preset functions
+from `src/materials` to quickly apply a consistent look.
+
+## Available presets
+
+- **basic** – simple `MeshBasicMaterial` with configurable color.
+- **wireframe** – renders geometry edges only.
+- **metallic** – shiny `MeshStandardMaterial` with high metalness.
+- **glass** – transparent physical material mimicking glass.
+- **toon** – cartoon-style shading using `MeshToonMaterial`.
+- **glowSprite** – additive blending sprite for luminous effects.
+- **dashedLine** – dashed line material for outlines or grids.
+- **depthMaterial** – renders depth values of geometry.
+
+Each function accepts an optional color (when applicable) and returns a ready
+configured Three.js material instance.

--- a/src/materials/index.ts
+++ b/src/materials/index.ts
@@ -1,0 +1,48 @@
+import * as THREE from 'three';
+
+/** Basic unlit material */
+export function basic(color: number | string = 0xffffff): THREE.MeshBasicMaterial {
+  return new THREE.MeshBasicMaterial({ color });
+}
+
+/** Wireframe display of geometry */
+export function wireframe(color: number | string = 0xffffff): THREE.MeshBasicMaterial {
+  return new THREE.MeshBasicMaterial({ color, wireframe: true });
+}
+
+/** Metallic surface with slight roughness */
+export function metallic(color: number | string = 0xffffff): THREE.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({ color, metalness: 1, roughness: 0.2 });
+}
+
+/** Transparent glass-like material */
+export function glass(color: number | string = 0xffffff): THREE.MeshPhysicalMaterial {
+  return new THREE.MeshPhysicalMaterial({
+    color,
+    transparent: true,
+    transmission: 0.9,
+    opacity: 0.6,
+    roughness: 0,
+    metalness: 0
+  });
+}
+
+/** Cartoon style shaded material */
+export function toon(color: number | string = 0xffffff): THREE.MeshToonMaterial {
+  return new THREE.MeshToonMaterial({ color });
+}
+
+/** Additive glowing sprite material */
+export function glowSprite(color: number | string = 0xffffaa): THREE.SpriteMaterial {
+  return new THREE.SpriteMaterial({ color, transparent: true, blending: THREE.AdditiveBlending });
+}
+
+/** Dashed line material for outlines */
+export function dashedLine(color: number | string = 0xffffff): THREE.LineDashedMaterial {
+  return new THREE.LineDashedMaterial({ color, dashSize: 0.1, gapSize: 0.1 });
+}
+
+/** Depth-encoded material useful for visualising depth */
+export function depthMaterial(): THREE.MeshDepthMaterial {
+  return new THREE.MeshDepthMaterial();
+}


### PR DESCRIPTION
## Summary
- expand `src/materials/README.md`
- add `src/materials/index.ts` with several material factory helpers

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841a37cb218832983dd3e1b959aaf09