### PR TITLE
Disable path overlay

### DIFF
--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -346,8 +346,7 @@ export default function FractalsGPU() {
     >
       <canvas
         ref={overlayRef}
-        onClick={handleSelect}
-        style={{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%', zIndex: 1 }}
+        style={{ position: 'absolute', left: 0, top: 0, width: '100%', height: '100%', zIndex: 1, pointerEvents: 'none' }}
       />
       <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
         <label>


### PR DESCRIPTION
## Summary
- prevent fractal path canvas from intercepting UI clicks

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6847181fc3088329b9da5db64f2acebd