### PR TITLE
Add fractal power and coloring controls

### DIFF
--- a/src/animations/FractalsGPU/README.md
+++ b/src/animations/FractalsGPU/README.md
@@ -2,4 +2,4 @@
 
 This viewer renders the Mandelbrot and Julia sets entirely on the GPU via a fragment shader. Escape times for every pixel are computed in parallel, then a color map is applied. Clicking the fractal now shows the orbit path just like the original CPU implementation.
 
-Pan and zoom are available through the arrow and zoom buttons in the interface.
+Pan and zoom are available through the arrow and zoom buttons in the interface. The power of the iteration function `z^k + c` can be changed, and the viewer offers multiple coloring modes including escape velocity, limit magnitude and a layered combination of both.


### PR DESCRIPTION
## Summary
- expose new `power` parameter to set exponent `k` for `z^k + c`
- add selectable coloring modes (escape, limit, layered) with separate inside palette
- update GPU fractal README with usage notes

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68474c51c8e8832980a7e009a096e318