### PR TITLE
Add Möbius Walk animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 3. **[Correspondence](https://piyarsquare.github.io/animath/#/correspondence)** – interactive Mandelbrot–Julia correspondence simulation
 4. **[Complex Roots](https://piyarsquare.github.io/animath/#/roots)** – explore $z^{p/q}$ mappings with adjustable integer exponents
 5. **[Complex Multibranch](https://piyarsquare.github.io/animath/#/multibranch)** – variant supporting multiple branches for functions
+6. **[Möbius Walk](https://piyarsquare.github.io/animath/#/mobius)** – stroll through an endless twisted corridor
 
 ---
 

--- a/src/animations/MobiusWalk/MobiusWalk.tsx
+++ b/src/animations/MobiusWalk/MobiusWalk.tsx
@@ -1,0 +1,59 @@
+import React, { useRef } from 'react';
+import * as THREE from 'three';
+import Canvas3D from '@/components/Canvas3D';
+import { makeCorridorGeometry, DEFAULT_PARAMS, paramToFrame } from './corridorGeometry';
+import { corridorMaterial } from './shaders/corridorMaterial';
+import { instantiateObjects } from './objects';
+
+export interface MobiusWalkProps {
+  speed?: number;      // metres / second along corridor
+}
+
+export default function MobiusWalk({ speed = 2 }: MobiusWalkProps) {
+  const camPosT = useRef(0);          // param t along centreline
+  const clockRef = useRef(new THREE.Clock());
+
+  const onMount = React.useCallback(({ scene, camera }: {
+    scene: THREE.Scene;
+    camera: THREE.PerspectiveCamera;
+    renderer: THREE.WebGLRenderer;
+  }) => {
+    const geom = makeCorridorGeometry(DEFAULT_PARAMS);
+    const mesh = new THREE.Mesh(geom, corridorMaterial());
+    scene.add(mesh);
+
+    scene.add(instantiateObjects());
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.35));
+    const dir = new THREE.DirectionalLight(0xffffff, 1.0);
+    dir.position.set(5, 2, 3);
+    scene.add(dir);
+
+    camera.fov = 70;
+    camera.near = 0.05;
+    camera.far = 100;
+    camera.updateProjectionMatrix();
+
+    const animate = () => {
+      const dt = clockRef.current.getDelta();
+      camPosT.current = (camPosT.current + (speed * dt) / (2 * Math.PI * DEFAULT_PARAMS.radius)) % 1;
+
+      const { position, quaternion } = paramToFrame(camPosT.current, 0, 0, DEFAULT_PARAMS);
+      camera.position.copy(position);
+      camera.quaternion.copy(quaternion);
+
+      camera.position.add(new THREE.Vector3(0, 0, 0.05 * Math.sin(10 * camPosT.current * Math.PI)));
+
+      const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion).negate();
+      camera.lookAt(position.clone().add(forward));
+
+      camera.updateMatrixWorld();
+      (camera as any).parent?.updateMatrixWorld?.();
+
+      requestAnimationFrame(animate);
+    };
+    animate();
+  }, [speed]);
+
+  return <Canvas3D onMount={onMount} />;
+}

--- a/src/animations/MobiusWalk/README.md
+++ b/src/animations/MobiusWalk/README.md
@@ -1,0 +1,21 @@
+# Mobius Walk
+
+A short on-rails stroll through a subtly twisted corridor. The hallway appears ordinary until you realise left and right have swapped. A gentle iridescent shader colours the walls while small objects line the passage.
+
+Import `MobiusWalk` and mount it like any other `<Canvas3D>` scene.
+
+## Textures
+
+The module expects two textures inside `public/textures/`:
+
+```
+public/textures/arrow.png
+public/textures/painting.jpg
+```
+
+Both are small PNG/JPG assets hosted externally. Download them from:
+
+- <https://raw.githubusercontent.com/piyarsquare/animath-assets/main/arrow.png>
+- <https://raw.githubusercontent.com/piyarsquare/animath-assets/main/painting.jpg>
+
+Place the files in the folder above before running the demo.

--- a/src/animations/MobiusWalk/corridorGeometry.ts
+++ b/src/animations/MobiusWalk/corridorGeometry.ts
@@ -1,0 +1,120 @@
+import * as THREE from 'three';
+
+/** Parameters that make the hall "feel" endless without revealing the twist. */
+export interface CorridorParams {
+  radius: number;       // radius of centreline circle
+  width: number;        // corridor half-width
+  height: number;       // corridor half-height
+  segments: number;     // longitudinal segments (>= 500 looks smooth)
+  tiltTurns: number;    // half-twists: 1 → Möbius, 2 → double twist …
+}
+
+export const DEFAULT_PARAMS: CorridorParams = {
+  radius: 20,
+  width : 1.5,
+  height: 2.5,
+  segments: 800,
+  tiltTurns: 1          // single half-twist
+};
+
+/** Returns a BufferGeometry whose *inside* face points inward. */
+export function makeCorridorGeometry(
+  p: CorridorParams = DEFAULT_PARAMS
+): THREE.BufferGeometry {
+  const g = new THREE.BufferGeometry();
+  const verts: number[] = [];
+  const norms: number[] = [];
+  const uvs  : number[] = [];
+
+  for (let i = 0; i <= p.segments; i++) {
+    const t  = i / p.segments;        // [0,1]
+    const φ  = 2 * Math.PI * t;       // angle along ring
+    const τ  = Math.PI * p.tiltTurns * t; // twist
+
+    // Centreline point in world space (circle in XY-plane).
+    const cx = p.radius * Math.cos(φ);
+    const cy = p.radius * Math.sin(φ);
+    const cz = 0;
+
+    // Tangent, normal, binormal (Frenet frame on circle).
+    const tangent   = new THREE.Vector3(-Math.sin(φ),  Math.cos(φ), 0).normalize();
+    const normalRef = new THREE.Vector3(-Math.cos(φ), -Math.sin(φ), 0).normalize(); // points outward
+    const binormal  = new THREE.Vector3(0, 0, 1);                                   // Z-up
+
+    // Rotate cross-section by τ around tangent -> gives Möbius twist.
+    const qTwist = new THREE.Quaternion().setFromAxisAngle(tangent, τ);
+    const n = normalRef.clone().applyQuaternion(qTwist);
+    const b = binormal .clone().applyQuaternion(qTwist);
+
+    // Four vertices per ring segment:  ⎡+w,+h⎤ ⎡+w,‑h⎤ ⎡‑w,+h⎤ ⎡‑w,‑h⎤
+    const offsets: [number, number][] = [
+      [ p.width,  p.height],
+      [ p.width, -p.height],
+      [-p.width,  p.height],
+      [-p.width, -p.height]
+    ];
+
+    for (const [u, v] of offsets) {
+      const pos = new THREE.Vector3(cx, cy, cz)
+        .addScaledVector(n, u)
+        .addScaledVector(b, v);
+      verts.push(pos.x, pos.y, pos.z);
+      norms.push(-n.x, -n.y, -n.z); // inside normals
+      uvs  .push(t, (v > 0 ? 1 : 0));
+    }
+  }
+
+  const indices: number[] = [];
+  const ringVerts = 4;
+  for (let i = 0; i < p.segments; i++) {
+    const a = i * ringVerts;
+    const b = (i + 1) * ringVerts;
+    // connect corresponding quad strips (two triangles each)
+    for (let j = 0; j < ringVerts; j += 2) {
+      const jn = j ^ 1; // 0↔→1, 2↔→3
+      indices.push(a + j,   b + j,   b + jn);
+      indices.push(a + j,   b + jn,  a + jn);
+    }
+  }
+
+  g.setAttribute('position', new THREE.Float32BufferAttribute(verts, 3));
+  g.setAttribute('normal'  , new THREE.Float32BufferAttribute(norms, 3));
+  g.setAttribute('uv'      , new THREE.Float32BufferAttribute(uvs , 2));
+  g.setIndex(indices);
+  g.computeBoundingSphere();
+  return g;
+}
+
+/** Maps (t∈[0,1], u, v) → world position & quaternion for orienting child meshes. */
+export function paramToFrame(
+  t: number,
+  u: number,
+  v: number,
+  p: CorridorParams = DEFAULT_PARAMS
+): { position: THREE.Vector3; quaternion: THREE.Quaternion } {
+  const φ  = 2 * Math.PI * t;
+  const τ  = Math.PI * p.tiltTurns * t;
+
+  const cx = p.radius * Math.cos(φ);
+  const cy = p.radius * Math.sin(φ);
+  const tangent   = new THREE.Vector3(-Math.sin(φ),  Math.cos(φ), 0).normalize();
+  const normalRef = new THREE.Vector3(-Math.cos(φ), -Math.sin(φ), 0).normalize();
+  const binormal  = new THREE.Vector3(0, 0, 1);
+
+  const qTwist = new THREE.Quaternion().setFromAxisAngle(tangent, τ);
+  const n = normalRef.applyQuaternion(qTwist);
+  const b = binormal .applyQuaternion(qTwist);
+
+  const pos = new THREE.Vector3(cx, cy, 0)
+    .addScaledVector(n, u)
+    .addScaledVector(b, v);
+
+  // Build quaternion whose Z-axis is –n (points inward) and Y-axis is b.
+  const m = new THREE.Matrix4().makeBasis(
+    tangent.clone().negate(), // X-axis
+    b,                        // Y-axis
+    n.clone().negate()        // Z-axis
+  );
+  const q = new THREE.Quaternion().setFromRotationMatrix(m);
+  return { position: pos, quaternion: q };
+}

--- a/src/animations/MobiusWalk/objects.ts
+++ b/src/animations/MobiusWalk/objects.ts
@@ -1,0 +1,75 @@
+import * as THREE from 'three';
+import { paramToFrame, DEFAULT_PARAMS } from './corridorGeometry';
+
+export type ObjKind = 'painting' | 'helix' | 'arrow';
+
+export interface HallObject {
+  t: number;              // 0–1 along corridor
+  kind: ObjKind;
+  offset: [number, number]; // (u,v) in corridor local frame
+  mesh?: THREE.Object3D;    // populated at runtime
+}
+
+const texLoader = new THREE.TextureLoader();
+
+function makePainting(): THREE.Mesh {
+  const geom = new THREE.PlaneGeometry(1.2, 0.8);
+  const mat  = new THREE.MeshStandardMaterial({
+    map: texLoader.load('/textures/painting.jpg'), // swap assets
+    side: THREE.DoubleSide
+  });
+  return new THREE.Mesh(geom, mat);
+}
+
+function makeArrow(): THREE.Mesh {
+  const g = new THREE.PlaneGeometry(0.6, 0.6);
+  const m = new THREE.MeshBasicMaterial({
+    map: texLoader.load('/textures/arrow.png'),
+    transparent: true
+  });
+  return new THREE.Mesh(g, m);
+}
+
+function makeHelix(): THREE.Mesh {
+  const g = new THREE.TorusKnotGeometry(0.3, 0.08, 128, 16, 2, 3);
+  const m = new THREE.MeshPhysicalMaterial({
+    roughness: 0.3,
+    metalness: 0.7,
+    color: 0x7799ff,
+    iridescence: 0.15
+  });
+  return new THREE.Mesh(g, m);
+}
+
+export const OBJECTS: HallObject[] = [
+  { t: 0.05, kind: 'painting', offset: [ 0.9,  0] },
+  { t: 0.15, kind: 'painting', offset: [-0.9,  0] },
+  { t: 0.25, kind: 'arrow'   , offset: [ 0,   -1.2] },
+  { t: 0.4 , kind: 'helix'   , offset: [ 0,    0]  },
+  { t: 0.55, kind: 'painting', offset: [ 0.9,  0] },
+  { t: 0.7 , kind: 'helix'   , offset: [ 0,    0] },
+  { t: 0.85, kind: 'arrow'   , offset: [ 0,   -1.2] }
+];
+
+export function instantiateObjects(): THREE.Group {
+  const group = new THREE.Group();
+  for (const obj of OBJECTS) {
+    const base =
+      obj.kind === 'painting' ? makePainting()
+      : obj.kind === 'arrow'   ? makeArrow()
+      : makeHelix();
+    const { position, quaternion } = paramToFrame(
+      obj.t,
+      obj.offset[0],
+      obj.offset[1],
+      DEFAULT_PARAMS
+    );
+    base.position.copy(position);
+    base.quaternion.copy(quaternion);
+    // paintings should hug the wall: n-axis points inward ⇒ rotate 180° so art faces camera
+    if (obj.kind === 'painting') base.rotateY(Math.PI);
+    group.add(base);
+    obj.mesh = base;
+  }
+  return group;
+}

--- a/src/animations/MobiusWalk/shaders/corridorMaterial.ts
+++ b/src/animations/MobiusWalk/shaders/corridorMaterial.ts
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+
+export function corridorMaterial(): THREE.MeshPhysicalMaterial {
+  const mat = new THREE.MeshPhysicalMaterial({
+    roughness: 0.2,
+    metalness: 0.4,
+    side: THREE.BackSide,      // we view the inside
+    clearcoat: 0.1,
+    transmission: 0.05,
+    iridescence: 0.2,
+    color: 0x445566
+  });
+  mat.onBeforeCompile = (shader) => {
+    shader.fragmentShader = shader.fragmentShader.replace(
+      '#include <color_fragment>',
+      `
+        // iridescent tint depending on normal•view
+        float facing = dot(normal, vViewPosition) / length(vViewPosition);
+        vec3 hueShift = vec3(0.5 + 0.3 * sin(6.283 * facing));
+        outgoingLight = mix(outgoingLight, hueShift, 0.15);
+      `
+    );
+  };
+  return mat;
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,13 +5,15 @@ import FractalsGPU from './animations/FractalsGPU/FractalsGPU';
 import Correspondence from './animations/Correspondence/Correspondence';
 import ComplexRoots from './animations/ComplexRoots/ComplexRoots';
 import ComplexMultibranch from './animations/ComplexMultibranch/ComplexMultibranch';
+import MobiusWalk from './animations/MobiusWalk/MobiusWalk';
 
 const routes: Record<string, JSX.Element> = {
   '/': <App />,
   '/fractals': <FractalsGPU />,
   '/correspondence': <Correspondence />,
   '/roots': <ComplexRoots />,
-  '/multibranch': <ComplexMultibranch />
+  '/multibranch': <ComplexMultibranch />,
+  '/mobius': <MobiusWalk />
 };
 
 function getRoute(): JSX.Element {


### PR DESCRIPTION
## Summary
- add Möbius Walk animation module with geometry, shaders and objects
- include arrow and painting textures
- wire new route in `src/index.tsx`
- list Möbius Walk in the project README
- remove textures from repo and document download links

## Testing
- `npm ci`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c5b4b688c83298da15d96e84c25a9