### PR TITLE
Show READMEs in demos

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,6 @@
   <body>
     <div id="root"></div>
     <p id="page-info">You are viewing the animath page. Try <a href="#/fractals">#/fractals</a> for the fractals demo.</p>
-    <textarea id="html-source" readonly style="width:100%;height:200px;"></textarea>
-    <script>
-      const srcBox = document.getElementById('html-source');
-      srcBox.textContent = document.documentElement.outerHTML;
-    </script>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "animath",
       "version": "0.1.0",
       "dependencies": {
+        "marked": "^15.0.12",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "three": "^0.163.0"
@@ -1426,6 +1427,18 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/marked": {
+      "version": "15.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
+      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/meshoptimizer": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "marked": "^15.0.12",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "three": "^0.163.0"

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -3,6 +3,8 @@ import * as THREE from 'three';
 import { RGBELoader } from 'three/examples/jsm/loaders/RGBELoader.js';
 import Canvas3D from '../../components/Canvas3D';
 import ToggleMenu from '../../components/ToggleMenu';
+import Readme from '../../components/Readme';
+import readmeText from './README.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import { quatRotate4D, ProjectionMode, project } from '../../lib/viewpoint';
 import QuarterTurnBar from '@/controls/QuarterTurnBar';
@@ -1147,6 +1149,11 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
           </table>
         </div>
         <QuarterTurnBar onTurn={turn}/>
+      </div>
+      <div style={{ position: 'absolute', bottom: 10, right: 10 }}>
+        <ToggleMenu title="About">
+          <Readme markdown={readmeText} />
+        </ToggleMenu>
       </div>
     </div>
   );

--- a/src/animations/Fractals/Fractals2D.tsx
+++ b/src/animations/Fractals/Fractals2D.tsx
@@ -1,5 +1,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import ToggleMenu from '../../components/ToggleMenu';
+import Readme from '../../components/Readme';
+import readmeText from './README.md?raw';
 
 /** Interactive 2D fractal viewer inspired by the old Fractint program. */
 export default function Fractals2D() {
@@ -409,6 +411,11 @@ export default function Fractals2D() {
               </>
             )}
           </div>
+        </ToggleMenu>
+      </div>
+      <div style={{ position: 'absolute', bottom: 10, right: 10 }}>
+        <ToggleMenu title="About">
+          <Readme markdown={readmeText} />
         </ToggleMenu>
       </div>
     </div>

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -1,5 +1,8 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import * as THREE from 'three';
+import Readme from '../../components/Readme';
+import ToggleMenu from '../../components/ToggleMenu';
+import readmeText from './README.md?raw';
 
 /** GPU accelerated Mandelbrot/Julia viewer using a fragment shader. */
 export default function FractalsGPU() {
@@ -339,6 +342,11 @@ export default function FractalsGPU() {
             </>
           )}
         </div>
+      </div>
+      <div style={{ position: 'absolute', bottom: 10, right: 10 }}>
+        <ToggleMenu title="About">
+          <Readme markdown={readmeText} />
+        </ToggleMenu>
       </div>
     </div>
   );

--- a/src/components/Readme.tsx
+++ b/src/components/Readme.tsx
@@ -1,0 +1,16 @@
+import React, { useMemo } from 'react';
+import { marked } from 'marked';
+
+export interface ReadmeProps {
+  markdown: string;
+}
+
+export default function Readme({ markdown }: ReadmeProps) {
+  const html = useMemo(() => marked.parse(markdown), [markdown]);
+  return (
+    <div
+      style={{ maxWidth: 300, maxHeight: 200, overflow: 'auto' }}
+      dangerouslySetInnerHTML={{ __html: html }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- display README info for all demos via new `Readme` component
- drop HTML source dump from `index.html`
- add `marked` dependency for Markdown parsing

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846f3f3f57c83298f033520e29071ae