### PR TITLE
Refactor fractal layout and controls

### DIFF
--- a/src/animations/Fractals/README.md
+++ b/src/animations/Fractals/README.md
@@ -1,5 +1,7 @@
 # Fractals 2D
 
-Interactive Mandelbrot and Julia set viewer. Use the on-screen controls to pan and zoom,
-or simply drag the canvas. Touch devices support drag panning and pinch to zoom. When the Julia
-option is selected the complex parameter can be adjusted and the palette can be animated.
+Interactive Mandelbrot and Julia set viewer. The fractal fills the screen and a small
+menu in the lower left provides palette, iteration and animation options. Pan and zoom
+are performed using the buttons in the upper right – no dragging or scrolling is needed.
+When the Julia option is selected the complex parameter can be adjusted and the palette
+can be animated.


### PR DESCRIPTION
## Summary
- overhaul Fractals2D component layout
- remove gesture handlers in favour of on‑screen pan/zoom buttons
- overlay fractal type dropdown and option menu similar to ComplexParticles
- update fractals README

## Testing
- `npm ci`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845e2c4f91c8329aa597cdd57af0a62