### PR TITLE
Fix EPUB line centering by replacing deprecated align attribute with CSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > *Animated mathematics for curious minds* — a modular, browser-based toolkit for creating, sharing, and exploring mathematical animations and generative art.
 
-<p align="center">
+<p style="text-align: center;">
   <a href="https://piyarsquare.github.io/animath/">Live demo</a>
 </p>
 


### PR DESCRIPTION
The `<p align="center">` tag uses a deprecated HTML attribute that EPUB
readers handle inconsistently, causing subsequent lines to shift back to
center alignment. Replacing it with `style="text-align: center;"` ensures
proper scoping in EPUB renderers.

https://claude.ai/code/session_01Q3urX26PUzmTdWuCN2mKF7