### PR TITLE
Introduce AppShell with tabbed nav drawer; migrate viewer controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,58 +5,28 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, maximum-scale=5" />
     <title>animath</title>
     <style>
-      /* Global styles for better responsive behavior */
-      * {
-        box-sizing: border-box;
-      }
-      
-      body {
+      * { box-sizing: border-box; }
+
+      html, body {
         margin: 0;
         padding: 0;
-        overflow: hidden;
-        touch-action: pan-x pan-y;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        height: 100%;
       }
-      
-      /* Button and UI improvements for mobile */
+      body {
+        overflow: hidden;
+        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
+        background: #0c0c10;
+        color: #f0f0f3;
+      }
+      #root { height: 100%; }
+
       button {
         touch-action: manipulation;
         user-select: none;
         -webkit-tap-highlight-color: transparent;
       }
-      
-      button:hover {
-        background-color: #e0e0e0;
-      }
-      
-      input, select {
-        touch-action: manipulation;
-      }
-      
-      /* Active button styling */
-      .projection-toolbar, .quarter-bar button.active {
-        background: #ffd400;
-      }
-      
-      .active {
-        background: #ffd400 !important;
-        color: #000;
-      }
-      
-      /* Mobile-specific styles */
-      @media (max-width: 768px) {
-        button {
-          min-height: 44px;
-          min-width: 44px;
-          font-size: 14px;
-        }
-        
-        input, select {
-          min-height: 44px;
-          font-size: 16px; /* Prevents zoom on iOS */
-        }
-      }
-      
+      input, select { touch-action: manipulation; }
+
       /* High DPI display support */
       @media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
         canvas {
@@ -64,42 +34,10 @@
           image-rendering: -webkit-optimize-contrast;
         }
       }
-      
-      #page-info {
-        position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
-        z-index: 50;
-        text-align: center;
-        margin: 0;
-        padding: 6px 10px;
-        background: rgba(0, 0, 0, 0.85);
-        color: white;
-        font-size: 13px;
-        backdrop-filter: blur(4px);
-      }
-
-      #page-info a {
-        color: #ffd400;
-        margin: 0 4px;
-      }
-
-      @media (max-width: 480px) {
-        #page-info {
-          font-size: 11px;
-          padding: 5px 8px;
-        }
-
-        #page-info a {
-          margin: 0 2px;
-        }
-      }
     </style>
   </head>
   <body>
     <div id="root"></div>
-    <p id="page-info"><a href="#/">particles</a> · <a href="#/fractals">fractals</a> · <a href="#/correspondence">correspondence</a> · <a href="#/mobius">mobius</a> · <a href="#/stable-marriage">stable marriage</a> · <a href="#/agentic-sorting">agentic sorting</a></p>
     <script type="module" src="/src/index.tsx"></script>
   </body>
 </html>

--- a/src/animations/AgenticSorting/AgenticSorting.tsx
+++ b/src/animations/AgenticSorting/AgenticSorting.tsx
@@ -4,6 +4,7 @@ import {
   Target, Activity
 } from 'lucide-react';
 import './agenticSorting.css';
+import { useAppHeader } from '../../components/AppShell';
 
 type AgentType = 'standard' | 'blindDate' | 'nomadic' | 'patrolling' | 'perfectionist';
 
