### PR TITLE
Pad the AppShell with iOS safe-area insets

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, maximum-scale=5" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes, maximum-scale=5, viewport-fit=cover" />
     <title>animath</title>
     <style>
       * { box-sizing: border-box; }

--- a/src/components/AppShell.css
+++ b/src/components/AppShell.css
@@ -19,12 +19,21 @@
   display: flex;
   flex-direction: column;
   /* Use the dynamic viewport so the shell shrinks when iOS Safari's URL bar
-     re-appears, keeping the bottom of our content above the browser chrome. */
+     re-appears, keeping the bottom of our content above the browser chrome.
+     viewport-fit=cover (set in index.html) lets env() inset values reflect
+     iOS's home-indicator safe area, which we pad against below. */
   height: 100vh;            /* fallback for older browsers */
   height: 100dvh;
   width: 100vw;
   width: 100dvw;
   overflow: hidden;
+  /* Belt + braces for iOS: dvh handles the URL bar, env() handles the home
+     indicator. With box-sizing: border-box on *, the padding is taken out of
+     the 100dvh height instead of adding to it. */
+  padding-top: env(safe-area-inset-top, 0);
+  padding-bottom: env(safe-area-inset-bottom, 0);
+  padding-left: env(safe-area-inset-left, 0);
+  padding-right: env(safe-area-inset-right, 0);
 }
 
 /* ---------- Top bar ---------- */


### PR DESCRIPTION
## Summary

Reported symptom: bottom of the page still hidden under the iOS browser's
bottom bar after the `100dvh` change shipped.

`100dvh` handles iOS Safari's **collapsing URL bar** (dvh shrinks while
the bar is showing). It does **not** subtract two other things:

- the **home indicator** safe area on iPhone X+ (≈ 34 px at the bottom),
- the extra space iOS Safari sometimes reserves below the bottom URL bar
  in the new bottom-bar mode.

Standard iOS fix, applied here:

- **`index.html`** — add `viewport-fit=cover` to the viewport meta. Without
  this, `env(safe-area-inset-*)` always evaluates to `0`, even on devices
  with insets.
- **`AppShell.css`** — pad `.as-shell` with `env(safe-area-inset-*)` on
  all four sides. Combined with `box-sizing: border-box`, the shell stays
  `100dvh` tall on the outside but loses inset pixels from the inside.
  Everything in `.as-content` (canvases, the quarter-turn floater at
  `bottom: 16px`, the scrollable content of StableMarriage / AgenticSorting)
  ends up clear of the home indicator and bottom URL bar. Body's dark
  background still extends to the screen edge, so the chrome doesn't see
  a flash of contrasting color through the inset region.

Padding on the top + sides too, not just the bottom, because
`viewport-fit=cover` also lets content under the notch in landscape on
iPhones with a notch — without the top inset, the hamburger and title
would sit underneath it.

Non-iOS browsers return `0` from `env()`, so this is a no-op on Android,
desktop, etc.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [ ] Real iPhone smoke test in both portrait and landscape — needs you, since this sandbox can't reach the live site or simulate iOS chrome.
- [ ] Pages cache cleared after deploy; hard reload (long-press refresh → Reload Without Content Blockers, or close + reopen tab) to bypass Safari's cached `index.html`.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_