### PR TITLE
Improve correspondence UI

### DIFF
--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -32,8 +32,9 @@ export default function Correspondence() {
       style={{
         display: 'flex',
         flexDirection: 'column',
+        gap: 16,
         width: dims.width,
-        height: dims.paneHeight * 2,
+        height: dims.paneHeight * 2 + 16,
         margin: 'auto',
         position: 'relative'
       }}
@@ -44,7 +45,15 @@ export default function Correspondence() {
           <input type="number" value={iter} min={1} max={1000} onChange={e => setIter(parseInt(e.target.value, 10))} style={{ width: 60 }} />
         </label>
       </div>
-      <div style={{ width: '100%', height: dims.paneHeight, position: 'relative' }}>
+      <div
+        style={{
+          width: '100%',
+          height: dims.paneHeight,
+          position: 'relative',
+          border: '1px solid white',
+          boxSizing: 'border-box'
+        }}
+      >
         <FractalPane type="mandelbrot" view={mandelView} onViewChange={setMandelView} juliaC={c} iter={iter} palette={paletteM} offset={offsetM} />
         <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
           <label>
@@ -59,7 +68,15 @@ export default function Correspondence() {
           <input type="range" min={0} max={255} value={offsetM} onChange={e => setOffsetM(parseInt(e.target.value, 10))} />
         </div>
       </div>
-      <div style={{ width: '100%', height: dims.paneHeight, position: 'relative' }}>
+      <div
+        style={{
+          width: '100%',
+          height: dims.paneHeight,
+          position: 'relative',
+          border: '1px solid white',
+          boxSizing: 'border-box'
+        }}
+      >
         <FractalPane type="julia" view={juliaView} onViewChange={setJuliaView} juliaC={c} iter={iter} palette={paletteJ} offset={offsetJ} />
         <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
           <label>

--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -174,22 +174,6 @@ export default function FractalPane({
     materialRef.current.uniforms.offset.value = offset;
   }, [view, type, juliaC, iter, palette, offset]);
 
-  const handleWheel = useCallback(
-    (e: React.WheelEvent) => {
-      e.preventDefault();
-      const scale = e.deltaY < 0 ? 0.9 : 1.1;
-      const frac = screenToComplex(e.nativeEvent, rendererRef.current!.domElement, view);
-      const xr = (view.xMax - view.xMin) * scale;
-      const yr = (view.yMax - view.yMin) * scale;
-      onViewChange({
-        xMin: frac.real - xr / 2,
-        xMax: frac.real + xr / 2,
-        yMin: frac.imag - yr / 2,
-        yMax: frac.imag + yr / 2,
-      });
-    },
-    [view, onViewChange]
-  );
 
   const handlePointerMove = useCallback(
     (e: React.PointerEvent) => {
@@ -206,7 +190,7 @@ export default function FractalPane({
     <div
       ref={mountRef}
       style={{ width: '100%', height: '100%' }}
-      onWheel={handleWheel}
+      // Wheel events are ignored to avoid accidental zooming
       onPointerMove={handlePointerMove}
     />
   );


### PR DESCRIPTION
## Summary
- stop using the wheel to zoom in Correspondence demo
- space out the fractal panes and give them a border

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6849f581f1088329b993b95fcb73649b