### PR TITLE
Simplify Correspondence demo

### DIFF
--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -1,30 +1,54 @@
 import React, { useState } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
-import Readme from '../../components/Readme';
-import ToggleMenu from '../../components/ToggleMenu';
-import readmeText from './README.md?raw';
 
 export default function Correspondence() {
   const baseView: ViewBounds = { xMin: -2.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 };
   const [mandelView, setMandelView] = useState<ViewBounds>(baseView);
   const [juliaView, setJuliaView] = useState<ViewBounds>({ xMin: -2, xMax: 2, yMin: -2, yMax: 2 });
-  const [c, setC] = useState<Complex>({ real: 0, imag: 0 });
+  const [c] = useState<Complex>({ real: -0.7, imag: 0.27015 });
+  const [iter, setIter] = useState(100);
+  const [paletteM, setPaletteM] = useState(0);
+  const [offsetM, setOffsetM] = useState(0);
+  const [paletteJ, setPaletteJ] = useState(0);
+  const [offsetJ, setOffsetJ] = useState(0);
 
   return (
-    <div style={{ display: 'flex', width: '100vw', height: '100vh' }}>
+    <div style={{ display: 'flex', flexDirection: 'column', width: '100vw', height: '100vh' }}>
+      <div style={{ position: 'absolute', top: 10, right: 10, color: 'white', zIndex: 1 }}>
+        <label>
+          Iter:
+          <input type="number" value={iter} min={1} max={1000} onChange={e => setIter(parseInt(e.target.value, 10))} style={{ width: 60 }} />
+        </label>
+      </div>
       <div style={{ flex: 1, position: 'relative' }}>
-        <FractalPane type="mandelbrot" view={mandelView} onViewChange={setMandelView} juliaC={c} onPickC={setC} />
+        <FractalPane type="mandelbrot" view={mandelView} onViewChange={setMandelView} juliaC={c} iter={iter} palette={paletteM} offset={offsetM} />
         <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
-          c = {c.real.toFixed(3)} + {c.imag.toFixed(3)}i
+          <label>
+            Palette:
+            <select value={paletteM} onChange={e => setPaletteM(parseInt(e.target.value, 10))}>
+              <option value={0}>Rainbow</option>
+              <option value={1}>Fire</option>
+              <option value={2}>Ocean</option>
+              <option value={3}>Gray</option>
+            </select>
+          </label>
+          <input type="range" min={0} max={255} value={offsetM} onChange={e => setOffsetM(parseInt(e.target.value, 10))} />
         </div>
       </div>
-      <div style={{ flex: 1 }}>
-        <FractalPane type="julia" view={juliaView} onViewChange={setJuliaView} juliaC={c} />
-      </div>
-      <div style={{ position: 'absolute', bottom: 10, right: 10 }}>
-        <ToggleMenu title="About">
-          <Readme markdown={readmeText} />
-        </ToggleMenu>
+      <div style={{ flex: 1, position: 'relative' }}>
+        <FractalPane type="julia" view={juliaView} onViewChange={setJuliaView} juliaC={c} iter={iter} palette={paletteJ} offset={offsetJ} />
+        <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
+          <label>
+            Palette:
+            <select value={paletteJ} onChange={e => setPaletteJ(parseInt(e.target.value, 10))}>
+              <option value={0}>Rainbow</option>
+              <option value={1}>Fire</option>
+              <option value={2}>Ocean</option>
+              <option value={3}>Gray</option>
+            </select>
+          </label>
+          <input type="range" min={0} max={255} value={offsetJ} onChange={e => setOffsetJ(parseInt(e.target.value, 10))} />
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- restructure correspondence demo to show Mandelbrot and Julia panes stacked
- add color palette options and animation offset control per pane
- remove correspondence code for selecting c

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68498296f64c8329b80f10bfc1bd43a3