### PR TITLE
Remove mouse controls from fractals-gpu

### DIFF
--- a/src/animations/FractalsGPU/README.md
+++ b/src/animations/FractalsGPU/README.md
@@ -2,4 +2,4 @@
 
 This variant of the fractal viewer renders the Mandelbrot and Julia sets entirely on the GPU via a fragment shader. The shader computes the iteration count for each pixel in parallel, making zoom and palette changes much faster than the CPU implementation.
 
-Pan and zoom are available through the arrow and zoom buttons in the interface. You can now also drag the fractal canvas to pan and use the mouse wheel to zoom in and out.
+Pan and zoom are available through the arrow and zoom buttons in the interface.


### PR DESCRIPTION
## Summary
- remove panning/zooming mouse handlers from Fractals GPU viewer
- simplify resize logic and remove unused path features
- update fractals-gpu documentation

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6846d89a7b84832998b834112436997c