### PR TITLE
Add Stable Marriage link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 4. **[Complex Roots](https://piyarsquare.github.io/animath/#/roots)** – explore $z^{p/q}$ mappings with adjustable integer exponents
 5. **[Complex Multibranch](https://piyarsquare.github.io/animath/#/multibranch)** – variant supporting multiple branches for functions
 6. **[Möbius Walk](https://piyarsquare.github.io/animath/#/mobius)** – stroll through an endless twisted corridor (now with optional twist toggle)
+7. **[Stable Marriage](https://piyarsquare.github.io/animath/#/stable-marriage)** – step through the Gale–Shapley process with bias and consensus controls
 
 ---
 


### PR DESCRIPTION
### Motivation
- Ensure the newly added Stable Marriage animation is discoverable from the main project README by adding it to the Table of contents.

### Description
- Update `README.md` to include a `Stable Marriage` entry linking to `https://piyarsquare.github.io/animath/#/stable-marriage` with a short description of the module.

### Testing
- No automated tests were run because this is a docs-only change; no build required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69754080f50c8329afb78e700f946d7c)