### PR TITLE
Mobile-fit + camera-orbit gestures on top of the AppShell

### DIFF
--- a/src/components/AppShell.css
+++ b/src/components/AppShell.css
@@ -18,8 +18,12 @@
 .as-shell {
   display: flex;
   flex-direction: column;
-  height: 100vh;
+  /* Use the dynamic viewport so the shell shrinks when iOS Safari's URL bar
+     re-appears, keeping the bottom of our content above the browser chrome. */
+  height: 100vh;            /* fallback for older browsers */
+  height: 100dvh;
   width: 100vw;
+  width: 100dvw;
   overflow: hidden;
 }
 

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -54,6 +54,7 @@ export default function ParticleViewerShell({
 
       <QuarterTurnFloater
         onTurn={controls.turn}
+        onRotateBy={controls.rotateBy}
         onReset={controls.snapToStandardView}
       />
 

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -3,6 +3,7 @@ import Canvas3D from './Canvas3D';
 import Readme from './Readme';
 import { Section, Slider, Pills, Select, Checkbox } from './ControlPanel';
 import { ShellSettings, ShellActions, useAppHeader } from './AppShell';
+import QuarterTurnFloater from '../controls/QuarterTurnFloater';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../config/defaults';
 import { useResponsive } from '../styles/responsive';
 import { planes } from '../math/constants';
@@ -50,6 +51,11 @@ export default function ParticleViewerShell({
       >
         <Canvas3D onMount={onMount} />
       </div>
+
+      <QuarterTurnFloater
+        onTurn={controls.turn}
+        onReset={controls.snapToStandardView}
+      />
 
       <ShellSettings>
         <Section title="Function" icon="ƒ" defaultOpen>
@@ -177,7 +183,18 @@ export default function ParticleViewerShell({
 
       <ShellActions>
         <div className="cp-section-body">
-          <div className="cp-row-label" style={{ marginBottom: 4 }}>4D quarter turns</div>
+          <button
+            style={{
+              padding: '12px 16px', borderRadius: 6,
+              border: '1px solid var(--cp-border)',
+              background: 'rgba(255,255,255,0.06)', color: 'var(--cp-fg)',
+              cursor: 'pointer', fontSize: 14, fontWeight: 600,
+            }}
+            onClick={controls.snapToStandardView}
+          >
+            Reset orientation
+          </button>
+          <div className="cp-row-label" style={{ marginTop: 8, marginBottom: 4 }}>4D quarter turns</div>
           <div className="cp-quarter">
             <div />
             <div className="cp-quarter-label" style={{ textAlign: 'center' }}>↻</div>

--- a/src/controls/QuarterTurnFloater.css
+++ b/src/controls/QuarterTurnFloater.css
@@ -1,0 +1,86 @@
+.qtb {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  background: rgba(12, 12, 16, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 8px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+
+.qtb-collapsed { padding: 4px; }
+
+.qtb-toggle {
+  background: transparent;
+  border: none;
+  color: #f0f0f3;
+  font-size: 16px;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.qtb-toggle:hover { background: rgba(255,255,255,0.08); }
+
+.qtb-grid {
+  display: grid;
+  grid-template-columns: auto auto auto;
+  gap: 4px;
+  align-items: center;
+}
+
+.qtb-label {
+  font-size: 11px;
+  color: #9b9ba3;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  padding: 0 4px;
+  text-align: center;
+}
+
+.qtb-btn {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.06);
+  color: #f0f0f3;
+  cursor: pointer;
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.qtb-btn:hover { background: rgba(255,255,255,0.12); }
+.qtb-btn:active { background: var(--cp-accent, #ffd400); color: #000; }
+
+.qtb-row-reset {
+  margin-top: 4px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+}
+.qtb-reset {
+  width: 100%;
+  padding: 6px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: transparent;
+  color: #f0f0f3;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.qtb-reset:hover { background: rgba(255,255,255,0.08); }

--- a/src/controls/QuarterTurnFloater.tsx
+++ b/src/controls/QuarterTurnFloater.tsx
@@ -1,18 +1,25 @@
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { planes, Plane } from '@/math/constants';
 import './QuarterTurnFloater.css';
 
 export interface QuarterTurnFloaterProps {
+  /** Tap callback — animated 90° turn. */
   onTurn: (p: Plane, dir: 1 | -1) => void;
+  /** Optional continuous-rotation callback driven by the floater's rAF loop. */
+  onRotateBy?: (p: Plane, theta: number) => void;
   onReset?: () => void;
 }
 
+const HOLD_THRESHOLD_MS = 220;     // how long before tap becomes hold
+const HOLD_RATE_RAD_PER_S = 1.5;   // ~86°/sec while holding
+
 /**
- * A small floating cluster of unit-rotation buttons (six 4D planes × two
- * directions, plus optional reset). Collapses to a single icon by default so
- * it stays out of the way; tap to expand. Placed bottom-left of the canvas.
+ * Floating cluster of unit-rotation buttons for the six 4D planes. Tap a
+ * button for an animated 90° quarter turn. Press and hold to rotate
+ * continuously in that plane (∼86°/sec). Includes a Reset orientation row.
+ * Starts collapsed; tap the ↻ chip to expand.
  */
-export default function QuarterTurnFloater({ onTurn, onReset }: QuarterTurnFloaterProps) {
+export default function QuarterTurnFloater({ onTurn, onRotateBy, onReset }: QuarterTurnFloaterProps) {
   const [open, setOpen] = useState(false);
 
   if (!open) {
@@ -44,7 +51,7 @@ export default function QuarterTurnFloater({ onTurn, onReset }: QuarterTurnFloat
         <div className="qtb-label">↻</div>
         <div className="qtb-label">↺</div>
         {planes.map(p => (
-          <Row key={p} plane={p} onTurn={onTurn} />
+          <Row key={p} plane={p} onTurn={onTurn} onRotateBy={onRotateBy} />
         ))}
       </div>
       {onReset && (
@@ -56,12 +63,87 @@ export default function QuarterTurnFloater({ onTurn, onReset }: QuarterTurnFloat
   );
 }
 
-function Row({ plane, onTurn }: { plane: Plane; onTurn: (p: Plane, d: 1 | -1) => void }) {
+function Row({
+  plane, onTurn, onRotateBy,
+}: {
+  plane: Plane;
+  onTurn: (p: Plane, d: 1 | -1) => void;
+  onRotateBy?: (p: Plane, theta: number) => void;
+}) {
   return (
     <>
       <div className="qtb-label" style={{ alignSelf: 'center' }}>{plane}</div>
-      <button className="qtb-btn" onClick={() => onTurn(plane, 1)} aria-label={`${plane} clockwise`}>↻</button>
-      <button className="qtb-btn" onClick={() => onTurn(plane, -1)} aria-label={`${plane} counter-clockwise`}>↺</button>
+      <HoldButton plane={plane} direction={1} onTurn={onTurn} onRotateBy={onRotateBy} label="↻" />
+      <HoldButton plane={plane} direction={-1} onTurn={onTurn} onRotateBy={onRotateBy} label="↺" />
     </>
+  );
+}
+
+function HoldButton({
+  plane, direction, onTurn, onRotateBy, label,
+}: {
+  plane: Plane;
+  direction: 1 | -1;
+  onTurn: (p: Plane, d: 1 | -1) => void;
+  onRotateBy?: (p: Plane, theta: number) => void;
+  label: string;
+}) {
+  const rafRef = useRef<number | null>(null);
+  const lastTimeRef = useRef<number>(0);
+  const holdTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const heldRef = useRef(false);
+
+  const startHold = () => {
+    heldRef.current = true;
+    lastTimeRef.current = performance.now();
+    const step = (now: number) => {
+      const dt = Math.min(0.1, (now - lastTimeRef.current) / 1000);
+      lastTimeRef.current = now;
+      onRotateBy?.(plane, direction * HOLD_RATE_RAD_PER_S * dt);
+      rafRef.current = requestAnimationFrame(step);
+    };
+    rafRef.current = requestAnimationFrame(step);
+  };
+
+  const stop = () => {
+    if (holdTimerRef.current) {
+      clearTimeout(holdTimerRef.current);
+      holdTimerRef.current = null;
+    }
+    if (rafRef.current != null) {
+      cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    }
+    const wasHeld = heldRef.current;
+    heldRef.current = false;
+    return wasHeld;
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    (e.currentTarget as Element).setPointerCapture(e.pointerId);
+    holdTimerRef.current = setTimeout(() => {
+      holdTimerRef.current = null;
+      if (onRotateBy) startHold();
+    }, HOLD_THRESHOLD_MS);
+  };
+
+  const onPointerUp = () => {
+    const wasHeld = stop();
+    if (!wasHeld) onTurn(plane, direction); // simple tap → animated quarter turn
+  };
+
+  const onPointerCancel = () => { stop(); };
+
+  useEffect(() => () => { stop(); }, []);
+
+  return (
+    <button
+      className="qtb-btn"
+      onPointerDown={onPointerDown}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerCancel}
+      onPointerLeave={(e) => { if (e.buttons === 0) stop(); }}
+      aria-label={`${plane} ${direction === 1 ? 'clockwise' : 'counter-clockwise'} (hold to rotate continuously)`}
+    >{label}</button>
   );
 }

--- a/src/controls/QuarterTurnFloater.tsx
+++ b/src/controls/QuarterTurnFloater.tsx
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import { planes, Plane } from '@/math/constants';
+import './QuarterTurnFloater.css';
+
+export interface QuarterTurnFloaterProps {
+  onTurn: (p: Plane, dir: 1 | -1) => void;
+  onReset?: () => void;
+}
+
+/**
+ * A small floating cluster of unit-rotation buttons (six 4D planes × two
+ * directions, plus optional reset). Collapses to a single icon by default so
+ * it stays out of the way; tap to expand. Placed bottom-left of the canvas.
+ */
+export default function QuarterTurnFloater({ onTurn, onReset }: QuarterTurnFloaterProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <div className="qtb qtb-collapsed">
+        <button
+          className="qtb-toggle"
+          onClick={() => setOpen(true)}
+          aria-label="Show quarter-turn rotations"
+          title="Quarter turns"
+        >↻</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="qtb">
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+        <span className="qtb-label" style={{ flex: 1, textAlign: 'left' }}>4D turns</span>
+        <button
+          className="qtb-toggle"
+          style={{ width: 24, height: 24, fontSize: 14 }}
+          onClick={() => setOpen(false)}
+          aria-label="Hide quarter-turn rotations"
+        >×</button>
+      </div>
+      <div className="qtb-grid">
+        <div />
+        <div className="qtb-label">↻</div>
+        <div className="qtb-label">↺</div>
+        {planes.map(p => (
+          <Row key={p} plane={p} onTurn={onTurn} />
+        ))}
+      </div>
+      {onReset && (
+        <div className="qtb-row-reset">
+          <button className="qtb-reset" onClick={onReset}>Reset orientation</button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Row({ plane, onTurn }: { plane: Plane; onTurn: (p: Plane, d: 1 | -1) => void }) {
+  return (
+    <>
+      <div className="qtb-label" style={{ alignSelf: 'center' }}>{plane}</div>
+      <button className="qtb-btn" onClick={() => onTurn(plane, 1)} aria-label={`${plane} clockwise`}>↻</button>
+      <button className="qtb-btn" onClick={() => onTurn(plane, -1)} aria-label={`${plane} counter-clockwise`}>↺</button>
+    </>
+  );
+}

--- a/src/lib/particles/useGestureRotation.ts
+++ b/src/lib/particles/useGestureRotation.ts
@@ -1,59 +1,34 @@
 import { useRef } from 'react';
-import { quarterQuat } from '../../math/quat4';
-import { Plane } from '../../math/constants';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import type { ParticleState } from './useParticleState';
 
-const ROT_SENSITIVITY = 0.005;       // radians per pixel of drag
+const ORBIT_SENSITIVITY = 0.006;     // radians of camera orbit per pixel
 const WHEEL_ZOOM_SENSITIVITY = 0.01; // cameraZ delta per wheel deltaY
+const ELEV_LIMIT = Math.PI / 2 - 0.01;
 
 interface Pt { x: number; y: number; }
 
 /**
- * Pointer-driven view controls for a particle viewer.
+ * Pointer-driven CAMERA controls for a particle viewer.
  *
- *   1 pointer drag         → XU (horizontal) + YU (vertical) — feels like a
- *                            standard 3D orbit in perspective view.
- *   2 pointers, pinch      → cameraZ (zoom).
- *   wheel                  → cameraZ.
- *
- * Earlier revisions mapped 2-finger drag and 2-finger twist onto the XV, YV,
- * and UV planes, but composing four rotations through a single drag was
- * unnavigable in 4D. Those planes are now reached via the on-screen quarter-
- * turn buttons (tap for 90°, hold for continuous rotation).
- *
- * Unifies mouse, pen, and touch via Pointer Events.
+ *   1 pointer drag    → orbit the camera around the origin (azimuth/elevation).
+ *                       The 4D quaternion rotation is untouched: gestures only
+ *                       change where you look from, not how the 4D object is
+ *                       oriented. Any plane rotation that "swaps axes" lives
+ *                       on the on-screen quarter-turn buttons.
+ *   2 pointer pinch   → cameraZ (zoom around origin).
+ *   wheel             → cameraZ.
  */
 export function useGestureRotation(state: ParticleState) {
   const pointers = useRef(new Map<number, Pt>());
   const lastPinchDist = useRef<number | null>(null);
 
-  function pushUniforms() {
-    const L = state.rotLRef.current;
-    const R = state.rotRRef.current;
-    state.materialsRef.current.forEach(m => {
-      m.uniforms.uRotL.value.w = L.w;
-      m.uniforms.uRotL.value.v.set(L.x, L.y, L.z);
-      m.uniforms.uRotR.value.w = R.w;
-      m.uniforms.uRotR.value.v.set(R.x, R.y, R.z);
-    });
-    state.viewPointRef.current = { L: L.clone(), R: R.clone() };
-    state.onViewPointChangeRef.current?.(state.viewPointRef.current);
-  }
-
-  function applyRotation(plane: Plane, theta: number) {
-    if (Math.abs(theta) < 1e-7) return;
-    const { L, R } = quarterQuat(plane, theta);
-    state.rotLRef.current.copy(L.clone().multiply(state.rotLRef.current).normalize());
-    state.rotRRef.current.copy(state.rotRRef.current.clone().multiply(R.conjugate()).normalize());
-  }
-
-  function clampedZoom(scale: number) {
+  function clampedZoomScale(scale: number) {
     const { min, max } = COMPLEX_PARTICLES_DEFAULTS.ranges.cameraZ;
     state.setCameraZ(cz => Math.max(min, Math.min(max, cz * scale)));
   }
 
-  function deltaZoom(delta: number) {
+  function clampedZoomDelta(delta: number) {
     const { min, max } = COMPLEX_PARTICLES_DEFAULTS.ranges.cameraZ;
     state.setCameraZ(cz => Math.max(min, Math.min(max, cz + delta)));
   }
@@ -76,16 +51,19 @@ export function useGestureRotation(state: ParticleState) {
     if (count === 1) {
       const dx = next.x - prev.x;
       const dy = next.y - prev.y;
-      applyRotation('XU', dx * ROT_SENSITIVITY);
-      applyRotation('YU', dy * ROT_SENSITIVITY);
-      pushUniforms();
+      // Drag-right turns the camera to the right (azimuth grows).
+      // Drag-up pitches the view down (elevation grows).
+      state.setAzimuth(a => a + dx * ORBIT_SENSITIVITY);
+      state.setElevation(e =>
+        Math.max(-ELEV_LIMIT, Math.min(ELEV_LIMIT, e - dy * ORBIT_SENSITIVITY)),
+      );
     } else if (count >= 2) {
       const others = [...pointers.current.entries()].filter(([id]) => id !== e.pointerId);
       const other = others[0]?.[1];
       if (other) {
         const newDist = Math.hypot(next.x - other.x, next.y - other.y);
         if (lastPinchDist.current != null && newDist > 1e-3) {
-          clampedZoom(lastPinchDist.current / newDist);
+          clampedZoomScale(lastPinchDist.current / newDist);
         }
         lastPinchDist.current = newDist;
       }
@@ -100,7 +78,7 @@ export function useGestureRotation(state: ParticleState) {
   };
 
   const onWheel = (e: React.WheelEvent) => {
-    deltaZoom(e.deltaY * WHEEL_ZOOM_SENSITIVITY);
+    clampedZoomDelta(e.deltaY * WHEEL_ZOOM_SENSITIVITY);
   };
 
   return {

--- a/src/lib/particles/useGestureRotation.ts
+++ b/src/lib/particles/useGestureRotation.ts
@@ -4,7 +4,9 @@ import { Plane } from '../../math/constants';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import type { ParticleState } from './useParticleState';
 
-const ROT_SENSITIVITY = 0.005;       // radians per pixel of drag
+// Lower than the original 0.005 — testers found 4D rotation too "twitchy",
+// since a small finger drag composes two plane rotations at once.
+const ROT_SENSITIVITY = 0.0025;      // radians per pixel of drag
 const WHEEL_ZOOM_SENSITIVITY = 0.01; // cameraZ delta per wheel deltaY
 
 interface Pt { x: number; y: number; }

--- a/src/lib/particles/useGestureRotation.ts
+++ b/src/lib/particles/useGestureRotation.ts
@@ -4,28 +4,29 @@ import { Plane } from '../../math/constants';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import type { ParticleState } from './useParticleState';
 
-// Lower than the original 0.005 — testers found 4D rotation too "twitchy",
-// since a small finger drag composes two plane rotations at once.
-const ROT_SENSITIVITY = 0.0025;      // radians per pixel of drag
+const ROT_SENSITIVITY = 0.005;       // radians per pixel of drag
 const WHEEL_ZOOM_SENSITIVITY = 0.01; // cameraZ delta per wheel deltaY
 
 interface Pt { x: number; y: number; }
 
 /**
- * Pointer-driven 4D rotation, zoom, and twist for a particle viewer.
+ * Pointer-driven view controls for a particle viewer.
  *
- *   1 pointer drag         → xu (horizontal), yu (vertical)
- *   2 pointers, centroid   → xv (horizontal), yv (vertical)
- *   2 pointers, pinch      → cameraZ
- *   2 pointers, twist      → uv
- *   wheel                  → cameraZ
+ *   1 pointer drag         → XU (horizontal) + YU (vertical) — feels like a
+ *                            standard 3D orbit in perspective view.
+ *   2 pointers, pinch      → cameraZ (zoom).
+ *   wheel                  → cameraZ.
+ *
+ * Earlier revisions mapped 2-finger drag and 2-finger twist onto the XV, YV,
+ * and UV planes, but composing four rotations through a single drag was
+ * unnavigable in 4D. Those planes are now reached via the on-screen quarter-
+ * turn buttons (tap for 90°, hold for continuous rotation).
  *
  * Unifies mouse, pen, and touch via Pointer Events.
  */
 export function useGestureRotation(state: ParticleState) {
   const pointers = useRef(new Map<number, Pt>());
   const lastPinchDist = useRef<number | null>(null);
-  const lastTwistAngle = useRef<number | null>(null);
 
   function pushUniforms() {
     const L = state.rotLRef.current;
@@ -63,7 +64,6 @@ export function useGestureRotation(state: ParticleState) {
     if (pointers.current.size === 2) {
       const [a, b] = [...pointers.current.values()];
       lastPinchDist.current = Math.hypot(a.x - b.x, a.y - b.y);
-      lastTwistAngle.current = Math.atan2(b.y - a.y, b.x - a.x);
     }
   };
 
@@ -83,29 +83,11 @@ export function useGestureRotation(state: ParticleState) {
       const others = [...pointers.current.entries()].filter(([id]) => id !== e.pointerId);
       const other = others[0]?.[1];
       if (other) {
-        const prevCx = (prev.x + other.x) / 2;
-        const prevCy = (prev.y + other.y) / 2;
-        const newCx = (next.x + other.x) / 2;
-        const newCy = (next.y + other.y) / 2;
-        applyRotation('XV', (newCx - prevCx) * ROT_SENSITIVITY);
-        applyRotation('YV', (newCy - prevCy) * ROT_SENSITIVITY);
-
         const newDist = Math.hypot(next.x - other.x, next.y - other.y);
         if (lastPinchDist.current != null && newDist > 1e-3) {
           clampedZoom(lastPinchDist.current / newDist);
         }
         lastPinchDist.current = newDist;
-
-        const newAngle = Math.atan2(next.y - other.y, next.x - other.x);
-        if (lastTwistAngle.current != null) {
-          let dAngle = newAngle - lastTwistAngle.current;
-          while (dAngle > Math.PI) dAngle -= 2 * Math.PI;
-          while (dAngle < -Math.PI) dAngle += 2 * Math.PI;
-          applyRotation('UV', dAngle);
-        }
-        lastTwistAngle.current = newAngle;
-
-        pushUniforms();
       }
     }
 
@@ -114,10 +96,7 @@ export function useGestureRotation(state: ParticleState) {
 
   const onPointerUp = (e: React.PointerEvent) => {
     pointers.current.delete(e.pointerId);
-    if (pointers.current.size < 2) {
-      lastPinchDist.current = null;
-      lastTwistAngle.current = null;
-    }
+    if (pointers.current.size < 2) lastPinchDist.current = null;
   };
 
   const onWheel = (e: React.WheelEvent) => {

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -21,6 +21,10 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   const [saturation, setSaturation] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.saturation);
   const [particleCount, setParticleCount] = useState(count);
   const [cameraZ, setCameraZ] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.cameraZ);
+  // Camera orbit: spherical coords around the origin. 1-finger drag updates
+  // these without touching the 4D quaternion rotation.
+  const [azimuth, setAzimuth] = useState(0);
+  const [elevation, setElevation] = useState(0);
   const [size, setSize] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.size);
   const [opacity, setOpacity] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.opacity);
   const [intensity, setIntensity] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.intensity);
@@ -97,6 +101,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     saturation, setSaturation,
     particleCount, setParticleCount,
     cameraZ, setCameraZ,
+    azimuth, setAzimuth,
+    elevation, setElevation,
     size, setSize,
     opacity, setOpacity,
     intensity, setIntensity,

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -66,8 +66,21 @@ export function useUniformSync(state: ParticleState): void {
   }, [state.realView]);
 
   useEffect(() => {
-    if (cameraRef.current) cameraRef.current.position.z = state.cameraZ;
-  }, [state.cameraZ]);
+    const cam = cameraRef.current;
+    if (!cam) return;
+    // Place the camera on a sphere of radius cameraZ around the origin, then
+    // look at the origin. azimuth = 0, elevation = 0 reproduces the original
+    // straight-back position (0, 0, cameraZ).
+    const r = state.cameraZ;
+    const az = state.azimuth;
+    const el = state.elevation;
+    cam.position.set(
+      r * Math.cos(el) * Math.sin(az),
+      r * Math.sin(el),
+      r * Math.cos(el) * Math.cos(az),
+    );
+    cam.lookAt(0, 0, 0);
+  }, [state.cameraZ, state.azimuth, state.elevation]);
 
   useEffect(() => {
     if (rendererRef.current) {

--- a/src/lib/particles/useViewControls.ts
+++ b/src/lib/particles/useViewControls.ts
@@ -106,5 +106,5 @@ export function useViewControls(state: ParticleState) {
     applyQuarterTurn(plane, (QUARTER / 2) * dir);
   };
 
-  return { handleViewType, handleMotion, handleDropAxis, turn };
+  return { handleViewType, handleMotion, handleDropAxis, turn, snapToStandardView };
 }

--- a/src/lib/particles/useViewControls.ts
+++ b/src/lib/particles/useViewControls.ts
@@ -106,5 +106,25 @@ export function useViewControls(state: ParticleState) {
     applyQuarterTurn(plane, (QUARTER / 2) * dir);
   };
 
-  return { handleViewType, handleMotion, handleDropAxis, turn, snapToStandardView };
+  /**
+   * Apply an incremental rotation in {plane} by {theta} radians, with no
+   * slerp animation. Used by hold-to-rotate buttons that drive their own
+   * requestAnimationFrame loop.
+   */
+  function rotateBy(plane: Plane, theta: number) {
+    if (materialsRef.current.length === 0) return;
+    const { L, R } = quarterQuat(plane, theta);
+    rotLRef.current.copy(L.clone().multiply(rotLRef.current).normalize());
+    rotRRef.current.copy(rotRRef.current.clone().multiply(R.conjugate()).normalize());
+    materialsRef.current.forEach(m => {
+      m.uniforms.uRotL.value.w = rotLRef.current.w;
+      m.uniforms.uRotL.value.v.set(rotLRef.current.x, rotLRef.current.y, rotLRef.current.z);
+      m.uniforms.uRotR.value.w = rotRRef.current.w;
+      m.uniforms.uRotR.value.v.set(rotRRef.current.x, rotRRef.current.y, rotRRef.current.z);
+    });
+    viewPointRef.current = { L: rotLRef.current.clone(), R: rotRRef.current.clone() };
+    onViewPointChangeRef.current?.(viewPointRef.current);
+  }
+
+  return { handleViewType, handleMotion, handleDropAxis, turn, snapToStandardView, rotateBy };
 }

--- a/src/lib/particles/useViewControls.ts
+++ b/src/lib/particles/useViewControls.ts
@@ -57,6 +57,9 @@ export function useViewControls(state: ParticleState) {
     });
     viewPointRef.current = { L: qL.clone(), R: qR.clone() };
     onViewPointChangeRef.current?.(viewPointRef.current);
+    // Camera also returns to its default vantage point.
+    state.setAzimuth(0);
+    state.setElevation(0);
   }
 
   function handleViewType(t: ProjectionMode) {


### PR DESCRIPTION
## Summary

Three follow-ups to the AppShell migration (PR #157), all in service of the
"finger does look, buttons do 4D" split:

- **`100dvh` viewport** so the bottom of every app stays visible when iOS
  Safari's URL bar slides in (the "major required change").
- **`QuarterTurnFloater`** — small bottom-left bubble on every particle
  viewer. Tap the chip to expand a 3-column grid of the six 4D planes ×
  two directions, plus a Reset orientation row. **Tap** = animated 90°
  turn; **press-and-hold** = continuous rotation in that plane at ~86°/s.
- **Camera-orbit gestures** — 1-finger drag now only moves the THREE.js
  camera (azimuth + elevation around the origin); 2-finger pinch + wheel
  still zoom; **gestures never touch the 4D rotation**. Every plane
  rotation (XY/XU/XV/YU/YV/UV) is reachable only via the floater or the
  Actions drawer. Earlier mappings of 2-finger drag to XV/YV and 2-finger
  twist to UV are removed.

New state in `useParticleState`: `azimuth`, `elevation` (radians). The
camera sync in `useUniformSync` recomputes `camera.position` from
spherical coordinates and calls `lookAt(0, 0, 0)`; default
`az=0, el=0` reproduces the original straight-back camera, so opening the
app looks identical to before. Elevation clamped to ±(π/2 − 0.01) to
avoid lookAt gimbal-lock. `snapToStandardView` resets the camera too, so
the Reset button truly returns home.

`useViewControls` exposes a new `rotateBy(plane, theta)` primitive —
an incremental, non-animated rotation that the hold-to-rotate loop
drives. Tap calls the existing animated `turn`.

## Test plan

- [x] Build is clean (`tsc --noEmit` + `vite build`).
- [x] Playwright probe with motion=Fixed: orientation matrix is byte-identical across reads taken 500 ms apart, confirming the 4D quaternion state doesn't drift on its own. Combined with no gesture handler referencing `rotLRef`/`rotRRef`, drag cannot change the 4D rotation by construction.
- [x] Playwright probe: holding a quarter-turn button for 1.2 s changes the orientation matrix; tapping fires the existing animated quarter turn.
- [x] Mobile bottom-bar fix verified by switching the shell's `height` from `100vh` to `100dvh` (with `100vh` fallback).
- [ ] Real-device smoke test — touch feel for hold-to-rotate timing (220 ms threshold, ~86°/s rate) is unverified on a phone.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_