### PR TITLE
Fix quaternion shader include

### DIFF
--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -1,6 +1,19 @@
 export const vertexShader = `
 // DOMAIN–COLORING VERTEX SHADER
-#include "quat.glsl"
+struct quat { float w; vec3 v; };
+
+quat quatMul(in quat a, in quat b){
+    return quat(
+        a.w*b.w - dot(a.v, b.v),
+        a.w*b.v + b.w*a.v + cross(a.v, b.v)
+    );
+}
+
+vec4 quatRotate4D(in vec4 p, in quat a, in quat b){
+    quat q = quat(p.w, p.xyz);
+    quat r = quatMul(quatMul(a, q), quat(b.w, -b.v));
+    return vec4(r.v.x, r.v.y, r.v.z, r.w);
+}
 uniform float time;
 uniform int   functionType;
 uniform float globalSize;


### PR DESCRIPTION
## Summary
- inline quaternion GLSL code to avoid runtime shader error

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6841ea0057648329b2c8799af66a2cab