### PR TITLE
Fix correspondence path rendering

### DIFF
--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
 
 export default function Correspondence() {
@@ -14,9 +14,26 @@ export default function Correspondence() {
   const [offsetJ, setOffsetJ] = useState(0);
   const [path, setPath] = useState<Complex[]>([]);
   const [drawingPath, setDrawingPath] = useState(false);
+  const [speed, setSpeed] = useState(0.02);
+  const speedRef = useRef(speed);
+  const [paused, setPaused] = useState(false);
+  const pausedRef = useRef(false);
   const animRef = useRef<number>();
   const progressRef = useRef(0);
   const [playing, setPlaying] = useState(false);
+  const playingRef = useRef(false);
+
+  useEffect(() => {
+    speedRef.current = speed;
+  }, [speed]);
+
+  useEffect(() => {
+    playingRef.current = playing;
+  }, [playing]);
+
+  useEffect(() => {
+    pausedRef.current = paused;
+  }, [paused]);
 
   const zoom = (factor: number, setView: React.Dispatch<React.SetStateAction<ViewBounds>>) => {
     setView(v => {
@@ -50,23 +67,27 @@ export default function Correspondence() {
     if (path.length < 2) return;
     cancelAnimationFrame(animRef.current!);
     progressRef.current = 0;
+    setPaused(false);
     setPlaying(true);
 
     const step = () => {
-      const idx = Math.floor(progressRef.current);
-      const t = progressRef.current - idx;
-      const p0 = path[idx];
-      const p1 = path[idx + 1];
-      const nc = {
-        real: p0.real * (1 - t) + p1.real * t,
-        imag: p0.imag * (1 - t) + p1.imag * t,
-      };
-      setC(nc);
-      progressRef.current += 0.02;
-      if (progressRef.current >= path.length - 1) {
-        setC(path[path.length - 1]);
-        setPlaying(false);
-        return;
+      if (!playingRef.current) return;
+      if (!pausedRef.current) {
+        const idx = Math.floor(progressRef.current);
+        const t = progressRef.current - idx;
+        const p0 = path[idx];
+        const p1 = path[idx + 1];
+        const nc = {
+          real: p0.real * (1 - t) + p1.real * t,
+          imag: p0.imag * (1 - t) + p1.imag * t,
+        };
+        setC(nc);
+        progressRef.current += speedRef.current;
+        if (progressRef.current >= path.length - 1) {
+          setC(path[path.length - 1]);
+          setPlaying(false);
+          return;
+        }
       }
       animRef.current = requestAnimationFrame(step);
     };
@@ -75,6 +96,7 @@ export default function Correspondence() {
 
   const stopPath = () => {
     setPlaying(false);
+    setPaused(false);
     cancelAnimationFrame(animRef.current!);
   };
 
@@ -168,6 +190,22 @@ export default function Correspondence() {
           <button onClick={playing ? stopPath : playPath} disabled={path.length < 2}>
             {playing ? 'Stop' : 'Play'}
           </button>
+          {playing && (
+            <button onClick={() => setPaused(p => !p)}>
+              {paused ? 'Resume' : 'Pause'}
+            </button>
+          )}
+          <label>
+            Speed:
+            <input
+              type="range"
+              min={0.005}
+              max={0.5}
+              step={0.005}
+              value={speed}
+              onChange={e => setSpeed(parseFloat(e.target.value))}
+            />
+          </label>
         </div>
       </div>
       <div
@@ -186,6 +224,7 @@ export default function Correspondence() {
           iter={iter}
           palette={paletteJ}
           offset={offsetJ}
+          path={path}
         />
         <div
           style={{ position: 'absolute', top: 4, left: '50%', transform: 'translateX(-50%)', color: 'white' }}

--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -142,11 +142,10 @@ export default function FractalPane({
       if (!mountRef.current) return;
       const rect = mountRef.current.getBoundingClientRect();
       const dpr = window.devicePixelRatio || 1;
-      const width = rect.width * 0.75;
-      const height = rect.height * 0.75;
-      renderer.setSize(width, height, false);
-      renderer.domElement.style.width = `${width}px`;
-      renderer.domElement.style.height = `${height}px`;
+      const size = Math.min(rect.width, rect.height);
+      renderer.setSize(size, size, false);
+      renderer.domElement.style.width = `${size}px`;
+      renderer.domElement.style.height = `${size}px`;
       renderer.domElement.style.margin = 'auto';
       renderer.setPixelRatio(dpr);
     };
@@ -240,12 +239,11 @@ export default function FractalPane({
   const crossStyle = () => {
     if (!markC || !mountRef.current) return { display: 'none' } as React.CSSProperties;
     const rect = mountRef.current.getBoundingClientRect();
-    const width = rect.width * 0.75;
-    const height = rect.height * 0.75;
-    const offsetX = (rect.width - width) / 2;
-    const offsetY = (rect.height - height) / 2;
-    const x = offsetX + ((markC.real - view.xMin) / (view.xMax - view.xMin)) * width;
-    const y = offsetY + ((markC.imag - view.yMin) / (view.yMax - view.yMin)) * height;
+    const size = Math.min(rect.width, rect.height);
+    const offsetX = (rect.width - size) / 2;
+    const offsetY = (rect.height - size) / 2;
+    const x = offsetX + ((markC.real - view.xMin) / (view.xMax - view.xMin)) * size;
+    const y = offsetY + ((markC.imag - view.yMin) / (view.yMax - view.yMin)) * size;
     return {
       position: 'absolute',
       left: `${x}px`,
@@ -259,12 +257,11 @@ export default function FractalPane({
   const toScreen = (c: Complex): { x: number; y: number } => {
     if (!mountRef.current) return { x: 0, y: 0 };
     const rect = mountRef.current.getBoundingClientRect();
-    const width = rect.width * 0.75;
-    const height = rect.height * 0.75;
-    const offsetX = (rect.width - width) / 2;
-    const offsetY = (rect.height - height) / 2;
-    const x = offsetX + ((c.real - view.xMin) / (view.xMax - view.xMin)) * width;
-    const y = offsetY + ((c.imag - view.yMin) / (view.yMax - view.yMin)) * height;
+    const size = Math.min(rect.width, rect.height);
+    const offsetX = (rect.width - size) / 2;
+    const offsetY = (rect.height - size) / 2;
+    const x = offsetX + ((c.real - view.xMin) / (view.xMax - view.xMin)) * size;
+    const y = offsetY + ((c.imag - view.yMin) / (view.yMax - view.yMin)) * size;
     return { x, y };
   };
 
@@ -289,12 +286,10 @@ export default function FractalPane({
       onMouseMove={handleMouseMove}
       onMouseUp={handleMouseUp}
     >
-      {markC && type === 'mandelbrot' && (
-        <div style={crossStyle()}>X</div>
-      )}
+      {markC && <div style={crossStyle()}>X</div>}
       {pathPoints.length > 0 && (
         <svg
-          style={{ position: 'absolute', inset: 0, pointerEvents: 'none' }}
+          style={{ position: 'absolute', inset: 0, pointerEvents: 'none', width: '100%', height: '100%' }}
         >
           <polyline
             points={pathPoints}


### PR DESCRIPTION
## Summary
- allow tuning animation speed in Correspondence with higher max
- draw the Mandelbrot path in the Julia pane
- add pause/resume for path playback
- ensure overlay SVG fills the fractal pane

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684ac2eee0b08329b1903a07075f12a9