### PR TITLE
Mobile-friendly pass for fractals, correspondence, agentic, stable ma…

### DIFF
--- a/src/animations/AgenticSorting/agenticSorting.css
+++ b/src/animations/AgenticSorting/agenticSorting.css
@@ -56,6 +56,25 @@
   .as-layout {
     grid-template-columns: 1fr;
   }
+  /* Show the arena first on narrow screens; controls scroll down below it. */
+  .as-main { order: -1; }
+}
+
+@media (max-width: 600px) {
+  .as-app { padding: 8px; }
+  .as-header { margin-bottom: 8px; }
+  .as-header h1 { font-size: 22px; }
+  .as-layout { gap: 12px; }
+  .as-card { padding: 14px; border-radius: 12px; }
+  .as-main { gap: 12px; }
+  .as-sidebar { gap: 12px; }
+  .as-controls-row { margin-bottom: 14px; }
+  .as-button-primary, .as-button-reset { padding: 12px 16px; font-size: 13px; }
+  .as-slider-group { margin-bottom: 14px; }
+  .as-slider { height: 8px; }
+  .as-slider::-webkit-slider-thumb { width: 22px; height: 22px; }
+  .as-slider::-moz-range-thumb { width: 22px; height: 22px; }
+  .as-stat-value { font-size: 16px; }
 }
 
 /* ── Sidebar ── */

