### PR TITLE
Add Mandelbrot fractal demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 ## 1 What is animath?
 
-`animath` is a TypeScript/React + WebGL (Three.js) code-base designed for **rapid prototyping of mathematical visuals**.  
-It began with complex-analysis “domain colouring” but is meant to grow into a **general playground**: fractals, differential-equation flows, algebraic surfaces, knot animations, and more.
+`animath` is a TypeScript/React + WebGL (Three.js) code-base designed for **rapid prototyping of mathematical visuals**.
+It began with complex-analysis “domain colouring” but is meant to grow into a **general playground**: fractals, differential-equation flows, algebraic surfaces, knot animations, and more. A simple Mandelbrot renderer now demonstrates the fractal side of the toolkit (see the `#/mandelbrot` route).
 
 Goals (observable intent):
 

--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   </head>
   <body>
     <div id="root"></div>
-    <p id="page-info">You are viewing the animath page.</p>
+    <p id="page-info">You are viewing the animath page. Try <a href="#/mandelbrot">#/mandelbrot</a> for the Mandelbrot demo.</p>
     <textarea id="html-source" readonly style="width:100%;height:200px;"></textarea>
     <script>
       const srcBox = document.getElementById('html-source');

--- a/src/animations/Mandelbrot/Mandelbrot2D.tsx
+++ b/src/animations/Mandelbrot/Mandelbrot2D.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef } from 'react';
+
+/**
+ * Simple Mandelbrot set renderer using a 2D canvas.
+ */
+export default function Mandelbrot2D() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+    const width = canvas.width;
+    const height = canvas.height;
+    const maxIter = 100;
+    const minX = -2.5;
+    const maxX = 1;
+    const minY = -1.5;
+    const maxY = 1.5;
+
+    const img = ctx.createImageData(width, height);
+    for (let y = 0; y < height; y++) {
+      const c_im = minY + (y / height) * (maxY - minY);
+      for (let x = 0; x < width; x++) {
+        const c_re = minX + (x / width) * (maxX - minX);
+        let zx = 0;
+        let zy = 0;
+        let iter = 0;
+        while (zx * zx + zy * zy <= 4 && iter < maxIter) {
+          const xtmp = zx * zx - zy * zy + c_re;
+          zy = 2 * zx * zy + c_im;
+          zx = xtmp;
+          iter++;
+        }
+        const idx = (y * width + x) * 4;
+        const col = iter === maxIter ? 0 : Math.floor((255 * iter) / maxIter);
+        img.data[idx] = col;
+        img.data[idx + 1] = col;
+        img.data[idx + 2] = col;
+        img.data[idx + 3] = 255;
+      }
+    }
+    ctx.putImageData(img, 0, 0);
+  }, []);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      width={800}
+      height={600}
+      style={{ width: '100%', height: '100%', display: 'block' }}
+    />
+  );
+}

--- a/src/animations/Mandelbrot/README.md
+++ b/src/animations/Mandelbrot/README.md
@@ -1,0 +1,3 @@
+# Mandelbrot 2D
+
+This basic component renders the Mandelbrot set to a 2D canvas on mount. It is intended as a starting point for future extensions such as interactive zooming or 3D visualisation.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import Mandelbrot2D from './animations/Mandelbrot/Mandelbrot2D';
 
 const routes: Record<string, JSX.Element> = {
-  '/': <App />
+  '/': <App />,
+  '/mandelbrot': <Mandelbrot2D />
 };
 
 function getRoute(): JSX.Element {


### PR DESCRIPTION
## Summary
- add a small Mandelbrot renderer
- link to the Mandelbrot demo route
- mention Mandelbrot in README

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68438b4122c0832985e36cf4b631b4b1