### PR TITLE
Fix navigation links and collapse menus on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -66,25 +66,40 @@
       }
       
       #page-info {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        z-index: 50;
         text-align: center;
-        margin: 4px 0;
-        padding: 10px;
-        background: rgba(0, 0, 0, 0.8);
+        margin: 0;
+        padding: 6px 10px;
+        background: rgba(0, 0, 0, 0.85);
         color: white;
-        font-size: 14px;
+        font-size: 13px;
+        backdrop-filter: blur(4px);
       }
-      
+
+      #page-info a {
+        color: #ffd400;
+        margin: 0 4px;
+      }
+
       @media (max-width: 480px) {
         #page-info {
-          font-size: 12px;
-          padding: 8px;
+          font-size: 11px;
+          padding: 5px 8px;
+        }
+
+        #page-info a {
+          margin: 0 2px;
         }
       }
     </style>
   </head>
   <body>
     <div id="root"></div>
-    <p id="page-info">You are viewing the animath page. Try <a href="#/fractals" style="color: #ffd400;">#/fractals</a> for the fractals demo.</p>
+    <p id="page-info"><a href="#/">particles</a> · <a href="#/fractals">fractals</a> · <a href="#/correspondence">correspondence</a> · <a href="#/roots">roots</a> · <a href="#/multibranch">multibranch</a> · <a href="#/mobius">mobius</a> · <a href="#/stable-marriage">stable marriage</a> · <a href="#/agentic-sorting">agentic sorting</a></p>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/src/animations/ComplexMultibranch/ComplexMultibranch.tsx
+++ b/src/animations/ComplexMultibranch/ComplexMultibranch.tsx
@@ -197,7 +197,7 @@ export default function ComplexMultibranch({ count = COMPLEX_PARTICLES_DEFAULTS.
           maxWidth: isMobile ? 'calc(100vw - 20px)' : '300px',
         }}
       >
-        <ToggleMenu title="Menu">
+        <ToggleMenu title="Menu" defaultOpen={!isMobile}>
           <div style={{ color: 'white', display: 'flex', flexDirection: 'column', gap: isMobile ? 6 : 8 }}>
             <label style={{ fontSize: isMobile ? '12px' : '14px' }}>
               Saturation:
@@ -372,7 +372,7 @@ export default function ComplexMultibranch({ count = COMPLEX_PARTICLES_DEFAULTS.
 
       {/* About Menu */}
       <div style={{ position: 'absolute', bottom: '10px', right: '10px', zIndex: 10 }}>
-        <ToggleMenu title="About">
+        <ToggleMenu title="About" defaultOpen={!isMobile}>
           <Readme markdown={readmeText} />
         </ToggleMenu>
       </div>

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -138,7 +138,7 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
           maxWidth: isMobile ? 'calc(100vw - 20px)' : '300px',
         }}
       >
-        <ToggleMenu title="Menu">
+        <ToggleMenu title="Menu" defaultOpen={!isMobile}>
           <div
             style={{
               color: 'white',
@@ -309,7 +309,7 @@ export default function ComplexParticles({ count = COMPLEX_PARTICLES_DEFAULTS.de
 
       {/* About Menu */}
       <div style={{ position: 'absolute', bottom: '10px', right: '10px', zIndex: 10 }}>
-        <ToggleMenu title="About">
+        <ToggleMenu title="About" defaultOpen={!isMobile}>
           <Readme markdown={readmeText} />
         </ToggleMenu>
       </div>

--- a/src/animations/ComplexRoots/ComplexRoots.tsx
+++ b/src/animations/ComplexRoots/ComplexRoots.tsx
@@ -140,7 +140,7 @@ export default function ComplexRoots({ count = COMPLEX_PARTICLES_DEFAULTS.defaul
           maxWidth: isMobile ? 'calc(100vw - 20px)' : '300px',
         }}
       >
-        <ToggleMenu title="Menu">
+        <ToggleMenu title="Menu" defaultOpen={!isMobile}>
           <div
             style={{
               color: 'white',
@@ -309,7 +309,7 @@ export default function ComplexRoots({ count = COMPLEX_PARTICLES_DEFAULTS.defaul
 
       {/* About Menu */}
       <div style={{ position: 'absolute', bottom: '10px', right: '10px', zIndex: 10 }}>
-        <ToggleMenu title="About">
+        <ToggleMenu title="About" defaultOpen={!isMobile}>
           <Readme markdown={readmeText} />
         </ToggleMenu>
       </div>

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -690,7 +690,7 @@ export default function FractalsGPU() {
       
       {/* About Menu */}
       <div style={{ position: 'absolute', bottom: '10px', right: '10px' }}>
-        <ToggleMenu title="About">
+        <ToggleMenu title="About" defaultOpen={!isMobile}>
           <Readme markdown={readmeText} />
         </ToggleMenu>
       </div>

--- a/src/components/ToggleMenu.tsx
+++ b/src/components/ToggleMenu.tsx
@@ -4,14 +4,15 @@ import { TOGGLE_MENU_STYLE } from '../config/defaults';
 export interface ToggleMenuProps {
   title: string;
   children: React.ReactNode;
+  defaultOpen?: boolean;
 }
 
 /**
  * A simple widget that can show or hide its children.
  * Useful for overlay menus.
  */
-export default function ToggleMenu({ title, children }: ToggleMenuProps) {
-  const [visible, setVisible] = useState(true);
+export default function ToggleMenu({ title, children, defaultOpen = true }: ToggleMenuProps) {
+  const [visible, setVisible] = useState(defaultOpen);
   return (
     <div style={TOGGLE_MENU_STYLE.container}>
       <button onClick={() => setVisible(v => !v)}>


### PR DESCRIPTION
Add a fixed navigation bar at the bottom of the page with links to all
animations (including agentic sorting). Menus in particle viewers and
fractals now start collapsed on mobile to avoid covering the viewport.

https://claude.ai/code/session_01EnFt6rUVnSJkVaRtVHgCLj