### PR TITLE
Fix fractal path starting point

### DIFF
--- a/src/animations/Fractals/Fractals2D.tsx
+++ b/src/animations/Fractals/Fractals2D.tsx
@@ -193,8 +193,8 @@ export default function Fractals2D() {
       const start = screenToFractal(e.clientX, e.clientY);
       const pts: { x: number; y: number }[] = [];
       if (type === 'mandelbrot') {
-        let zx = 0,
-          zy = 0;
+        let zx = start.x,
+          zy = start.y;
         for (let i = 0; i < iter && zx * zx + zy * zy <= 4; i++) {
           pts.push({ x: zx, y: zy });
           const xt = zx * zx - zy * zy + start.x;


### PR DESCRIPTION
## Summary
- start the orbit path at the clicked point rather than at zero

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68461d254ac483299b1409d2c9a874a0