### PR TITLE
Add shape options

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -45,6 +45,8 @@ const functionFormulas: Record<string, string> = {
   branchSqrtPoly: '√(z(z-1)(z+1))'
 };
 
+const shapeNames = ['sphere', 'hexagon', 'pyramid'] as const;
+
 const AXIS_LENGTH = 4;
 
 // CPU versions of the complex functions used in the shader
@@ -206,6 +208,7 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
   const [hueShift, setHueShift] = useState(0);
   const [jitter, setJitter] = useState(0);
   const [objectMode, setObjectMode] = useState(false);
+  const [shapeIndex, setShapeIndex] = useState(0);
   const [realView, setRealView] = useState(false);
   const materialRef = useRef<THREE.ShaderMaterial>();
   const geometryRef = useRef<THREE.BufferGeometry>();
@@ -240,7 +243,8 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
           jitterAmp: { value: jitter },
           hueShift: { value: hueShift },
           saturation: { value: saturation },
-          realView: { value: realViewRef.current ? 1 : 0 }
+          realView: { value: realViewRef.current ? 1 : 0 },
+          shapeType: { value: shapeIndex }
         },
         vertexShader,
         fragmentShader,
@@ -478,6 +482,12 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
   }, [functionIndex]);
 
   useEffect(() => {
+    if (materialRef.current) {
+      materialRef.current.uniforms.shapeType.value = shapeIndex;
+    }
+  }, [shapeIndex]);
+
+  useEffect(() => {
     if (geometryRef.current) {
       const side = Math.sqrt(particleCount);
       const pos = new Float32Array(particleCount * 3);
@@ -617,6 +627,19 @@ export default function ComplexParticles({ count = 40000, selectedFunction = 'sq
               value={hueShift}
               onChange={(e) => setHueShift(parseFloat(e.target.value))}
             />
+          </label>
+          <label>
+            Shape:
+            <select
+              value={shapeIndex}
+              onChange={(e) => setShapeIndex(parseInt(e.target.value, 10))}
+            >
+              {shapeNames.map((s, idx) => (
+                <option key={s} value={idx}>
+                  {s}
+                </option>
+              ))}
+            </select>
           </label>
           <label>
             Object Mode:

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -9,6 +9,7 @@ uniform float hueShift;
 uniform float saturation;
 uniform float realView;
 uniform float jitterAmp;
+uniform int   shapeType;
 attribute float size;
 attribute vec4 seed;
 varying vec3 vColor;
@@ -101,5 +102,30 @@ void main(){vec2 z = vec2(position.x, position.z);vec2 f = applyComplex(z, funct
 
 export const fragmentShader = `
 uniform float opacity;
+uniform int   shapeType;
 varying vec3 vColor;
-void main(){vec2 d = gl_PointCoord - vec2(0.5);float r2 = dot(d,d);if(r2>0.25) discard;float alpha = (1. - smoothstep(0.2,0.5,sqrt(r2))) * opacity;gl_FragColor = vec4(vColor, alpha);}`;
+void main(){
+  vec2 d = gl_PointCoord - vec2(0.5);
+  float alpha = opacity;
+  vec3 col = vColor;
+
+  if(shapeType==0){
+    float r2 = dot(d,d);
+    if(r2>0.25) discard;
+    alpha *= 1.0 - smoothstep(0.2,0.5,sqrt(r2));
+  }else if(shapeType==1){
+    vec2 p = d*2.0;
+    p = abs(p);
+    float dist = max(p.y*0.57735027 + p.x*0.5, p.x) - 0.5;
+    if(dist>0.0) discard;
+    alpha *= 1.0 - smoothstep(-0.02,0.02,dist);
+  }else{ // pyramid
+    vec2 p = abs(d*2.0);
+    float dist = p.x + p.y - 0.5;
+    if(dist>0.0) discard;
+    float h = 0.5 - (p.x + p.y);
+    col *= 0.7 + 0.6*h;
+    alpha *= 1.0 - smoothstep(-0.02,0.02,dist);
+  }
+  gl_FragColor = vec4(col, alpha);
+}`;


### PR DESCRIPTION
## Summary
- expand shader to support multiple particle shapes
- allow choosing sphere, hexagon or pyramid shapes in UI

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841b6346f84832990b0c3d3979a6b9f