### PR TITLE
Fix path drawn only on Mandelbrot

### DIFF
--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -224,7 +224,6 @@ export default function Correspondence() {
           iter={iter}
           palette={paletteJ}
           offset={offsetJ}
-          path={path}
         />
         <div
           style={{ position: 'absolute', top: 4, left: '50%', transform: 'translateX(-50%)', color: 'white' }}


### PR DESCRIPTION
## Summary
- Correspondence: don't render drawn path on the Julia pane

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684c8fc759c88329be70b95f64c16a89