### PR TITLE
Improve fractal canvas resizing

### DIFF
--- a/src/animations/Fractals/Fractals2D.tsx
+++ b/src/animations/Fractals/Fractals2D.tsx
@@ -159,9 +159,30 @@ export default function Fractals2D() {
     animRef.current = requestAnimationFrame(animate);
   }, []);
 
+  // Ensure canvas resolution matches its displayed size so pixels remain square
+  const handleResize = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const parent = canvas.parentElement;
+    if (!parent) return;
+    const dpr = window.devicePixelRatio || 1;
+    const rect = parent.getBoundingClientRect();
+    canvas.style.width = `${rect.width}px`;
+    canvas.style.height = `${rect.height}px`;
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    render();
+  }, [render]);
+
   useEffect(() => {
     render();
   }, [render]);
+
+  useEffect(() => {
+    handleResize();
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, [handleResize]);
 
   useEffect(() => {
     if (animating) {
@@ -178,8 +199,8 @@ export default function Fractals2D() {
     <div style={{ position: 'relative', width: '100vw', height: '100vh' }}>
       <canvas
         ref={canvasRef}
-        width={800}
-        height={600}
+        width={1}
+        height={1}
         style={{ width: '100%', height: '100%', display: 'block', background: 'black' }}
       />
       <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>

--- a/src/animations/Fractals/README.md
+++ b/src/animations/Fractals/README.md
@@ -1,7 +1,9 @@
 # Fractals 2D
 
-Interactive Mandelbrot and Julia set viewer. The fractal fills the screen and a small
-menu in the lower left provides palette, iteration and animation options. Pan and zoom
-are performed using the buttons in the upper right – no dragging or scrolling is needed.
-When the Julia option is selected the complex parameter can be adjusted and the palette
-can be animated.
+Interactive Mandelbrot and Julia set viewer. The fractal now resizes with the
+window so pixels remain square in either orientation. A small menu in the lower
+left provides palette, iteration and animation options. Pan and zoom are
+performed using the buttons in the upper right – no dragging or scrolling is
+needed. When the Julia option is selected the complex parameter can be adjusted
+and the palette can be animated. Zooming or panning recomputes the fractal each
+time.


### PR DESCRIPTION
## Summary
- maintain square pixels on the fractal canvas
- update fractal README for the behaviour

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6845eecce50c8329ae209b560dbcae92