### PR TITLE
Fix runaway resizing in correspondence demo

### DIFF
--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -135,6 +135,8 @@ export default function FractalPane({
       const rect = mountRef.current.getBoundingClientRect();
       const dpr = window.devicePixelRatio || 1;
       renderer.setSize(rect.width, rect.height, false);
+      renderer.domElement.style.width = `${rect.width}px`;
+      renderer.domElement.style.height = `${rect.height}px`;
       renderer.setPixelRatio(dpr);
     };
     handleResize();


### PR DESCRIPTION
## Summary
- update correspondence fractal pane so the canvas CSS size is fixed on resize

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6849fe63148c8329ba60dc4e1d0f7d57