### PR TITLE
Add circular hallway animation

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 4. **[Complex Roots](https://piyarsquare.github.io/animath/#/roots)** – explore $z^{p/q}$ mappings with adjustable integer exponents
 5. **[Complex Multibranch](https://piyarsquare.github.io/animath/#/multibranch)** – variant supporting multiple branches for functions
 6. **[Möbius Walk](https://piyarsquare.github.io/animath/#/mobius)** – stroll through an endless twisted corridor
+7. **[Circular Hallway](https://piyarsquare.github.io/animath/#/hallway)** – simple corridor with an optional Möbius twist
 
 ---
 

--- a/src/animations/CircularHallway/CircularHallway.tsx
+++ b/src/animations/CircularHallway/CircularHallway.tsx
@@ -1,0 +1,55 @@
+import React, { useCallback, useRef, useState } from 'react';
+import * as THREE from 'three';
+import Canvas3D from '@/components/Canvas3D';
+import { corridorMaterial } from '../MobiusWalk/shaders/corridorMaterial';
+import { makeCorridorGeometry, DEFAULT_PARAMS, paramToFrame, CorridorParams } from '../MobiusWalk/corridorGeometry';
+
+export interface CircularHallwayProps {
+  speed?: number;
+}
+
+export default function CircularHallway({ speed = 2 }: CircularHallwayProps) {
+  const camPosT = useRef(0);
+  const clockRef = useRef(new THREE.Clock());
+  const [twist, setTwist] = useState(false);
+
+  const onMount = useCallback(({ scene, camera, renderer }: { scene: THREE.Scene; camera: THREE.PerspectiveCamera; renderer: THREE.WebGLRenderer; }) => {
+    const params: CorridorParams = { ...DEFAULT_PARAMS, tiltTurns: twist ? 1 : 0 };
+    const geom = makeCorridorGeometry(params);
+    const mesh = new THREE.Mesh(geom, corridorMaterial());
+    scene.add(mesh);
+
+    scene.add(new THREE.AmbientLight(0xffffff, 0.4));
+    const dir = new THREE.DirectionalLight(0xffffff, 0.8);
+    dir.position.set(5, 2, 3);
+    scene.add(dir);
+
+    const animate = () => {
+      const dt = clockRef.current.getDelta();
+      camPosT.current = (camPosT.current + (speed * dt) / (2 * Math.PI * params.radius)) % 1;
+      const { position, quaternion } = paramToFrame(camPosT.current, 0, 0, params);
+      camera.position.copy(position);
+      camera.quaternion.copy(quaternion);
+      camera.position.add(new THREE.Vector3(0, 0, 0.05 * Math.sin(10 * camPosT.current * Math.PI)));
+      const forward = new THREE.Vector3(0, 0, 1).applyQuaternion(quaternion).negate();
+      camera.lookAt(position.clone().add(forward));
+      camera.updateMatrixWorld();
+      (camera as any).parent?.updateMatrixWorld?.();
+      renderer.render(scene, camera);
+      requestAnimationFrame(animate);
+    };
+    animate();
+  }, [speed, twist]);
+
+  return (
+    <div>
+      <Canvas3D onMount={onMount} />
+      <button
+        style={{ position: 'absolute', top: 20, left: 20 }}
+        onClick={() => setTwist((t) => !t)}
+      >
+        {twist ? 'Disable Twist' : 'Enable Möbius Twist'}
+      </button>
+    </div>
+  );
+}

--- a/src/animations/CircularHallway/README.md
+++ b/src/animations/CircularHallway/README.md
@@ -1,0 +1,5 @@
+# Circular Hallway
+
+This animation shows a simple circular corridor rendered with Three.js. The path slowly curves without any twist, giving the impression of a long loop. A button toggles a Möbius twist so you can switch between the ordinary corridor and the original Möbius version.
+
+No external textures are required.

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,6 +6,7 @@ import Correspondence from './animations/Correspondence/Correspondence';
 import ComplexRoots from './animations/ComplexRoots/ComplexRoots';
 import ComplexMultibranch from './animations/ComplexMultibranch/ComplexMultibranch';
 import MobiusWalk from './animations/MobiusWalk/MobiusWalk';
+import CircularHallway from './animations/CircularHallway/CircularHallway';
 
 const routes: Record<string, JSX.Element> = {
   '/': <App />,
@@ -13,7 +14,8 @@ const routes: Record<string, JSX.Element> = {
   '/correspondence': <Correspondence />,
   '/roots': <ComplexRoots />,
   '/multibranch': <ComplexMultibranch />,
-  '/mobius': <MobiusWalk />
+  '/mobius': <MobiusWalk />,
+  '/hallway': <CircularHallway />
 };
 
 function getRoute(): JSX.Element {


### PR DESCRIPTION
## Summary
- implement `CircularHallway` animation with optional Möbius twist
- expose `/hallway` route and document it in README
- add documentation for the new animation

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684c88edd9508329851a5c9a624ff3d4