--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 import * as THREE from 'three';
+import { useViewportGestures } from '../../lib/useViewportGestures';
 
 export interface Complex {
   real: number;
@@ -61,6 +62,7 @@ export default function FractalPane({
   const mountRef = useRef<HTMLDivElement>(null);
   const rendererRef = useRef<THREE.WebGLRenderer>();
   const materialRef = useRef<THREE.ShaderMaterial>();
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
   const vertexShader = `
     varying vec2 vUv;
@@ -137,6 +139,7 @@ export default function FractalPane({
     const mesh = new THREE.Mesh(new THREE.PlaneGeometry(2, 2), material);
     scene.add(mesh);
     mountRef.current.appendChild(canvas);
+    canvasRef.current = canvas;
 
     const handleResize = () => {
       if (!mountRef.current) return;
@@ -188,53 +191,32 @@ export default function FractalPane({
 
 
   const [drawPoints, setDrawPoints] = useState<Complex[]>([]);
-  const isDrawingRef = useRef(false);
+  const drawBufferRef = useRef<Complex[]>([]);
 
-  const handleClick = useCallback(
-    (e: React.MouseEvent) => {
-      if (drawing) return;
-      if (!onPickC) return;
-      const canvas = rendererRef.current?.domElement;
-      if (!canvas) return;
-      const c = screenToComplex(e.nativeEvent, canvas, view);
-      onPickC(c);
+  const gestures = useViewportGestures({
+    view,
+    onViewChange,
+    coordRef: canvasRef,
+    mode: drawing ? 'draw' : 'pan',
+    onTap: (p) => {
+      onPickC?.({ real: p.x, imag: p.y });
     },
-    [onPickC, view, drawing]
-  );
-
-  const handleMouseDown = useCallback(
-    (e: React.MouseEvent) => {
-      if (!drawing) return;
-      const canvas = rendererRef.current?.domElement;
-      if (!canvas) return;
-      const c = screenToComplex(e.nativeEvent, canvas, view);
-      isDrawingRef.current = true;
+    onDrawStart: (p) => {
+      const c = { real: p.x, imag: p.y };
+      drawBufferRef.current = [c];
       setDrawPoints([c]);
       onPathChange?.([c]);
     },
-    [drawing, view, onPathChange]
-  );
-
-  const handleMouseMove = useCallback(
-    (e: React.MouseEvent) => {
-      if (!drawing || !isDrawingRef.current) return;
-      const canvas = rendererRef.current?.domElement;
-      if (!canvas) return;
-      const c = screenToComplex(e.nativeEvent, canvas, view);
-      setDrawPoints(prev => {
-        const np = [...prev, c];
-        onPathChange?.(np);
-        return np;
-      });
+    onDrawMove: (p) => {
+      const c = { real: p.x, imag: p.y };
+      drawBufferRef.current = [...drawBufferRef.current, c];
+      setDrawPoints(drawBufferRef.current);
+      onPathChange?.(drawBufferRef.current);
     },
-    [drawing, view, onPathChange]
-  );
-
-  const handleMouseUp = useCallback(() => {
-    if (!drawing || !isDrawingRef.current) return;
-    isDrawingRef.current = false;
-    onPathChange?.(drawPoints);
-  }, [drawing, drawPoints, onPathChange]);
+    onDrawEnd: () => {
+      onPathChange?.(drawBufferRef.current);
+    },
+  });
 
   const crossStyle = () => {
     if (!markC || !mountRef.current) return { display: 'none' } as React.CSSProperties;
@@ -279,12 +261,10 @@ export default function FractalPane({
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        position: 'relative'
+        position: 'relative',
+        touchAction: 'none'
       }}
-      onClick={handleClick}
-      onMouseDown={handleMouseDown}
-      onMouseMove={handleMouseMove}
-      onMouseUp={handleMouseUp}
+      {...gestures}
     >
       {markC && <div style={crossStyle()}>X</div>}
       {pathPoints.length > 0 && (

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -4,6 +4,7 @@ import Readme from '../../components/Readme';
 import ToggleMenu from '../../components/ToggleMenu';
 import readmeText from './README.md?raw';
 import { useResponsive, getResponsiveControlsStyle, getResponsiveButtonStyle, getResponsiveInputStyle } from '../../styles/responsive';
+import { useViewportGestures } from '../../lib/useViewportGestures';
 
 /** GPU accelerated Mandelbrot/Julia viewer using a fragment shader. */
 export default function FractalsGPU() {
@@ -217,18 +218,6 @@ export default function FractalsGPU() {
     animRef.current = requestAnimationFrame(animate);
   }, []);
 
-  const screenToFractal = useCallback(
-    (sx: number, sy: number) => {
-      const canvas = rendererRef.current?.domElement;
-      if (!canvas) return { x: 0, y: 0 };
-      const rect = canvas.getBoundingClientRect();
-      const x = sx - rect.left;
-      const y = sy - rect.top;
-      const scale = (view.xMax - view.xMin) / canvas.width;
-      return { x: view.xMin + x * scale, y: view.yMin + y * scale };
-    },
-    [view]
-  );
 
   const fractalToScreen = useCallback(
     (fx: number, fy: number) => {
@@ -259,9 +248,8 @@ export default function FractalsGPU() {
     }
   }
 
-  const handleSelect = useCallback(
-    (e: React.MouseEvent<HTMLCanvasElement>) => {
-      const start = screenToFractal(e.clientX, e.clientY);
+  const tracePath = useCallback(
+    (start: { x: number; y: number }) => {
       const pts: { x: number; y: number }[] = [];
       const powComplex = (x: number, y: number) => {
         let rx = x;
@@ -305,44 +293,19 @@ export default function FractalsGPU() {
       pathRef.current = pts;
       drawPath();
     },
-    [screenToFractal, iter, type, juliaC, drawPath, power]
+    [iter, type, juliaC, drawPath, power]
   );
 
 
-  const zoom = useCallback((factor: number) => {
-    const canvas = rendererRef.current?.domElement;
-    if (!canvas) return;
-    const center = {
-      x: (view.xMin + view.xMax) / 2,
-      y: (view.yMin + view.yMax) / 2
-    };
-    const xr = (view.xMax - view.xMin) * factor;
-    const yr = (view.yMax - view.yMin) * factor;
-    const newView = {
-      xMin: center.x - xr / 2,
-      xMax: center.x + xr / 2,
-      yMin: center.y - yr / 2,
-      yMax: center.y + yr / 2
-    };
-    setView(normalizeView(newView, canvas));
-  }, [view, normalizeView]);
-
-
-  const pan = useCallback((dx: number, dy: number) => {
-    const canvas = rendererRef.current?.domElement;
-    if (!canvas) return;
-    setView(v => {
-      const scale = (v.xMax - v.xMin) / canvas.width;
-      const newView = {
-        xMin: v.xMin - dx * scale,
-        xMax: v.xMax - dx * scale,
-        yMin: v.yMin - dy * scale,
-        yMax: v.yMax - dy * scale
-      };
-      return normalizeView(newView, canvas);
-    });
-  }, [normalizeView]);
-
+  const gestures = useViewportGestures({
+    view,
+    onViewChange: setView,
+    clamp: (v) => {
+      const canvas = rendererRef.current?.domElement;
+      return canvas ? normalizeView(v, canvas) : v;
+    },
+    onTap: tracePath,
+  });
 
   const reset = useCallback(() => {
     const canvas = rendererRef.current?.domElement;
@@ -424,7 +387,8 @@ export default function FractalsGPU() {
   return (
     <div
       ref={mountRef}
-      style={{ position: 'relative', width: '100%', height: '100vh', overflow: 'hidden' }}
+      style={{ position: 'relative', width: '100%', height: '100vh', overflow: 'hidden', touchAction: 'none' }}
+      {...gestures}
     >
       <canvas
         ref={overlayRef}
@@ -482,62 +446,14 @@ export default function FractalsGPU() {
           <div style={{ fontSize: isMobile ? '0.8em' : '0.9em' }}>{FORMULAS[type]}</div>
         </div>
         
-        {!isMobile && (
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: 4 }}>
-            <button 
-              onClick={() => pan(0, -50)}
-              style={getResponsiveButtonStyle(isMobile)}
-            >
-              Up
-            </button>
-            <div style={{ display: 'flex', gap: 4 }}>
-              <button 
-                onClick={() => pan(-50, 0)}
-                style={getResponsiveButtonStyle(isMobile)}
-              >
-                Left
-              </button>
-              <button 
-                onClick={() => pan(50, 0)}
-                style={getResponsiveButtonStyle(isMobile)}
-              >
-                Right
-              </button>
-            </div>
-            <button 
-              onClick={() => pan(0, 50)}
-              style={getResponsiveButtonStyle(isMobile)}
-            >
-              Down
-            </button>
-          </div>
-        )}
-        
-        <div style={{ display: 'flex', gap: isMobile ? 2 : 4 }}>
-          <button 
-            onClick={() => zoom(0.9)}
-            style={getResponsiveButtonStyle(isMobile)}
-          >
-            Zoom In
-          </button>
-          <button 
-            onClick={() => zoom(1.1)}
-            style={getResponsiveButtonStyle(isMobile)}
-          >
-            Zoom Out
-          </button>
+        <div style={{
+          fontSize: isMobile ? '10px' : '11px',
+          color: '#ccc',
+          textAlign: 'center',
+          marginTop: '4px'
+        }}>
+          {isMobile ? 'Pinch to zoom · drag to pan · tap to trace' : 'Wheel to zoom · drag to pan · click to trace'}
         </div>
-        
-        {isMobile && (
-          <div style={{ 
-            fontSize: '10px', 
-            color: '#ccc', 
-            textAlign: 'center',
-            marginTop: '4px'
-          }}>
-            Pinch to zoom, drag to pan
-          </div>
-        )}
       </div>
       
       {/* Bottom Left - Main Controls */}

--- a/src/animations/StableMarriage/StableMarriage.tsx
+++ b/src/animations/StableMarriage/StableMarriage.tsx
@@ -356,6 +356,10 @@ const Heatmap = ({
   labels?: { left: string; right: string };
 }) => {
   const [hover, setHover] = useState<HeatmapPoint | null>(null);
+  const [pinned, setPinned] = useState<HeatmapPoint | null>(null);
+  const active = pinned ?? hover;
+  const samePoint = (a: HeatmapPoint | null, b: HeatmapPoint | null) =>
+    !!a && !!b && a.x === b.x && a.y === b.y;
 
   if (!data || data.length === 0) {
     return (
@@ -391,11 +395,11 @@ const Heatmap = ({
         <div className="sm-heatmap-axis">
           <span>Women Consensus (0% → 100%)</span>
         </div>
-        <div className="sm-heatmap-grid">
+        <div className="sm-heatmap-grid" onClick={() => setPinned(null)}>
           {data.map((point, index) => (
             <div
               key={`${point.x}-${point.y}-${index}`}
-              className="sm-heatmap-cell"
+              className={`sm-heatmap-cell${samePoint(pinned, point) ? ' pinned' : ''}`}
               style={{
                 left: `${point.x}%`,
                 bottom: `${point.y}%`,
@@ -403,21 +407,25 @@ const Heatmap = ({
                 height: `${cellSize}%`,
                 backgroundColor: getColor(Number(point[dataKey]))
               }}
-              onMouseEnter={() => setHover(point)}
-              onMouseLeave={() => setHover(null)}
+              onMouseEnter={() => { if (!pinned) setHover(point); }}
+              onMouseLeave={() => { if (!pinned) setHover(null); }}
+              onClick={(e) => {
+                e.stopPropagation();
+                setPinned(p => samePoint(p, point) ? null : point);
+              }}
             />
           ))}
-          {hover ? (
+          {active ? (
             <div className="sm-heatmap-hover">
               <div className="sm-heatmap-tooltip">
                 <div className="sm-heatmap-tooltip-header">
-                  M-Consensus: {hover.x.toFixed(0)}%<br />W-Consensus: {hover.y.toFixed(0)}%
+                  M-Consensus: {active.x.toFixed(0)}%<br />W-Consensus: {active.y.toFixed(0)}%
                 </div>
                 <div className="sm-heatmap-tooltip-grid">
-                  <span>Men: {hover.menAvg.toFixed(1)}</span>
-                  <span>Women: {hover.womenAvg.toFixed(1)}</span>
-                  <span>Asker: {hover.askerAvg.toFixed(1)}</span>
-                  <span>Asked: {hover.askedAvg.toFixed(1)}</span>
+                  <span>Men: {active.menAvg.toFixed(1)}</span>
+                  <span>Women: {active.womenAvg.toFixed(1)}</span>
+                  <span>Asker: {active.askerAvg.toFixed(1)}</span>
+                  <span>Asked: {active.askedAvg.toFixed(1)}</span>
                 </div>
               </div>
             </div>

--- a/src/animations/StableMarriage/stableMarriage.css
+++ b/src/animations/StableMarriage/stableMarriage.css
@@ -645,3 +645,65 @@
     align-items: flex-start;
   }
 }
+
+@media (max-width: 600px) {
+  .sm-app { padding: 12px; }
+  .sm-header h1 { font-size: 20px; }
+  .sm-mode-toggle { flex-wrap: wrap; }
+  .sm-card { padding: 14px; border-radius: 12px; }
+  .sm-card + .sm-card { margin-top: 12px; }
+  .sm-card-header { flex-direction: column; align-items: flex-start; gap: 8px; }
+
+  /* Single-column controls/results/people on phones */
+  .sm-control-group { grid-template-columns: 1fr 1fr; gap: 10px; }
+  .sm-people { grid-template-columns: 1fr; gap: 16px; }
+  .sm-summary { grid-template-columns: 1fr 1fr; gap: 8px; }
+  .sm-summary div { padding: 10px; }
+  .sm-summary strong { font-size: 16px; }
+  .sm-lab-grid { grid-template-columns: 1fr; gap: 14px; }
+
+  /* Shorter scroll regions */
+  .sm-column-list { max-height: 320px; }
+
+  /* Smaller people circles, tighter rows */
+  .sm-person { width: 36px; height: 36px; }
+  .sm-rank-badge { font-size: 9px; padding: 1px 5px; }
+  .sm-role-badge { width: 16px; height: 16px; font-size: 8px; }
+
+  /* Tabs & header wrap */
+  .sm-result-header { flex-direction: column; align-items: flex-start; }
+  .sm-tabs { flex-wrap: wrap; }
+  .sm-result-meta { flex-wrap: wrap; }
+
+  /* Distribution: shorter, more touch-friendly */
+  .sm-distribution-bars { height: 160px; gap: 4px; }
+  .sm-distribution-column { min-width: 18px; }
+  .sm-distribution-bar { width: 8px; }
+  .sm-distribution-legend { flex-wrap: wrap; gap: 8px; }
+
+  /* Heatmap: shorter so it doesn't dominate the screen */
+  .sm-heatmap-body { min-height: 240px; }
+  .sm-heatmap-tooltip { font-size: 10px; padding: 6px 8px; }
+  .sm-heatmap-tooltip-grid { grid-template-columns: 1fr 1fr; gap: 2px 8px; }
+
+  /* Bigger range thumb so it's touchable */
+  .sm-controls input[type='range'] {
+    height: 8px;
+    -webkit-appearance: none;
+    appearance: none;
+    background: #cbd5f5;
+    border-radius: 4px;
+  }
+  .sm-controls input[type='range']::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    width: 22px; height: 22px; border-radius: 50%;
+    background: #2563eb; cursor: pointer;
+  }
+  .sm-controls input[type='range']::-moz-range-thumb {
+    width: 22px; height: 22px; border-radius: 50%;
+    background: #2563eb; border: none; cursor: pointer;
+  }
+}
+
+/* Heatmap cell: keep hover-style highlight for taps too */
+.sm-heatmap-cell.pinned { filter: brightness(0.85); }

--- a/src/lib/useViewportGestures.ts
+++ b/src/lib/useViewportGestures.ts
@@ -1,0 +1,208 @@
+import { useRef } from 'react';
+
+export interface ViewBounds {
+  xMin: number;
+  xMax: number;
+  yMin: number;
+  yMax: number;
+}
+
+export interface Point2 { x: number; y: number; }
+
+interface UseViewportGesturesOptions {
+  view: ViewBounds;
+  onViewChange: (v: ViewBounds) => void;
+  /**
+   * 'pan' (default) — 1-finger drag pans the viewport, clean taps fire onTap.
+   * 'draw' — 1-finger drag invokes onDrawStart/Move/End; tap is suppressed.
+   * In both modes 2-finger pinches to zoom around the pinch midpoint, wheel zooms.
+   */
+  mode?: 'pan' | 'draw';
+  /** Optional clamp applied to every emitted view (e.g. enforce aspect ratio). */
+  clamp?: (v: ViewBounds, el: HTMLElement) => ViewBounds;
+  /**
+   * Element whose rect defines the math-coordinate space. Use when the canvas is
+   * smaller than the event-target element (e.g. a centered square inside a wider
+   * wrapper). Defaults to the pointer-event target.
+   */
+  coordRef?: React.RefObject<HTMLElement | null>;
+  /** Clean tap callback — fires only if a single pointer went down and up without dragging. */
+  onTap?: (mathPoint: Point2) => void;
+  /** Called when the user begins drawing in draw mode. */
+  onDrawStart?: (mathPoint: Point2) => void;
+  /** Called on each pointer move while drawing. */
+  onDrawMove?: (mathPoint: Point2) => void;
+  /** Called when drawing ends (pointer up or canceled). */
+  onDrawEnd?: () => void;
+}
+
+const TAP_MAX_MOVE_PX = 5;
+const TAP_MAX_DURATION_MS = 350;
+const WHEEL_ZOOM_FACTOR = 0.0015; // factor = exp(deltaY * WHEEL_ZOOM_FACTOR)
+
+function screenToMath(view: ViewBounds, px: number, py: number, el: HTMLElement): Point2 {
+  const w = el.clientWidth;
+  const h = el.clientHeight;
+  return {
+    x: view.xMin + (view.xMax - view.xMin) * (px / w),
+    y: view.yMin + (view.yMax - view.yMin) * (py / h),
+  };
+}
+
+function panView(view: ViewBounds, dxPx: number, dyPx: number, el: HTMLElement): ViewBounds {
+  const sx = (view.xMax - view.xMin) / el.clientWidth;
+  const sy = (view.yMax - view.yMin) / el.clientHeight;
+  return {
+    xMin: view.xMin - dxPx * sx,
+    xMax: view.xMax - dxPx * sx,
+    yMin: view.yMin - dyPx * sy,
+    yMax: view.yMax - dyPx * sy,
+  };
+}
+
+/** Scale view about a pivot expressed in canvas-local pixels. factor < 1 zooms in. */
+function zoomViewAtPixel(view: ViewBounds, factor: number, px: number, py: number, el: HTMLElement): ViewBounds {
+  const w = el.clientWidth;
+  const h = el.clientHeight;
+  const tx = px / w;
+  const ty = py / h;
+  const fx = view.xMin + (view.xMax - view.xMin) * tx;
+  const fy = view.yMin + (view.yMax - view.yMin) * ty;
+  const newW = (view.xMax - view.xMin) * factor;
+  const newH = (view.yMax - view.yMin) * factor;
+  return {
+    xMin: fx - newW * tx,
+    xMax: fx + newW * (1 - tx),
+    yMin: fy - newH * ty,
+    yMax: fy + newH * (1 - ty),
+  };
+}
+
+interface PointerRecord { x: number; y: number; downX: number; downY: number; downTime: number; }
+
+/**
+ * Pointer/wheel-driven pan, pinch-zoom, and wheel-zoom for a 2D viewport.
+ * Unifies mouse, pen, and touch via Pointer Events. Spread the return value onto
+ * the element that hosts the viewport (typically the canvas container).
+ */
+export function useViewportGestures(opts: UseViewportGesturesOptions) {
+  const { view, onViewChange, mode = 'pan', clamp, coordRef, onTap, onDrawStart, onDrawMove, onDrawEnd } = opts;
+
+  const pointers = useRef(new Map<number, PointerRecord>());
+  const lastPinch = useRef<{ dist: number; midX: number; midY: number } | null>(null);
+  const drawing = useRef(false);
+
+  const coordEl = (e: React.PointerEvent | React.WheelEvent): HTMLElement =>
+    coordRef?.current ?? (e.currentTarget as HTMLElement);
+
+  const emit = (v: ViewBounds, el: HTMLElement) => {
+    onViewChange(clamp ? clamp(v, el) : v);
+  };
+
+  const localCoords = (e: React.PointerEvent | React.WheelEvent) => {
+    const rect = coordEl(e).getBoundingClientRect();
+    return { x: e.clientX - rect.left, y: e.clientY - rect.top };
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    const el = coordEl(e);
+    const local = localCoords(e);
+    pointers.current.set(e.pointerId, {
+      x: local.x, y: local.y, downX: local.x, downY: local.y, downTime: performance.now(),
+    });
+
+    if (pointers.current.size === 1 && mode === 'draw') {
+      drawing.current = true;
+      onDrawStart?.(screenToMath(view, local.x, local.y, el));
+    }
+
+    if (pointers.current.size === 2) {
+      // Starting a pinch — drop any in-progress draw.
+      if (drawing.current) {
+        drawing.current = false;
+        onDrawEnd?.();
+      }
+      const pts = [...pointers.current.values()];
+      const dx = pts[0].x - pts[1].x;
+      const dy = pts[0].y - pts[1].y;
+      lastPinch.current = {
+        dist: Math.hypot(dx, dy),
+        midX: (pts[0].x + pts[1].x) / 2,
+        midY: (pts[0].y + pts[1].y) / 2,
+      };
+    }
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const rec = pointers.current.get(e.pointerId);
+    if (!rec) return;
+    const el = coordEl(e);
+    const local = localCoords(e);
+    const dxFromLast = local.x - rec.x;
+    const dyFromLast = local.y - rec.y;
+    rec.x = local.x;
+    rec.y = local.y;
+
+    if (pointers.current.size === 1) {
+      if (mode === 'draw' && drawing.current) {
+        onDrawMove?.(screenToMath(view, local.x, local.y, el));
+      } else if (mode === 'pan') {
+        if (dxFromLast || dyFromLast) emit(panView(view, dxFromLast, dyFromLast, el), el);
+      }
+    } else if (pointers.current.size >= 2) {
+      const pts = [...pointers.current.values()];
+      const newDist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+      const newMidX = (pts[0].x + pts[1].x) / 2;
+      const newMidY = (pts[0].y + pts[1].y) / 2;
+
+      let v = view;
+      if (lastPinch.current && newDist > 1e-3) {
+        const factor = lastPinch.current.dist / newDist;
+        v = zoomViewAtPixel(v, factor, newMidX, newMidY, el);
+      }
+      if (lastPinch.current) {
+        const dMx = newMidX - lastPinch.current.midX;
+        const dMy = newMidY - lastPinch.current.midY;
+        if (dMx || dMy) v = panView(v, dMx, dMy, el);
+      }
+      lastPinch.current = { dist: newDist, midX: newMidX, midY: newMidY };
+      emit(v, el);
+    }
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    const rec = pointers.current.get(e.pointerId);
+    pointers.current.delete(e.pointerId);
+    if (pointers.current.size < 2) lastPinch.current = null;
+
+    if (drawing.current && pointers.current.size === 0) {
+      drawing.current = false;
+      onDrawEnd?.();
+    }
+
+    if (rec && mode === 'pan' && onTap && pointers.current.size === 0) {
+      const movedPx = Math.hypot(rec.x - rec.downX, rec.y - rec.downY);
+      const heldMs = performance.now() - rec.downTime;
+      if (movedPx < TAP_MAX_MOVE_PX && heldMs < TAP_MAX_DURATION_MS) {
+        const el = coordEl(e);
+        onTap(screenToMath(view, rec.x, rec.y, el));
+      }
+    }
+  };
+
+  const onWheel = (e: React.WheelEvent) => {
+    const el = coordEl(e);
+    const local = localCoords(e);
+    const factor = Math.exp(e.deltaY * WHEEL_ZOOM_FACTOR);
+    emit(zoomViewAtPixel(view, factor, local.x, local.y, el), el);
+  };
+
+  return {
+    onPointerDown,
+    onPointerMove,
+    onPointerUp,
+    onPointerCancel: onPointerUp,
+    onWheel,
+  };
+}


### PR DESCRIPTION
…rriage

Adds touch/gesture support and 390px layout fixes across the four remaining apps. Pulls the shared 2D pan/pinch logic into a new hook mirroring the recently-added useGestureRotation for the 4D viewer.

src/lib/useViewportGestures.ts (new)
  Pointer Events-based hook for any 2D viewport. Modes:
    pan  — 1-finger drag pans, clean taps fire onTap.
    draw — 1-finger drag invokes onDrawStart/Move/End.
  Both modes: 2-finger pinches to zoom around the pinch midpoint
  (with simultaneous centroid pan), wheel zooms. Optional coordRef lets
  the math-coord space differ from the event target (e.g. a centered
  square canvas inside a letterboxed wrapper, like FractalPane).

FractalsGPU
  Replaces the click-to-trace dead code (handleSelect/screenToFractal)
  and removes the up/down/left/right + zoom buttons that just hinted at
  gestures that didn't exist. Tap = trace, drag = pan, wheel = zoom,
  pinch = zoom — matching the on-screen hint, which used to be a lie
  on mobile.

Correspondence FractalPane
  Drops mouse-only onMouseDown/Move/Up handlers — touch users couldn't
  draw paths at all. Now: drawing mode uses onDrawStart/Move/End,
  non-drawing mode uses onTap for picking the Julia constant (parent
  still gates with `selecting` so behavior is preserved). 2-finger
  pinch zooms either pane, and the existing parent zoom/pan buttons
  continue to work.

StableMarriage
  Heatmap tooltips now toggle on tap (pinned) while preserving
  mouse-hover behavior on desktop. Mobile breakpoint (≤ 600px):
  single-column person lists, two-column controls and summary, 22 px
  range thumbs, shorter scroll regions, smaller person circles.

AgenticSorting
  CRITICAL: `.as-main { order: -1 }` at ≤ 900px puts the arena
  visualization above the controls sidebar on mobile. Previously the
  controls dominated the first screen and the actual sorting arena was
  scrolled offscreen. Also: 22 px slider thumbs and tighter padding at
  ≤ 600px.

Verified by Playwright at 390×844: AgenticSorting arena now visible 74 px from top; StableMarriage has zero horizontal overflow; both desktop layouts (1280×800) unchanged.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL