### PR TITLE
Animate quarter turn transitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Switching modes interpolates on the GPU for a smooth transition.
 
 ## Controls
 
-* Six **Quarter-Turn** buttons perform instant 90° rotations in the XY, XU, XV, YU, YV, and UV planes; combine them for any orthogonal orientation before you drop an axis.
+* Six **Quarter-Turn** buttons perform smooth 90° rotations in the XY, XU, XV, YU, YV, and UV planes; combine them for any orthogonal orientation before you drop an axis.
 
 ---
 


### PR DESCRIPTION
## Summary
- animate quarter-turn rotations instead of applying them instantly
- update README to mention smooth rotation

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684301223ef48329b767b81bf8a29bff