### PR TITLE
Interactive Julia selector for correspondence demo

### DIFF
--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -5,7 +5,8 @@ export default function Correspondence() {
   const baseView: ViewBounds = { xMin: -2.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 };
   const [mandelView, setMandelView] = useState<ViewBounds>(baseView);
   const [juliaView, setJuliaView] = useState<ViewBounds>({ xMin: -2, xMax: 2, yMin: -2, yMax: 2 });
-  const [c] = useState<Complex>({ real: -0.7, imag: 0.27015 });
+  const [c, setC] = useState<Complex>({ real: -0.7, imag: 0.27015 });
+  const [selecting, setSelecting] = useState(false);
   const [iter, setIter] = useState(100);
   const [paletteM, setPaletteM] = useState(0);
   const [offsetM, setOffsetM] = useState(0);
@@ -28,6 +29,12 @@ export default function Correspondence() {
       const sy = (v.yMax - v.yMin) * 0.1 * dy;
       return { xMin: v.xMin + sx, xMax: v.xMax + sx, yMin: v.yMin + sy, yMax: v.yMax + sy };
     });
+  };
+
+  const handlePick = (nc: Complex) => {
+    if (!selecting) return;
+    setC(nc);
+    setSelecting(false);
   };
 
 
@@ -58,7 +65,22 @@ export default function Correspondence() {
           boxSizing: 'border-box'
         }}
       >
-        <FractalPane type="mandelbrot" view={mandelView} onViewChange={setMandelView} juliaC={c} iter={iter} palette={paletteM} offset={offsetM} />
+        <FractalPane
+          type="mandelbrot"
+          view={mandelView}
+          onViewChange={setMandelView}
+          juliaC={c}
+          iter={iter}
+          palette={paletteM}
+          offset={offsetM}
+          markC={c}
+          onPickC={handlePick}
+        />
+        <div
+          style={{ position: 'absolute', top: 4, left: '50%', transform: 'translateX(-50%)', color: 'white' }}
+        >
+          Mandelbrot
+        </div>
         <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
           <label>
             Palette:
@@ -94,6 +116,7 @@ export default function Correspondence() {
             <button onClick={() => zoom(0.9, setMandelView)}>Zoom In</button>
             <button onClick={() => zoom(1.1, setMandelView)}>Zoom Out</button>
           </div>
+          <button onClick={() => setSelecting(true)}>Select Julia point</button>
         </div>
       </div>
       <div
@@ -104,7 +127,20 @@ export default function Correspondence() {
           boxSizing: 'border-box'
         }}
       >
-        <FractalPane type="julia" view={juliaView} onViewChange={setJuliaView} juliaC={c} iter={iter} palette={paletteJ} offset={offsetJ} />
+        <FractalPane
+          type="julia"
+          view={juliaView}
+          onViewChange={setJuliaView}
+          juliaC={c}
+          iter={iter}
+          palette={paletteJ}
+          offset={offsetJ}
+        />
+        <div
+          style={{ position: 'absolute', top: 4, left: '50%', transform: 'translateX(-50%)', color: 'white' }}
+        >
+          {`Julia (c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i)`}
+        </div>
         <div style={{ position: 'absolute', top: 10, left: 10, color: 'white' }}>
           <label>
             Palette:

--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -24,6 +24,7 @@ export interface FractalPaneProps {
   palette: number;
   offset: number;
   onPickC?: (c: Complex) => void;
+  markC?: Complex;
 }
 
 export function screenToComplex(
@@ -49,6 +50,7 @@ export default function FractalPane({
   palette,
   offset,
   onPickC,
+  markC,
 }: FractalPaneProps) {
   const mountRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer>();
@@ -180,8 +182,8 @@ export default function FractalPane({
   }, [view, type, juliaC, iter, palette, offset]);
 
 
-  const handlePointerMove = useCallback(
-    (e: React.PointerEvent) => {
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
       if (!onPickC) return;
       const canvas = rendererRef.current?.domElement;
       if (!canvas) return;
@@ -190,6 +192,25 @@ export default function FractalPane({
     },
     [onPickC, view]
   );
+
+  const crossStyle = () => {
+    if (!markC || !mountRef.current) return { display: 'none' } as React.CSSProperties;
+    const rect = mountRef.current.getBoundingClientRect();
+    const width = rect.width * 0.75;
+    const height = rect.height * 0.75;
+    const offsetX = (rect.width - width) / 2;
+    const offsetY = (rect.height - height) / 2;
+    const x = offsetX + ((markC.real - view.xMin) / (view.xMax - view.xMin)) * width;
+    const y = offsetY + ((markC.imag - view.yMin) / (view.yMax - view.yMin)) * height;
+    return {
+      position: 'absolute',
+      left: `${x}px`,
+      top: `${y}px`,
+      transform: 'translate(-50%, -50%)',
+      pointerEvents: 'none',
+      color: 'white'
+    } as React.CSSProperties;
+  };
 
   return (
     <div
@@ -200,9 +221,13 @@ export default function FractalPane({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
+        position: 'relative'
       }}
-      // Wheel events are ignored to avoid accidental zooming
-      onPointerMove={handlePointerMove}
-    />
+      onClick={handleClick}
+    >
+      {markC && type === 'mandelbrot' && (
+        <div style={crossStyle()}>X</div>
+      )}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add dynamic titles to Mandelbrot and Julia panes
- mark Julia focus on the Mandelbrot set
- allow selecting the Julia point via mouse click

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684a04582a908329b1ac22772f637ad3