### PR TITLE
UI tweaks for ComplexParticles

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -880,6 +880,29 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
               onClick={() => setFunctionIndex(idx)}>{name}</button>
           ))}
         </div>
+        <div
+          style={{
+            color: objectMode ? 'black' : 'white',
+            fontSize: '1.2em',
+            textAlign: 'right',
+            pointerEvents: 'none'
+          }}
+        >
+          <div>{currentName}</div>
+          <div>{currentFormula}</div>
+        </div>
+      </div>
+
+      <div
+        style={{
+          position: 'absolute',
+          top: 10,
+          left: 10,
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 8
+        }}
+      >
         <div className="view-type-toolbar">
           {viewTypes.map(([name,code]) => (
             <button key={name}
@@ -894,17 +917,7 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
               onClick={() => handleMotion(m)}>{m}</button>
           ))}
         </div>
-        <div
-          style={{
-            color: objectMode ? 'black' : 'white',
-            fontSize: '1.2em',
-            textAlign: 'right',
-            pointerEvents: 'none'
-          }}
-        >
-          <div>{currentName}</div>
-          <div>{currentFormula}</div>
-        </div>
+        <div style={{color:'white'}}>Distance: {cameraZ.toFixed(1)}</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- keep function picker at top-right
- move view type and motion buttons to top-left
- display camera distance in new control block

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6842f6d674148329b67113b4b02751e7