### PR TITLE
Organize toolbar layout

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -664,29 +664,30 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
   return (
     <div style={{ position: 'relative' }}>
       <Canvas3D onMount={onMount} />
-      <div className="proj-toolbar" style={{position:'absolute',top:10,left:150}}>
-        {modes.map(([name,code]) => (
-          <button key={code}
-            className={proj===code ? 'active' : ''}
-            onClick={() => animateTo(code as ProjectionMode)}>
-            {name}
-          </button>
-        ))}
-      </div>
-      <div className="colour-toolbar" style={{position:'absolute',top:10,left:10}}>
-        {Object.keys(ColorScheme).map(k => (
-          <button key={k}
-            className={colour===ColorScheme[k as keyof typeof ColorScheme] ? 'active' : ''}
-            onClick={() => setColour(ColorScheme[k as keyof typeof ColorScheme])}>{k}</button>
-        ))}
-      </div>
-      <ToggleMenu title="Menu">
-        <div
-          style={{
-            color: 'white',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: 8
+      <div style={{position:'absolute',top:10,left:10,display:'flex',flexDirection:'column',gap:8}}>
+        <div className="proj-toolbar">
+          {modes.map(([name,code]) => (
+            <button key={code}
+              className={proj===code ? 'active' : ''}
+              onClick={() => animateTo(code as ProjectionMode)}>
+              {name}
+            </button>
+          ))}
+        </div>
+        <div className="colour-toolbar">
+          {Object.keys(ColorScheme).map(k => (
+            <button key={k}
+              className={colour===ColorScheme[k as keyof typeof ColorScheme] ? 'active' : ''}
+              onClick={() => setColour(ColorScheme[k as keyof typeof ColorScheme])}>{k}</button>
+          ))}
+        </div>
+        <ToggleMenu title="Menu">
+          <div
+            style={{
+              color: 'white',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 8
           }}
         >
           <label>
@@ -836,7 +837,8 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
             />
           </label>
         </div>
-      </ToggleMenu>
+        </ToggleMenu>
+      </div>
       <div
         style={{
           position: 'absolute',

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -10,9 +10,7 @@ export const CANVAS_CONFIG = {
 
 export const TOGGLE_MENU_STYLE = {
   container: {
-    position: 'absolute' as const,
-    top: 10,
-    left: 10
+    display: 'inline-block'
   },
   panel: {
     marginTop: 8,


### PR DESCRIPTION
## Summary
- stack projection, color and menu controls into a single vertical toolbar
- simplify ToggleMenu style so it can be positioned by its parent

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68423a7589a8832981a542f66143a0c6