### PR TITLE
Fix env map path for glass shards

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -291,7 +291,8 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
     // load HDR environment map for reflections
     const pmrem = new THREE.PMREMGenerator(renderer);
     pmrem.compileEquirectangularShader();
-    new RGBELoader().load('/textures/royal_esplanade_1k.hdr', (tex) => {
+    const envPath = `${import.meta.env.BASE_URL}textures/royal_esplanade_1k.hdr`;
+    new RGBELoader().load(envPath, (tex) => {
       const env = pmrem.fromEquirectangular(tex).texture;
       scene.environment = env;
       shardMaterial.envMap = env;


### PR DESCRIPTION
## Summary
- fix HDR environment map path by prepending Vite base URL

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841aa67c9448329abb5ce3478a8048f