### PR TITLE
Add bidirectional quarter-turn controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Switching modes interpolates on the GPU for a smooth transition.
 
 ## Controls
 
-* Six **Quarter-Turn** buttons perform smooth 90° rotations in the XY, XU, XV, YU, YV, and UV planes; combine them for any orthogonal orientation before you drop an axis.
+* For each plane (XY, XU, XV, YU, YV, UV) there are two **Quarter-Turn** buttons — clockwise and counterclockwise — enabling smooth 90° rotations. Combine them for any orthogonal orientation before you drop an axis.
 
 ---
 

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -807,8 +807,8 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
     requestAnimationFrame(step);
   }
 
-  const turn = (plane: Plane) => {
-    applyQuarterTurn(plane, QUARTER);
+  const turn = (plane: Plane, dir: 1 | -1) => {
+    applyQuarterTurn(plane, QUARTER * dir);
   };
 
   const currentName = functionNames[functionIndex];

--- a/src/controls/QuarterTurnBar.tsx
+++ b/src/controls/QuarterTurnBar.tsx
@@ -1,10 +1,13 @@
 import { planes, Plane } from '@/math/constants';
 
-export default function QuarterTurnBar({ onTurn }: { onTurn: (p: Plane) => void }) {
+export default function QuarterTurnBar({ onTurn }: { onTurn: (p: Plane, dir: 1 | -1) => void }) {
   return (
     <div className="quarter-bar" style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
       {planes.map(p => (
-        <button key={p} onClick={() => onTurn(p)}>{p}</button>
+        <div key={p} style={{ display: 'flex', gap: 4 }}>
+          <button onClick={() => onTurn(p, 1)}>{p}&#x21bb;</button>
+          <button onClick={() => onTurn(p, -1)}>{p}&#x21ba;</button>
+        </div>
       ))}
     </div>
   );


### PR DESCRIPTION
## Summary
- update QuarterTurnBar to show clockwise/counterclockwise buttons per plane
- adjust `turn` handler to accept rotation direction
- update README to describe new buttons

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68438935a8dc8329bfe4b563e64a05cb