### PR TITLE
Fix README links to animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 ## Table of contents
 
-1. **[Complex Particles](#/)** – 3D representation of four-dimensional complex functions
-2. **[Fractals](#/fractals)** – explore Mandelbrot, Julia, Burning Ship and Multibrot sets
+1. **[Complex Particles](https://piyarsquare.github.io/animath/#/)** – 3D representation of four-dimensional complex functions
+2. **[Fractals](https://piyarsquare.github.io/animath/#/fractals)** – explore Mandelbrot, Julia, Burning Ship and Multibrot sets
 
 ---
 


### PR DESCRIPTION
## Summary
- fix table-of-contents links to point to the live site

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684394b30d24832998a6f274e0841afb