@@ -64,6 +65,7 @@ type Stats = {
 type Weights = Record<AgentType, number>;
 
 export default function AgenticSorting() {
+  useAppHeader('Agentic Sorting');
   const [itemCount, setItemCount] = useState(60);
   const [simulationSpeed, setSimulationSpeed] = useState(20);
   const [isRunning, setIsRunning] = useState(false);

--- a/src/animations/AgenticSorting/agenticSorting.css
+++ b/src/animations/AgenticSorting/agenticSorting.css
@@ -1,6 +1,7 @@
 /* ── App shell ── */
 .as-app {
-  min-height: 100vh;
+  height: 100%;
+  width: 100%;
   background: #020617;
   color: #e2e8f0;
   padding: 16px;
@@ -9,6 +10,7 @@
   flex-direction: column;
   align-items: center;
   overflow-y: auto;
+  overflow-x: hidden;
 }
 
 /* ── Header ── */

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -1,9 +1,13 @@
 import React, { useState, useRef, useEffect } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
-import { useResponsive, getResponsiveLayoutStyle, getResponsiveControlsStyle, getResponsiveButtonStyle, getResponsiveInputStyle } from '../../styles/responsive';
+import { useResponsive } from '../../styles/responsive';
+import { ShellSettings, ShellActions, useAppHeader } from '../../components/AppShell';
+import { Section, Slider, Select } from '../../components/ControlPanel';
+import Readme from '../../components/Readme';
+import readmeText from './README.md?raw';
 
 export default function Correspondence() {
-  const { isMobile, isTablet, screenSize } = useResponsive();
+  const { isMobile } = useResponsive();
   const baseView: ViewBounds = { xMin: -2.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 };
   const [mandelView, setMandelView] = useState<ViewBounds>(baseView);
   const [juliaView, setJuliaView] = useState<ViewBounds>({ xMin: -2, xMax: 2, yMin: -2, yMax: 2 });
@@ -25,35 +29,9 @@ export default function Correspondence() {
   const [playing, setPlaying] = useState(false);
   const playingRef = useRef(false);
 
-  useEffect(() => {
-    speedRef.current = speed;
-  }, [speed]);
-
-  useEffect(() => {
-    playingRef.current = playing;
-  }, [playing]);
-
-  useEffect(() => {
-    pausedRef.current = paused;
-  }, [paused]);
-
-  const zoom = (factor: number, setView: React.Dispatch<React.SetStateAction<ViewBounds>>) => {
-    setView(v => {
-      const cx = (v.xMin + v.xMax) / 2;
-      const cy = (v.yMin + v.yMax) / 2;
-      const xr = (v.xMax - v.xMin) * factor;
-      const yr = (v.yMax - v.yMin) * factor;
-      return { xMin: cx - xr / 2, xMax: cx + xr / 2, yMin: cy - yr / 2, yMax: cy + yr / 2 };
-    });
-  };
-
-  const pan = (dx: number, dy: number, setView: React.Dispatch<React.SetStateAction<ViewBounds>>) => {
-    setView(v => {
-      const sx = (v.xMax - v.xMin) * 0.1 * dx;
-      const sy = (v.yMax - v.yMin) * 0.1 * dy;
-      return { xMin: v.xMin + sx, xMax: v.xMax + sx, yMin: v.yMin + sy, yMax: v.yMax + sy };
-    });
-  };
+  useEffect(() => { speedRef.current = speed; }, [speed]);
+  useEffect(() => { playingRef.current = playing; }, [playing]);
+  useEffect(() => { pausedRef.current = paused; }, [paused]);
 
   const handlePick = (nc: Complex) => {
     if (!selecting) return;
@@ -102,351 +80,165 @@ export default function Correspondence() {
     cancelAnimationFrame(animRef.current!);
   };
 
+  useAppHeader('Mandelbrot ↔ Julia', `c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i`);
 
   return (
-    <div style={{...getResponsiveLayoutStyle('split', isMobile)}}>
-      
-      {/* Global Controls - Mobile Friendly */}
-      <div 
-        style={{ 
-          ...getResponsiveControlsStyle(isMobile),
-          position: 'absolute', 
-          top: '10px', 
-          right: '10px', 
-          zIndex: 20,
-          fontSize: isMobile ? '12px' : '14px'
-        }}
-      >
-        <label>
-          Iterations:
-          <input 
-            type="number" 
-            value={iter} 
-            min={1} 
-            max={1000} 
-            onChange={e => setIter(parseInt(e.target.value, 10))} 
-            style={{ ...getResponsiveInputStyle(isMobile), width: isMobile ? '50px' : '60px' }} 
+    <>
+      <div style={{
+        position: 'absolute', inset: 0,
+        display: 'flex',
+        flexDirection: isMobile ? 'column' : 'row',
+        background: '#0c0c10',
+      }}>
+        <div style={{ flex: 1, position: 'relative', minHeight: 0, borderRight: isMobile ? 'none' : '1px solid #1e293b', borderBottom: isMobile ? '1px solid #1e293b' : 'none' }}>
+          <FractalPane
+            type="mandelbrot"
+            view={mandelView}
+            onViewChange={setMandelView}
+            juliaC={c}
+            iter={iter}
+            palette={paletteM}
+            offset={offsetM}
+            markC={c}
+            onPickC={handlePick}
+            drawing={drawingPath}
+            path={path}
+            onPathChange={handlePathChange}
           />
-        </label>
+          <div style={{ position: 'absolute', top: 6, left: '50%', transform: 'translateX(-50%)', color: '#fff', textShadow: '1px 1px 2px black', fontWeight: 700, fontSize: 14 }}>
+            Mandelbrot
+          </div>
+        </div>
+        <div style={{ flex: 1, position: 'relative', minHeight: 0 }}>
+          <FractalPane
+            type="julia"
+            view={juliaView}
+            onViewChange={setJuliaView}
+            juliaC={c}
+            iter={iter}
+            palette={paletteJ}
+            offset={offsetJ}
+          />
+          <div style={{ position: 'absolute', top: 6, left: '50%', transform: 'translateX(-50%)', color: '#fff', textShadow: '1px 1px 2px black', fontWeight: 700, fontSize: 14 }}>
+            Julia
+          </div>
+        </div>
       </div>
 
-      {/* Mandelbrot Pane */}
-      <div
-        style={{
-          flex: 1,
-          position: 'relative',
-          border: '1px solid white',
-          boxSizing: 'border-box',
-          minHeight: isMobile ? '40vh' : '50vh',
-        }}
-      >
-        <FractalPane
-          type="mandelbrot"
-          view={mandelView}
-          onViewChange={setMandelView}
-          juliaC={c}
-          iter={iter}
-          palette={paletteM}
-          offset={offsetM}
-          markC={c}
-          onPickC={handlePick}
-          drawing={drawingPath}
-          path={path}
-          onPathChange={handlePathChange}
-        />
-        
-        <div
-          style={{ 
-            position: 'absolute', 
-            top: '4px', 
-            left: '50%', 
-            transform: 'translateX(-50%)', 
-            color: 'white',
-            fontSize: isMobile ? '14px' : '16px',
-            fontWeight: 'bold',
-            textShadow: '1px 1px 2px black'
-          }}
-        >
-          Mandelbrot
-        </div>
-        
-        {/* Mandelbrot Controls */}
-        <div 
-          style={{
-            ...getResponsiveControlsStyle(isMobile),
-            position: 'absolute',
-            top: '10px',
-            left: '10px',
-            fontSize: isMobile ? '12px' : '14px'
-          }}
-        >
-          <label>
-            Palette:
-            <select 
-              value={paletteM} 
-              onChange={e => setPaletteM(parseInt(e.target.value, 10))}
-              style={{ ...getResponsiveInputStyle(isMobile), marginLeft: '4px' }}
-            >
-              <option value={0}>Rainbow</option>
-              <option value={1}>Fire</option>
-              <option value={2}>Ocean</option>
-              <option value={3}>Gray</option>
-            </select>
-          </label>
-          <input 
-            type="range" 
-            min={0} 
-            max={255} 
-            value={offsetM} 
-            onChange={e => setOffsetM(parseInt(e.target.value, 10))}
-            style={{ width: '100%', marginTop: '4px' }}
-          />
-        </div>
-        
-        {/* Navigation and Action Controls */}
-        <div
-          style={{
-            ...getResponsiveControlsStyle(isMobile),
-            position: 'absolute',
-            top: '10px',
-            right: '10px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: isMobile ? 4 : 6,
-            fontSize: isMobile ? '11px' : '12px'
-          }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: isMobile ? 2 : 4 }}>
-            <button 
-              onClick={() => pan(0, -1, setMandelView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Up
-            </button>
-            <div style={{ display: 'flex', gap: isMobile ? 2 : 4 }}>
-              <button 
-                onClick={() => pan(-1, 0, setMandelView)}
-                style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-              >
-                Left
-              </button>
-              <button 
-                onClick={() => pan(1, 0, setMandelView)}
-                style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-              >
-                Right
-              </button>
-            </div>
-            <button 
-              onClick={() => pan(0, 1, setMandelView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Down
-            </button>
+      <ShellSettings>
+        <Section title="Iterations" icon="↻" defaultOpen>
+          <Slider label="Max iterations" value={iter}
+            min={10} max={1000} step={10}
+            onChange={(v) => setIter(Math.max(1, Math.round(v)))}
+            format={v => String(v)} />
+        </Section>
+
+        <Section title="Mandelbrot palette" icon="◐" defaultOpen>
+          <Select label="Palette"
+            options={[
+              { value: 0, label: 'Rainbow' },
+              { value: 1, label: 'Fire' },
+              { value: 2, label: 'Ocean' },
+              { value: 3, label: 'Gray' },
+            ]}
+            value={paletteM} onChange={setPaletteM} />
+          <Slider label="Offset" value={offsetM}
+            min={0} max={255} step={1}
+            onChange={(v) => setOffsetM(Math.round(v))} format={v => String(v)} />
+        </Section>
+
+        <Section title="Julia palette" icon="◑">
+          <Select label="Palette"
+            options={[
+              { value: 0, label: 'Rainbow' },
+              { value: 1, label: 'Fire' },
+              { value: 2, label: 'Ocean' },
+              { value: 3, label: 'Gray' },
+            ]}
+            value={paletteJ} onChange={setPaletteJ} />
+          <Slider label="Offset" value={offsetJ}
+            min={0} max={255} step={1}
+            onChange={(v) => setOffsetJ(Math.round(v))} format={v => String(v)} />
+        </Section>
+
+        <Section title="Julia point" icon="·">
+          <div style={{ display: 'flex', gap: 8 }}>
+            <label className="cp-row" style={{ flex: 1 }}>
+              <div className="cp-row-label"><span>c real</span></div>
+              <input type="number" step="any" value={c.real}
+                onChange={e => setC({ ...c, real: parseFloat(e.target.value) || 0 })} />
+            </label>
+            <label className="cp-row" style={{ flex: 1 }}>
+              <div className="cp-row-label"><span>c imag</span></div>
+              <input type="number" step="any" value={c.imag}
+                onChange={e => setC({ ...c, imag: parseFloat(e.target.value) || 0 })} />
+            </label>
           </div>
-          
-          <div style={{ display: 'flex', gap: isMobile ? 2 : 4 }}>
-            <button 
-              onClick={() => zoom(0.9, setMandelView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Zoom In
-            </button>
-            <button 
-              onClick={() => zoom(1.1, setMandelView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Zoom Out
-            </button>
+        </Section>
+
+        <Section title="Path playback" icon="▷">
+          <Slider label="Speed" value={speed}
+            min={0.005} max={0.5} step={0.005}
+            onChange={setSpeed} format={v => v.toFixed(3)} />
+        </Section>
+
+        <Section title="About" icon="ⓘ">
+          <Readme markdown={readmeText} />
+          <div style={{ fontSize: 11, color: 'var(--cp-fg-dim)', marginTop: 8 }}>
+            Drag panes to pan · pinch / wheel to zoom · tap "Pick Julia" then tap the Mandelbrot to choose c.
           </div>
-          
-          <button 
+        </Section>
+      </ShellSettings>
+
+      <ShellActions>
+        <div className="cp-section-body">
+          <ActionButton
+            label={selecting ? 'Tap Mandelbrot to pick…' : 'Pick Julia c by tap'}
+            active={selecting}
             onClick={() => setSelecting(true)}
-            style={{ ...getResponsiveButtonStyle(isMobile), backgroundColor: selecting ? '#ffd400' : undefined }}
-          >
-            {isMobile ? 'Pick Julia' : 'Select Julia point'}
-          </button>
-          
-          <button 
-            onClick={() => setDrawingPath(p => !p)}
-            style={{ ...getResponsiveButtonStyle(isMobile), backgroundColor: drawingPath ? '#ffd400' : undefined }}
-          >
-            {drawingPath ? 'Finish Path' : (isMobile ? 'Draw Path' : 'Draw Path')}
-          </button>
-          
-          <button 
-            onClick={() => setPath([])}
-            style={getResponsiveButtonStyle(isMobile)}
-          >
-            Clear Path
-          </button>
-          
-          <button 
-            onClick={playing ? stopPath : playPath} 
-            disabled={path.length < 2}
-            style={{ 
-              ...getResponsiveButtonStyle(isMobile),
-              backgroundColor: playing ? '#ff4444' : '#44ff44',
-              opacity: path.length < 2 ? 0.5 : 1
-            }}
-          >
-            {playing ? 'Stop' : 'Play'}
-          </button>
-          
-          {playing && (
-            <button 
-              onClick={() => setPaused(p => !p)}
-              style={{ ...getResponsiveButtonStyle(isMobile), backgroundColor: paused ? '#ffaa44' : '#44aaff' }}
-            >
-              {paused ? 'Resume' : 'Pause'}
-            </button>
-          )}
-          
-          <label style={{ fontSize: isMobile ? '10px' : '12px' }}>
-            Speed:
-            <input
-              type="range"
-              min={0.005}
-              max={0.5}
-              step={0.005}
-              value={speed}
-              onChange={e => setSpeed(parseFloat(e.target.value))}
-              style={{ width: '100%' }}
-            />
-          </label>
-        </div>
-      </div>
-
-      {/* Julia Set Pane */}
-      <div
-        style={{
-          flex: 1,
-          position: 'relative',
-          border: '1px solid white',
-          boxSizing: 'border-box',
-          minHeight: isMobile ? '40vh' : '50vh',
-        }}
-      >
-        <FractalPane
-          type="julia"
-          view={juliaView}
-          onViewChange={setJuliaView}
-          juliaC={c}
-          iter={iter}
-          palette={paletteJ}
-          offset={offsetJ}
-        />
-        
-        <div
-          style={{ 
-            position: 'absolute', 
-            top: '4px', 
-            left: '50%', 
-            transform: 'translateX(-50%)', 
-            color: 'white',
-            fontSize: isMobile ? '12px' : '14px',
-            fontWeight: 'bold',
-            textShadow: '1px 1px 2px black',
-            textAlign: 'center',
-            maxWidth: '90%'
-          }}
-        >
-          {isMobile 
-            ? `Julia (${c.real.toFixed(2)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(2)}i)`
-            : `Julia (c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i)`
-          }
-        </div>
-        
-        {/* Julia Controls */}
-        <div 
-          style={{
-            ...getResponsiveControlsStyle(isMobile),
-            position: 'absolute',
-            top: '10px',
-            left: '10px',
-            fontSize: isMobile ? '12px' : '14px'
-          }}
-        >
-          <label>
-            Palette:
-            <select 
-              value={paletteJ} 
-              onChange={e => setPaletteJ(parseInt(e.target.value, 10))}
-              style={{ ...getResponsiveInputStyle(isMobile), marginLeft: '4px' }}
-            >
-              <option value={0}>Rainbow</option>
-              <option value={1}>Fire</option>
-              <option value={2}>Ocean</option>
-              <option value={3}>Gray</option>
-            </select>
-          </label>
-          <input 
-            type="range" 
-            min={0} 
-            max={255} 
-            value={offsetJ} 
-            onChange={e => setOffsetJ(parseInt(e.target.value, 10))}
-            style={{ width: '100%', marginTop: '4px' }}
           />
+          <ActionButton
+            label={drawingPath ? 'Finish drawing path' : 'Draw c-path'}
+            active={drawingPath}
+            onClick={() => setDrawingPath(p => !p)}
+          />
+          <ActionButton
+            label="Clear path"
+            disabled={path.length === 0}
+            onClick={() => setPath([])}
+          />
+          <ActionButton
+            label={playing ? 'Stop playback' : 'Play path'}
+            primary
+            disabled={path.length < 2}
+            onClick={playing ? stopPath : playPath}
+          />
+          {playing && (
+            <ActionButton
+              label={paused ? 'Resume' : 'Pause'}
+              onClick={() => setPaused(p => !p)}
+            />
+          )}
         </div>
-        
-        {/* Julia Navigation */}
-        <div
-          style={{
-            ...getResponsiveControlsStyle(isMobile),
-            position: 'absolute',
-            top: '10px',
-            right: '10px',
-            display: 'flex',
-            flexDirection: 'column',
-            gap: isMobile ? 4 : 6
-          }}
-        >
-          <div style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: isMobile ? 2 : 4 }}>
-            <button 
-              onClick={() => pan(0, -1, setJuliaView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Up
-            </button>
-            <div style={{ display: 'flex', gap: isMobile ? 2 : 4 }}>
-              <button 
-                onClick={() => pan(-1, 0, setJuliaView)}
-                style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-              >
-                Left
-              </button>
-              <button 
-                onClick={() => pan(1, 0, setJuliaView)}
-                style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-              >
-                Right
-              </button>
-            </div>
-            <button 
-              onClick={() => pan(0, 1, setJuliaView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Down
-            </button>
-          </div>
-          
-          <div style={{ display: 'flex', gap: isMobile ? 2 : 4 }}>
-            <button 
-              onClick={() => zoom(0.9, setJuliaView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Zoom In
-            </button>
-            <button 
-              onClick={() => zoom(1.1, setJuliaView)}
-              style={{ ...getResponsiveButtonStyle(isMobile), fontSize: isMobile ? '10px' : '12px' }}
-            >
-              Zoom Out
-            </button>
-          </div>
-        </div>
-      </div>
-    </div>
+      </ShellActions>
+    </>
   );
+}
+
+function ActionButton({ label, onClick, active, primary, disabled }: {
+  label: string; onClick: () => void;
+  active?: boolean; primary?: boolean; disabled?: boolean;
+}) {
+  const style: React.CSSProperties = {
+    padding: '12px 16px', borderRadius: 6,
+    border: active ? '1px solid var(--cp-accent)' : '1px solid var(--cp-border)',
+    background: primary && !disabled ? '#10b981'
+      : active ? 'rgba(255, 212, 0, 0.18)'
+      : 'rgba(255,255,255,0.06)',
+    color: primary && !disabled ? '#fff' : 'var(--cp-fg)',
+    cursor: disabled ? 'not-allowed' : 'pointer',
+    fontSize: 14, opacity: disabled ? 0.5 : 1, fontWeight: primary ? 700 : 500,
+    textAlign: 'left',
+  };
+  return <button style={style} onClick={onClick} disabled={disabled}>{label}</button>;
 }

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useRef, useState, useCallback } from 'react';
 import * as THREE from 'three';
 import Readme from '../../components/Readme';
-import ToggleMenu from '../../components/ToggleMenu';
 import readmeText from './README.md?raw';
-import { useResponsive, getResponsiveControlsStyle, getResponsiveButtonStyle, getResponsiveInputStyle } from '../../styles/responsive';
+import { useResponsive } from '../../styles/responsive';
 import { useViewportGestures } from '../../lib/useViewportGestures';
+import { ShellSettings, ShellActions, useAppHeader } from '../../components/AppShell';
+import { Section, Slider, Pills, Select } from '../../components/ControlPanel';
 
 /** GPU accelerated Mandelbrot/Julia viewer using a fragment shader. */
 export default function FractalsGPU() {
@@ -384,232 +385,133 @@ export default function FractalsGPU() {
     drawPath();
   }, [view]);
 
+  useAppHeader(TYPE_NAMES[type], FORMULAS[type]);
+
   return (
-    <div
-      ref={mountRef}
-      style={{ position: 'relative', width: '100%', height: '100vh', overflow: 'hidden', touchAction: 'none' }}
-      {...gestures}
-    >
-      <canvas
-        ref={overlayRef}
-        style={{ 
-          position: 'absolute', 
-          left: 0, 
-          top: 0, 
-          width: '100%', 
-          height: '100%', 
-          zIndex: 1, 
-          pointerEvents: 'none',
-          touchAction: 'none' 
-        }}
-      />
-      
-      {/* Top Left - Function Selector */}
-      <div 
-        style={{
-          ...getResponsiveControlsStyle(isMobile),
-          top: '10px',
-          left: '10px',
-        }}
-      >
-        <label>
-          Function:
-          <select 
-            value={type} 
-            onChange={e => setType(e.target.value as any)}
-            style={{ ...getResponsiveInputStyle(isMobile), marginLeft: '4px' }}
-          >
-            <option value="mandelbrot">Mandelbrot</option>
-            <option value="julia">Julia</option>
-            <option value="burning">Burning Ship</option>
-            <option value="tricorn">Tricorn</option>
-          </select>
-        </label>
-      </div>
-      
-      {/* Top Right - Info and Navigation */}
+    <>
       <div
-        style={{
-          ...getResponsiveControlsStyle(isMobile),
-          position: 'absolute',
-          top: '10px',
-          right: '10px',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'flex-end',
-          gap: isMobile ? 4 : 6,
-          maxWidth: isMobile ? '180px' : '220px'
-        }}
+        ref={mountRef}
+        style={{ position: 'absolute', inset: 0, overflow: 'hidden', touchAction: 'none' }}
+        {...gestures}
       >
-        <div style={{ fontSize: isMobile ? '1em' : '1.2em', textAlign: 'center' }}>
-          <div>{TYPE_NAMES[type]}</div>
-          <div style={{ fontSize: isMobile ? '0.8em' : '0.9em' }}>{FORMULAS[type]}</div>
-        </div>
-        
-        <div style={{
-          fontSize: isMobile ? '10px' : '11px',
-          color: '#ccc',
-          textAlign: 'center',
-          marginTop: '4px'
-        }}>
-          {isMobile ? 'Pinch to zoom · drag to pan · tap to trace' : 'Wheel to zoom · drag to pan · click to trace'}
-        </div>
-      </div>
-      
-      {/* Bottom Left - Main Controls */}
-      <div style={{ position: 'absolute', bottom: '10px', left: '10px' }}>
-        <div 
-          style={{ 
-            ...getResponsiveControlsStyle(isMobile),
-            display: 'flex', 
-            flexDirection: 'column', 
-            gap: isMobile ? 6 : 8,
-            maxWidth: isMobile ? '200px' : '250px',
-            maxHeight: isMobile ? '50vh' : '60vh',
-            overflowY: 'auto'
+        <canvas
+          ref={overlayRef}
+          style={{
+            position: 'absolute', left: 0, top: 0,
+            width: '100%', height: '100%',
+            zIndex: 1, pointerEvents: 'none', touchAction: 'none',
           }}
-        >
-          <label>
-            Palette:
-            <select 
-              value={palette} 
-              onChange={e => setPalette(parseInt(e.target.value, 10))}
-              style={{ ...getResponsiveInputStyle(isMobile), width: '100%' }}
-            >
-              <option value={0}>Rainbow</option>
-              <option value={1}>Fire</option>
-              <option value={2}>Ocean</option>
-              <option value={3}>Gray</option>
-            </select>
-          </label>
-          
-          <label>
-            Power k:
-            <input
-              type="number"
-              value={powerInput}
-              min={1}
-              max={100}
-              onChange={e => {
-                const val = e.target.value;
-                setPowerInput(val);
-                const parsed = parseInt(val, 10);
-                if (!isNaN(parsed)) {
-                  setPower(Math.min(100, Math.max(1, parsed)));
-                }
-              }}
-              style={{ ...getResponsiveInputStyle(isMobile), width: isMobile ? '50px' : '60px' }}
-            />
-          </label>
-          
-          <label>
-            Coloring:
-            <select 
-              value={colorMode} 
-              onChange={e => setColorMode(e.target.value as any)}
-              style={{ ...getResponsiveInputStyle(isMobile), width: '100%' }}
-            >
-              <option value="escape">Escape velocity</option>
-              <option value="limit">Limit magnitude</option>
-              <option value="layered">Layered</option>
-            </select>
-          </label>
-          
-          {colorMode !== 'escape' && (
-            <label>
-              Inside palette:
-              <select 
-                value={insidePalette} 
-                onChange={e => setInsidePalette(parseInt(e.target.value, 10))}
-                style={{ ...getResponsiveInputStyle(isMobile), width: '100%' }}
-              >
-                <option value={0}>Rainbow</option>
-                <option value={1}>Fire</option>
-                <option value={2}>Ocean</option>
-                <option value={3}>Gray</option>
-              </select>
-            </label>
-          )}
-          
-          <label>
-            Iterations:
-            <input
-              type="number"
-              value={iterInput}
-              min={1}
-              max={1000}
-              onChange={e => {
-                const val = e.target.value;
-                setIterInput(val);
-                const parsed = parseInt(val, 10);
-                if (!isNaN(parsed)) {
-                  setIter(Math.min(1000, Math.max(1, parsed)));
-                }
-              }}
-              style={{ ...getResponsiveInputStyle(isMobile), width: isMobile ? '50px' : '60px' }}
-            />
-          </label>
-          
-          <label>
-            Start Iter:
-            <input
-              type="number"
-              value={startIter}
-              min={0}
-              max={1000}
-              onChange={e => setStartIter(parseInt(e.target.value, 10))}
-              style={{ ...getResponsiveInputStyle(isMobile), width: isMobile ? '50px' : '60px' }}
-            />
-          </label>
-          
-          <div style={{ display: 'flex', gap: isMobile ? 2 : 4 }}>
-            <button 
-              onClick={() => setAnimating(a => !a)}
-              style={{ ...getResponsiveButtonStyle(isMobile), backgroundColor: animating ? '#ff4444' : '#44ff44' }}
-            >
-              {animating ? 'Stop' : 'Cycle'}
-            </button>
-            <button 
-              onClick={reset}
-              style={getResponsiveButtonStyle(isMobile)}
-            >
-              Reset
-            </button>
-          </div>
-          
+        />
+      </div>
+
+      <ShellSettings>
+        <Section title="Function" icon="ƒ" defaultOpen>
+          <Select
+            label="Fractal type"
+            options={[
+              { value: 'mandelbrot', label: 'Mandelbrot' },
+              { value: 'julia', label: 'Julia' },
+              { value: 'burning', label: 'Burning Ship' },
+              { value: 'tricorn', label: 'Tricorn' },
+            ]}
+            value={type}
+            onChange={(v) => setType(v)}
+          />
+          <Slider label="Power k" value={power}
+            min={1} max={10} step={1}
+            onChange={(v) => setPower(Math.max(1, Math.round(v)))}
+            format={v => String(v)} />
           {type === 'julia' && (
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-              <label>
-                C real:
-                <input
-                  type="number"
-                  step="any"
-                  value={juliaC.real}
-                  onChange={e => setJuliaC({ ...juliaC, real: parseFloat(e.target.value) })}
-                  style={{ ...getResponsiveInputStyle(isMobile), width: isMobile ? '60px' : '70px' }}
-                />
+            <div style={{ display: 'flex', gap: 8 }}>
+              <label className="cp-row" style={{ flex: 1 }}>
+                <div className="cp-row-label"><span>c real</span></div>
+                <input type="number" step="any" value={juliaC.real}
+                  onChange={e => setJuliaC({ ...juliaC, real: parseFloat(e.target.value) || 0 })} />
               </label>
-              <label>
-                C imaginary:
-                <input
-                  type="number"
-                  step="any"
-                  value={juliaC.imag}
-                  onChange={e => setJuliaC({ ...juliaC, imag: parseFloat(e.target.value) })}
-                  style={{ ...getResponsiveInputStyle(isMobile), width: isMobile ? '60px' : '70px' }}
-                />
+              <label className="cp-row" style={{ flex: 1 }}>
+                <div className="cp-row-label"><span>c imag</span></div>
+                <input type="number" step="any" value={juliaC.imag}
+                  onChange={e => setJuliaC({ ...juliaC, imag: parseFloat(e.target.value) || 0 })} />
               </label>
             </div>
           )}
-        </div>
-      </div>
-      
-      {/* About Menu */}
-      <div style={{ position: 'absolute', bottom: '10px', right: '10px' }}>
-        <ToggleMenu title="About" defaultOpen={!isMobile}>
+        </Section>
+
+        <Section title="Iteration" icon="↻" defaultOpen>
+          <Slider label="Max iterations" value={iter}
+            min={10} max={1000} step={10}
+            onChange={(v) => setIter(Math.max(1, Math.round(v)))}
+            format={v => String(v)} />
+          <Slider label="Start iteration" value={startIter}
+            min={0} max={500} step={1}
+            onChange={(v) => setStartIter(Math.max(0, Math.round(v)))}
+            format={v => String(v)} />
+        </Section>
+
+        <Section title="Colour" icon="◐">
+          <Select label="Palette"
+            options={[
+              { value: 0, label: 'Rainbow' },
+              { value: 1, label: 'Fire' },
+              { value: 2, label: 'Ocean' },
+              { value: 3, label: 'Gray' },
+            ]}
+            value={palette} onChange={setPalette} />
+          <Pills label="Colouring"
+            options={[
+              { value: 'escape', label: 'Escape' },
+              { value: 'limit', label: 'Limit' },
+              { value: 'layered', label: 'Layered' },
+            ]}
+            value={colorMode}
+            onChange={setColorMode} />
+          {colorMode !== 'escape' && (
+            <Select label="Inside palette"
+              options={[
+                { value: 0, label: 'Rainbow' },
+                { value: 1, label: 'Fire' },
+                { value: 2, label: 'Ocean' },
+                { value: 3, label: 'Gray' },
+              ]}
+              value={insidePalette} onChange={setInsidePalette} />
+          )}
+        </Section>
+
+        <Section title="About" icon="ⓘ">
           <Readme markdown={readmeText} />
-        </ToggleMenu>
-      </div>
-    </div>
+          <div style={{ fontSize: 11, color: 'var(--cp-fg-dim)', marginTop: 8 }}>
+            {isMobile ? 'Pinch to zoom · drag to pan · tap to trace' : 'Wheel to zoom · drag to pan · click to trace'}
+          </div>
+        </Section>
+      </ShellSettings>
+
+      <ShellActions>
+        <div className="cp-section-body">
+          <button
+            className="cp-pills"
+            style={{
+              padding: '12px 16px', borderRadius: 6, border: 'none',
+              background: animating ? '#ef4444' : '#10b981',
+              color: '#fff', fontWeight: 700, cursor: 'pointer', fontSize: 14,
+            }}
+            onClick={() => setAnimating(a => !a)}
+          >
+            {animating ? 'Stop colour cycle' : 'Start colour cycle'}
+          </button>
+          <button
+            className="cp-pills"
+            style={{
+              padding: '12px 16px', borderRadius: 6,
+              border: '1px solid var(--cp-border)',
+              background: 'rgba(255,255,255,0.06)', color: 'var(--cp-fg)',
+              cursor: 'pointer', fontSize: 14,
+            }}
+            onClick={reset}
+          >
+            Reset view
+          </button>
+        </div>
+      </ShellActions>
+    </>
   );
 }

--- a/src/animations/MobiusWalk/MobiusWalk.tsx
+++ b/src/animations/MobiusWalk/MobiusWalk.tsx
@@ -4,15 +4,18 @@ import Canvas3D from '@/components/Canvas3D';
 import { makeCorridorGeometry, DEFAULT_PARAMS, paramToFrame } from './corridorGeometry';
 import { corridorMaterial } from './shaders/corridorMaterial';
 import { instantiateObjects } from './objects';
+import { ShellActions, useAppHeader } from '../../components/AppShell';
 
 export interface MobiusWalkProps {
-  speed?: number;      // metres / second along corridor
+  speed?: number;
 }
 
 export default function MobiusWalk({ speed = 2 }: MobiusWalkProps) {
-  const camPosT = useRef(0);          // param t along centreline
+  const camPosT = useRef(0);
   const clockRef = useRef(new THREE.Clock());
   const [twist, setTwist] = useState(true);
+
+  useAppHeader('Möbius Walk', twist ? 'twisted corridor' : 'untwisted corridor');
 
   const onMount = React.useCallback(({ scene, camera, renderer }: {
     scene: THREE.Scene;
@@ -59,14 +62,25 @@ export default function MobiusWalk({ speed = 2 }: MobiusWalkProps) {
   }, [speed, twist]);
 
   return (
-    <div>
-      <Canvas3D onMount={onMount} />
-      <button
-        style={{ position: 'absolute', top: 20, left: 20 }}
-        onClick={() => setTwist((t) => !t)}
-      >
-        {twist ? 'Disable Twist' : 'Enable Möbius Twist'}
-      </button>
-    </div>
+    <>
+      <div style={{ position: 'absolute', inset: 0 }}>
+        <Canvas3D onMount={onMount} />
+      </div>
+      <ShellActions>
+        <div className="cp-section-body">
+          <button
+            style={{
+              padding: '12px 16px', borderRadius: 6,
+              border: '1px solid var(--cp-border)',
+              background: twist ? 'rgba(255, 212, 0, 0.18)' : 'rgba(255,255,255,0.06)',
+              color: 'var(--cp-fg)', cursor: 'pointer', fontSize: 14,
+            }}
+            onClick={() => setTwist((t) => !t)}
+          >
+            {twist ? 'Disable twist' : 'Enable Möbius twist'}
+          </button>
+        </div>
+      </ShellActions>
+    </>
   );
 }

--- a/src/animations/StableMarriage/StableMarriage.tsx
+++ b/src/animations/StableMarriage/StableMarriage.tsx
@@ -21,6 +21,7 @@ import {
   Zap
 } from 'lucide-react';
 import './stableMarriage.css';
+import { useAppHeader } from '../../components/AppShell';
 
 const MAX_POPULATION = 100;
 const ROW_HEIGHT = 64;
@@ -515,6 +516,7 @@ const DistributionChart = ({
 };
 
 export default function StableMarriage() {
+  useAppHeader('Stable Marriage');
   const [appMode, setAppMode] = useState<'visualizer' | 'lab'>('visualizer');
 
   const [n, setN] = useState(20);

--- a/src/animations/StableMarriage/stableMarriage.css
+++ b/src/animations/StableMarriage/stableMarriage.css
@@ -7,7 +7,9 @@
   color: #0f172a;
   padding: 32px;
   background: #f8fafc;
-  min-height: 100vh;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
 }
 
 .sm-header {

--- a/src/components/AppShell.css
+++ b/src/components/AppShell.css
@@ -1,0 +1,228 @@
+/* AppShell — persistent chrome around every route.
+   Header bar + slide-in nav with tabs for Apps / Settings / Actions. */
+
+:root {
+  --as-bar-h: 48px;
+  --as-bar-bg: rgba(12, 12, 16, 0.92);
+  --as-bg: rgba(12, 12, 16, 0.96);
+  --as-fg: #f0f0f3;
+  --as-fg-dim: #9b9ba3;
+  --as-accent: #ffd400;
+  --as-border: rgba(255, 255, 255, 0.08);
+  --as-hover: rgba(255, 255, 255, 0.06);
+  --as-drawer-w: 340px;
+  --as-shadow: 0 6px 24px rgba(0, 0, 0, 0.45);
+  --as-radius: 8px;
+}
+
+.as-shell {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+}
+
+/* ---------- Top bar ---------- */
+.as-bar {
+  height: var(--as-bar-h);
+  flex-shrink: 0;
+  background: var(--as-bar-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--as-border);
+  display: flex;
+  align-items: center;
+  padding: 0 8px;
+  gap: 8px;
+  position: relative;
+  z-index: 50;
+}
+
+.as-bar-btn {
+  width: 40px;
+  height: 40px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--as-fg);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 20px;
+  flex-shrink: 0;
+}
+.as-bar-btn:hover { background: var(--as-hover); }
+.as-bar-btn:focus-visible { outline: 2px solid var(--as-accent); outline-offset: 2px; }
+
+.as-bar-title {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  cursor: pointer;
+  height: 100%;
+  padding: 0 4px;
+  border-radius: 6px;
+  background: transparent;
+  border: none;
+  color: var(--as-fg);
+  text-align: left;
+}
+.as-bar-title:hover { background: var(--as-hover); }
+.as-bar-title-name {
+  font-weight: 600;
+  font-size: 15px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.as-bar-title-formula {
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 12px;
+  color: var(--as-accent);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ---------- Content area ---------- */
+.as-content {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  overflow: hidden;
+}
+.as-content-scroll {
+  width: 100%;
+  height: 100%;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+/* ---------- Drawer / scrim ---------- */
+.as-scrim {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.4);
+  z-index: 99;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 200ms ease;
+}
+.as-scrim.as-open { opacity: 1; pointer-events: auto; }
+
+.as-drawer {
+  position: fixed;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  width: var(--as-drawer-w);
+  max-width: 92vw;
+  background: var(--as-bg);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-right: 1px solid var(--as-border);
+  box-shadow: var(--as-shadow);
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  transform: translateX(-100%);
+  transition: transform 220ms ease;
+}
+.as-drawer.as-open { transform: translateX(0); }
+
+.as-drawer-header {
+  display: flex;
+  align-items: center;
+  padding: 8px;
+  gap: 4px;
+  border-bottom: 1px solid var(--as-border);
+  height: var(--as-bar-h);
+  flex-shrink: 0;
+}
+.as-drawer-header h2 {
+  flex: 1;
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  padding-left: 8px;
+}
+
+.as-tabs {
+  display: flex;
+  border-bottom: 1px solid var(--as-border);
+  flex-shrink: 0;
+}
+.as-tab {
+  flex: 1;
+  padding: 12px 8px;
+  background: transparent;
+  border: none;
+  color: var(--as-fg-dim);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: color 150ms ease, border-color 150ms ease;
+}
+.as-tab:hover { color: var(--as-fg); }
+.as-tab.as-active {
+  color: var(--as-fg);
+  border-bottom-color: var(--as-accent);
+}
+.as-tab.as-empty-tab { opacity: 0.4; }
+
+.as-tab-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 4px 0;
+}
+
+/* ---------- App picker list ---------- */
+.as-app-list {
+  display: flex;
+  flex-direction: column;
+}
+.as-app-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 14px 18px;
+  background: transparent;
+  border: none;
+  color: var(--as-fg);
+  cursor: pointer;
+  font-size: 15px;
+  text-align: left;
+  border-bottom: 1px solid var(--as-border);
+}
+.as-app-item:hover { background: var(--as-hover); }
+.as-app-item-icon {
+  font-size: 18px;
+  width: 24px;
+  flex-shrink: 0;
+  text-align: center;
+}
+.as-app-item-name { flex: 1; }
+.as-app-item.as-active {
+  background: rgba(255, 212, 0, 0.1);
+  border-left: 3px solid var(--as-accent);
+  padding-left: 15px;
+}
+.as-app-item.as-active .as-app-item-name { font-weight: 700; }
+
+/* ---------- Empty state ---------- */
+.as-empty {
+  padding: 28px 18px;
+  color: var(--as-fg-dim);
+  font-size: 13px;
+  text-align: center;
+  line-height: 1.5;
+}
+
+/* ---------- Sections shared with old ControlPanel ---------- */
+.as-tab-body .cp-section { border-bottom: 1px solid var(--as-border); }
+.as-tab-body .cp-section:last-child { border-bottom: none; }

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,0 +1,217 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import './AppShell.css';
+
+export interface AppDescriptor {
+  /** Hash route (no leading `#`, e.g. `/` or `/fractals`). */
+  hash: string;
+  /** Human-readable name shown in the bar and picker. */
+  name: string;
+  /** Optional emoji or single character used as a list-icon. */
+  icon?: string;
+}
+
+export interface AppShellState {
+  /** Title shown in the bar (defaults to the registered AppDescriptor name). */
+  title?: string;
+  /** Subtle subtitle rendered in monospace next to the title (e.g. a formula). */
+  subtitle?: string;
+  /** DOM nodes — portal targets — for the Settings and Actions drawer tabs. */
+  settingsTargetRef: React.RefObject<HTMLDivElement | null>;
+  actionsTargetRef: React.RefObject<HTMLDivElement | null>;
+  /** Whether the registered app has populated each tab. */
+  hasSettings: boolean;
+  hasActions: boolean;
+  setHasSettings: (v: boolean) => void;
+  setHasActions: (v: boolean) => void;
+  setHeader: (h: { title?: string; subtitle?: string }) => void;
+}
+
+const AppShellContext = createContext<AppShellState | null>(null);
+
+export interface AppShellProps {
+  apps: AppDescriptor[];
+  currentHash: string;
+  onNavigate: (hash: string) => void;
+  children: React.ReactNode;
+}
+
+type Tab = 'apps' | 'settings' | 'actions';
+
+export function AppShell({ apps, currentHash, onNavigate, children }: AppShellProps) {
+  const [open, setOpen] = useState(false);
+  const [tab, setTab] = useState<Tab>('apps');
+  const [header, setHeader] = useState<{ title?: string; subtitle?: string }>({});
+  const [hasSettings, setHasSettings] = useState(false);
+  const [hasActions, setHasActions] = useState(false);
+  const settingsTargetRef = useRef<HTMLDivElement | null>(null);
+  const actionsTargetRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset header + tab flags when the active app changes.
+  useEffect(() => {
+    setHeader({});
+    setHasSettings(false);
+    setHasActions(false);
+    // After app switch, keep the drawer closed; re-snap tab to apps if user opens it.
+    setTab('apps');
+  }, [currentHash]);
+
+  // Escape closes drawer.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, []);
+
+  const current = apps.find(a => a.hash === currentHash) ?? apps[0];
+  const titleName = header.title ?? current?.name ?? '';
+  const subtitle = header.subtitle;
+
+  const ctx = useMemo<AppShellState>(() => ({
+    title: header.title,
+    subtitle: header.subtitle,
+    settingsTargetRef,
+    actionsTargetRef,
+    hasSettings,
+    hasActions,
+    setHasSettings,
+    setHasActions,
+    setHeader,
+  }), [header.title, header.subtitle, hasSettings, hasActions]);
+
+  const openWithTab = useCallback((t: Tab) => { setTab(t); setOpen(true); }, []);
+
+  return (
+    <AppShellContext.Provider value={ctx}>
+      <div className="as-shell">
+        <header className="as-bar">
+          <button className="as-bar-btn" aria-label="Open menu" onClick={() => openWithTab('apps')}>≡</button>
+          <button
+            className="as-bar-title"
+            onClick={() => openWithTab(hasSettings ? 'settings' : 'apps')}
+            aria-label="Show settings"
+          >
+            <span className="as-bar-title-name">{titleName}</span>
+            {subtitle && <span className="as-bar-title-formula">{subtitle}</span>}
+          </button>
+          {hasActions && (
+            <button className="as-bar-btn" aria-label="Show actions" onClick={() => openWithTab('actions')}>▶</button>
+          )}
+        </header>
+
+        <div className="as-content">
+          {children}
+        </div>
+
+        <div className={`as-scrim ${open ? 'as-open' : ''}`} onClick={() => setOpen(false)} />
+        <aside className={`as-drawer ${open ? 'as-open' : ''}`} aria-hidden={!open}>
+          <div className="as-drawer-header">
+            <button className="as-bar-btn" aria-label="Close menu" onClick={() => setOpen(false)}>×</button>
+            <h2>Menu</h2>
+          </div>
+          <div className="as-tabs">
+            <button
+              className={`as-tab ${tab === 'apps' ? 'as-active' : ''}`}
+              onClick={() => setTab('apps')}
+            >Apps</button>
+            <button
+              className={`as-tab ${tab === 'settings' ? 'as-active' : ''} ${!hasSettings ? 'as-empty-tab' : ''}`}
+              onClick={() => setTab('settings')}
+            >Settings</button>
+            <button
+              className={`as-tab ${tab === 'actions' ? 'as-active' : ''} ${!hasActions ? 'as-empty-tab' : ''}`}
+              onClick={() => setTab('actions')}
+            >Actions</button>
+          </div>
+
+          {/* Mount all three panels but only show the active one. The Settings/
+              Actions panes own DOM refs that child apps portal into; tearing
+              them down on tab switch would re-create them and lose portal
+              contents. So we toggle visibility, not mount state. */}
+          <div className="as-tab-body" style={{ display: tab === 'apps' ? 'block' : 'none' }}>
+            <AppList apps={apps} currentHash={currentHash} onPick={(h) => {
+              onNavigate(h);
+              setOpen(false);
+            }} />
+          </div>
+          <div className="as-tab-body" style={{ display: tab === 'settings' ? 'block' : 'none' }}>
+            <div ref={settingsTargetRef} />
+            {!hasSettings && <div className="as-empty">No settings for this view.</div>}
+          </div>
+          <div className="as-tab-body" style={{ display: tab === 'actions' ? 'block' : 'none' }}>
+            <div ref={actionsTargetRef} />
+            {!hasActions && <div className="as-empty">No actions for this view.</div>}
+          </div>
+        </aside>
+      </div>
+    </AppShellContext.Provider>
+  );
+}
+
+function AppList({ apps, currentHash, onPick }: {
+  apps: AppDescriptor[]; currentHash: string; onPick: (hash: string) => void;
+}) {
+  return (
+    <div className="as-app-list">
+      {apps.map(app => (
+        <button
+          key={app.hash}
+          className={`as-app-item ${app.hash === currentHash ? 'as-active' : ''}`}
+          onClick={() => onPick(app.hash)}
+        >
+          <span className="as-app-item-icon">{app.icon ?? '•'}</span>
+          <span className="as-app-item-name">{app.name}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------ *
+ * Hooks and portal slots for app authors.                       *
+ * ------------------------------------------------------------ */
+
+function useShell(): AppShellState {
+  const ctx = useContext(AppShellContext);
+  if (!ctx) throw new Error('AppShell components must be used inside <AppShell>.');
+  return ctx;
+}
+
+/** Set the bar title and subtitle for the active app. */
+export function useAppHeader(title: string | undefined, subtitle?: string) {
+  const shell = useContext(AppShellContext);
+  useEffect(() => {
+    if (!shell) return;
+    shell.setHeader({ title, subtitle });
+  }, [shell, title, subtitle]);
+}
+
+/** Render children into the drawer's Settings tab. */
+export function ShellSettings({ children }: { children: React.ReactNode }) {
+  const shell = useShell();
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    if (shell.settingsTargetRef.current) {
+      setReady(true);
+      shell.setHasSettings(true);
+    }
+    return () => shell.setHasSettings(false);
+  }, [shell]);
+  if (!ready || !shell.settingsTargetRef.current) return null;
+  return createPortal(<>{children}</>, shell.settingsTargetRef.current);
+}
+
+/** Render children into the drawer's Actions tab. */
+export function ShellActions({ children }: { children: React.ReactNode }) {
+  const shell = useShell();
+  const [ready, setReady] = useState(false);
+  useEffect(() => {
+    if (shell.actionsTargetRef.current) {
+      setReady(true);
+      shell.setHasActions(true);
+    }
+    return () => shell.setHasActions(false);
+  }, [shell]);
+  if (!ready || !shell.actionsTargetRef.current) return null;
+  return createPortal(<>{children}</>, shell.actionsTargetRef.current);
+}

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,92 +1,11 @@
-import React, { useEffect, useState } from 'react';
-import { useResponsive } from '../styles/responsive';
+import React, { useState } from 'react';
 import './ControlPanel.css';
 
-type SheetSize = 'peek' | 'half' | 'full';
-
-export interface ControlPanelProps {
-  children: React.ReactNode;
-  /** Compact content shown in mobile peek state and never elsewhere. */
-  peekContent?: React.ReactNode;
-}
-
-export function ControlPanel({ children, peekContent }: ControlPanelProps) {
-  const { isMobile, isTablet } = useResponsive();
-  const useSheet = isMobile || isTablet;
-  const [hidden, setHidden] = useState(false);
-  const [open, setOpen] = useState(true);
-  const [sheetSize, setSheetSize] = useState<SheetSize>('half');
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === 'h' || e.key === 'H') setHidden(v => !v);
-    };
-    window.addEventListener('keydown', handler);
-    return () => window.removeEventListener('keydown', handler);
-  }, []);
-
-  if (hidden) {
-    return (
-      <button
-        className="cp-show-btn cp-root"
-        title="Show controls (H)"
-        onClick={() => setHidden(false)}
-      >
-        ⊞
-      </button>
-    );
-  }
-
-  if (useSheet) {
-    const cycle: Record<SheetSize, SheetSize> = { peek: 'half', half: 'full', full: 'peek' };
-    return (
-      <>
-        <div className={`cp-sheet cp-root cp-${sheetSize}`} role="dialog" aria-label="Controls">
-          <div
-            className="cp-sheet-handle"
-            onClick={() => setSheetSize(cycle[sheetSize])}
-            role="button"
-            aria-label="Resize panel"
-          />
-          {sheetSize === 'peek' && peekContent && (
-            <div className="cp-sheet-peek-row">{peekContent}</div>
-          )}
-          {sheetSize !== 'peek' && <div className="cp-body">{children}</div>}
-        </div>
-        <button
-          className="cp-hide-btn cp-root"
-          title="Hide UI (H)"
-          onClick={() => setHidden(true)}
-        >
-          ⊟
-        </button>
-      </>
-    );
-  }
-
-  return (
-    <>
-      <div className={`cp-drawer cp-root ${open ? '' : 'cp-closed'}`} role="dialog" aria-label="Controls">
-        <div className="cp-body">{children}</div>
-      </div>
-      <button
-        className={`cp-tab cp-root ${open ? '' : 'cp-closed'}`}
-        title={open ? 'Collapse panel' : 'Expand panel'}
-        onClick={() => setOpen(v => !v)}
-      >
-        {open ? '›' : '‹'}
-      </button>
-      <button
-        className="cp-hide-btn cp-root"
-        title="Hide UI (H)"
-        onClick={() => setHidden(true)}
-        style={open ? { right: 'calc(var(--cp-drawer-width) + 12px)' } : undefined}
-      >
-        ⊟
-      </button>
-    </>
-  );
-}
+/**
+ * Form primitives — Section, Slider, Pills, Select, Checkbox — used inside
+ * AppShell's Settings/Actions tabs. The old desktop-drawer/mobile-sheet
+ * wrapper that lived here previously is now replaced by the global AppShell.
+ */
 
 export interface SectionProps {
   title: string;

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import Canvas3D from './Canvas3D';
 import Readme from './Readme';
-import { ControlPanel, Section, Slider, Pills, Select, Checkbox } from './ControlPanel';
+import { Section, Slider, Pills, Select, Checkbox } from './ControlPanel';
+import { ShellSettings, ShellActions, useAppHeader } from './AppShell';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../config/defaults';
 import { useResponsive } from '../styles/responsive';
 import { planes } from '../math/constants';
@@ -24,15 +25,10 @@ export interface ParticleViewerShellProps {
     camera: import('three').PerspectiveCamera;
     renderer: import('three').WebGLRenderer;
   }) => void;
-  /** Variant-specific label, e.g. "exp" or "z^(1/2)". */
   functionName: string;
-  /** Variant-specific formula, rendered in accent color. */
   functionFormula: string;
-  /** Variant-specific picker UI (dropdown / p,q / etc.) rendered inside Function section. */
   functionPicker: React.ReactNode;
-  /** Optional extra controls (e.g. multibranch branch count/indices/style). */
   variantExtras?: React.ReactNode;
-  /** README markdown to render inside the About section. */
   readme: string;
 }
 
@@ -44,17 +40,10 @@ export default function ParticleViewerShell({
   const compact = isMobile || isTablet;
   const gestures = useGestureRotation(state);
 
-  const peek = (
-    <>
-      <div style={{ display: 'flex', flexDirection: 'column', overflow: 'hidden', flex: 1 }}>
-        <span className="cp-peek-name">{functionName}</span>
-        <span className="cp-peek-formula">{functionFormula}</span>
-      </div>
-    </>
-  );
+  useAppHeader(functionName, functionFormula);
 
   return (
-    <div style={{ position: 'relative', width: '100%', height: '100vh', overflow: 'hidden' }}>
+    <>
       <div
         style={{ position: 'absolute', inset: 0, touchAction: 'none' }}
         {...gestures}
@@ -62,10 +51,8 @@ export default function ParticleViewerShell({
         <Canvas3D onMount={onMount} />
       </div>
 
-      <ControlPanel peekContent={peek}>
+      <ShellSettings>
         <Section title="Function" icon="ƒ" defaultOpen>
-          <div className="cp-function-title">{functionName}</div>
-          <div className="cp-function-formula">{functionFormula}</div>
           {functionPicker}
           {variantExtras}
         </Section>
@@ -96,18 +83,6 @@ export default function ParticleViewerShell({
             onChange={state.setCameraZ}
             format={v => v.toFixed(1)}
           />
-          <div className="cp-quarter">
-            <div className="cp-quarter-label">4D turn</div>
-            <div />
-            <div />
-            {planes.map(p => (
-              <React.Fragment key={p}>
-                <div className="cp-quarter-label" style={{ alignSelf: 'center' }}>{p}</div>
-                <button onClick={() => controls.turn(p, 1)}>↻</button>
-                <button onClick={() => controls.turn(p, -1)}>↺</button>
-              </React.Fragment>
-            ))}
-          </div>
           {!compact && (
             <table className="cp-orient-matrix">
               <thead>
@@ -198,10 +173,27 @@ export default function ParticleViewerShell({
         <Section title="About" icon="ⓘ">
           <Readme markdown={readme} />
         </Section>
-      </ControlPanel>
-    </div>
+      </ShellSettings>
+
+      <ShellActions>
+        <div className="cp-section-body">
+          <div className="cp-row-label" style={{ marginBottom: 4 }}>4D quarter turns</div>
+          <div className="cp-quarter">
+            <div />
+            <div className="cp-quarter-label" style={{ textAlign: 'center' }}>↻</div>
+            <div className="cp-quarter-label" style={{ textAlign: 'center' }}>↺</div>
+            {planes.map(p => (
+              <React.Fragment key={p}>
+                <div className="cp-quarter-label" style={{ alignSelf: 'center' }}>{p}</div>
+                <button onClick={() => controls.turn(p, 1)}>↻ {p}</button>
+                <button onClick={() => controls.turn(p, -1)}>↺ {p}</button>
+              </React.Fragment>
+            ))}
+          </div>
+        </div>
+      </ShellActions>
+    </>
   );
 }
 
-/** Re-export so variants can build their function pickers using a single import. */
 export { ProjectionMode };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { AppShell, AppDescriptor } from './components/AppShell';
 
 const FractalsGPU = React.lazy(() => import('./animations/FractalsGPU/FractalsGPU'));
 const Fractals2D = React.lazy(() => import('./animations/Fractals/Fractals2D'));
@@ -8,6 +9,15 @@ const Correspondence = React.lazy(() => import('./animations/Correspondence/Corr
 const MobiusWalk = React.lazy(() => import('./animations/MobiusWalk/MobiusWalk'));
 const StableMarriage = React.lazy(() => import('./animations/StableMarriage/StableMarriage'));
 const AgenticSorting = React.lazy(() => import('./animations/AgenticSorting/AgenticSorting'));
+
+const apps: AppDescriptor[] = [
+  { hash: '/', name: 'Complex Particles', icon: '✦' },
+  { hash: '/fractals', name: 'Fractals', icon: '◯' },
+  { hash: '/correspondence', name: 'Mandelbrot ↔ Julia', icon: '⇄' },
+  { hash: '/mobius', name: 'Möbius Walk', icon: '∞' },
+  { hash: '/stable-marriage', name: 'Stable Marriage', icon: '♥' },
+  { hash: '/agentic-sorting', name: 'Agentic Sorting', icon: '⇅' },
+];
 
 const routes: Record<string, React.ComponentType> = {
   '/': App,
@@ -20,7 +30,7 @@ const routes: Record<string, React.ComponentType> = {
 };
 
 function getHash(): string {
-  return window.location.hash.replace(/^#/, '');
+  return window.location.hash.replace(/^#/, '') || '/';
 }
 
 function Router(): JSX.Element {
@@ -33,11 +43,14 @@ function Router(): JSX.Element {
   }, []);
 
   const Component = routes[hash] ?? App;
+  const navigate = (h: string) => { window.location.hash = '#' + h; };
 
   return (
-    <React.Suspense fallback={<div style={{ background: '#000', width: '100vw', height: '100vh' }} />}>
-      <Component />
-    </React.Suspense>
+    <AppShell apps={apps} currentHash={hash} onNavigate={navigate}>
+      <React.Suspense fallback={<div style={{ background: '#000', width: '100%', height: '100%' }} />}>
+        <Component />
+      </React.Suspense>
+    </AppShell>
   );
 }
 


### PR DESCRIPTION
A persistent top bar (~48 px) now wraps every route. The hamburger
opens a side drawer with three tabs:

  Apps     — picker for all routes; replaces the tiny bottom-of-page
             text strip in index.html
  Settings — app-specific settings, portaled in by each route
  Actions  — app-specific one-shot buttons, portaled in by each route

Two helper components, ShellSettings and ShellActions, are React
portals that mount their children into the drawer's respective tabs.
A useAppHeader hook lets each app set its bar title + monospace
subtitle. The pattern keeps each app self-contained while sharing a
uniform chrome.

Migrations:

  ComplexParticles
    The old per-viewer ControlPanel (right-drawer / bottom-sheet) is
    gone. Its seven sections (Function / Camera / Colour / Particles
    / Motion / Detail / About) now portal into ShellSettings; the
    quarter-turn buttons portal into ShellActions.

  FractalsGPU
    Six floating overlay boxes (function picker, formula display,
    palette, power, colouring, iterations, animate/reset buttons,
    Julia c, hint text, About) collapse into ShellSettings sections
    + a ShellActions panel with "Start colour cycle" and "Reset
    view".

  Correspondence
    Each pane's two-column overlay (palette, offset, up/down/left/
    right, zoom in/out, pick Julia, draw path, clear, play, speed)
    consolidates into ShellSettings + ShellActions. The pan/zoom
    buttons disappear in favor of the touch gestures that already
    work; the action buttons that toggle modes (pick / draw / play)
    move to the Actions tab so they're discoverable from any route.

  MobiusWalk
    Bar title + the twist toggle moves to ShellActions.

  StableMarriage / AgenticSorting
    Inline page layouts kept (their controls are part of the layout,
    not an overlay), but they now register a bar title. Both .as-app
    and .sm-app switched from min-height: 100vh + body-overflow scroll
    to height: 100% + own overflow-y: auto so they scroll inside the
    shell's content area.

index.html: removed the bottom #page-info text strip (replaced by the
Apps tab), set body { overflow: hidden; height: 100% }, made the html
and #root fill 100% height so the AppShell can layout cleanly.

ControlPanel.tsx: removed the old wrapper component and SheetSize
plumbing; kept the form primitives (Section / Slider / Pills / Select
/ Checkbox) which the new shell consumes.

The old "Pinch to zoom · drag to pan · tap to trace" hint moves
inside the About section of each viewer instead of being a separate
overlay.

Verified by Playwright at 390×844 across all six routes: every app
shows its bar title, no horizontal overflow, settings tabs populated
where expected, "No settings for this view" empty state on MobiusWalk.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL