### PR TITLE
Add pan gesture (2-finger drag and Shift+drag)

### DIFF
--- a/src/lib/particles/useGestureRotation.ts
+++ b/src/lib/particles/useGestureRotation.ts
@@ -1,4 +1,5 @@
 import { useRef } from 'react';
+import * as THREE from 'three';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import type { ParticleState } from './useParticleState';
 
@@ -9,19 +10,21 @@ const ELEV_LIMIT = Math.PI / 2 - 0.01;
 interface Pt { x: number; y: number; }
 
 /**
- * Pointer-driven CAMERA controls for a particle viewer.
+ * Pointer-driven CAMERA controls for a particle viewer. Gestures never touch
+ * the 4D quaternion rotation — plane rotations live on the on-screen
+ * quarter-turn buttons.
  *
- *   1 pointer drag    → orbit the camera around the origin (azimuth/elevation).
- *                       The 4D quaternion rotation is untouched: gestures only
- *                       change where you look from, not how the 4D object is
- *                       oriented. Any plane rotation that "swaps axes" lives
- *                       on the on-screen quarter-turn buttons.
- *   2 pointer pinch   → cameraZ (zoom around origin).
- *   wheel             → cameraZ.
+ *   1-pointer drag             → orbit (azimuth + elevation around look-at).
+ *   1-pointer drag + Shift     → pan (translates the look-at target in the
+ *                                screen plane, scene follows the finger).
+ *   2-pointer pinch            → cameraZ (zoom).
+ *   2-pointer centroid drag    → pan, in addition to any pinch.
+ *   wheel                      → cameraZ.
  */
 export function useGestureRotation(state: ParticleState) {
   const pointers = useRef(new Map<number, Pt>());
   const lastPinchDist = useRef<number | null>(null);
+  const lastCentroid = useRef<Pt | null>(null);
 
   function clampedZoomScale(scale: number) {
     const { min, max } = COMPLEX_PARTICLES_DEFAULTS.ranges.cameraZ;
@@ -33,12 +36,30 @@ export function useGestureRotation(state: ParticleState) {
     state.setCameraZ(cz => Math.max(min, Math.min(max, cz + delta)));
   }
 
+  /** Translate the look-at target by a screen-space drag. Drag right shifts
+   *  the target left so the visible scene follows the finger (Maps convention). */
+  function applyPan(dxPx: number, dyPx: number, el: HTMLElement) {
+    const cam = state.cameraRef.current;
+    if (!cam || el.clientHeight === 0) return;
+    const fovRad = (cam.fov * Math.PI) / 180;
+    // By construction the camera-to-target distance equals state.cameraZ.
+    const worldPerPixel = (2 * state.cameraZ * Math.tan(fovRad / 2)) / el.clientHeight;
+    const right = new THREE.Vector3().setFromMatrixColumn(cam.matrixWorld, 0);
+    const up    = new THREE.Vector3().setFromMatrixColumn(cam.matrixWorld, 1);
+    const sx = -dxPx * worldPerPixel;
+    const sy =  dyPx * worldPerPixel; // browser y grows downward
+    state.setPanX(p => p + right.x * sx + up.x * sy);
+    state.setPanY(p => p + right.y * sx + up.y * sy);
+    state.setPanZ(p => p + right.z * sx + up.z * sy);
+  }
+
   const onPointerDown = (e: React.PointerEvent) => {
     (e.currentTarget as Element).setPointerCapture(e.pointerId);
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     if (pointers.current.size === 2) {
       const [a, b] = [...pointers.current.values()];
       lastPinchDist.current = Math.hypot(a.x - b.x, a.y - b.y);
+      lastCentroid.current  = { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
     }
   };
 
@@ -47,25 +68,39 @@ export function useGestureRotation(state: ParticleState) {
     if (!prev) return;
     const next: Pt = { x: e.clientX, y: e.clientY };
     const count = pointers.current.size;
+    const el = e.currentTarget as HTMLElement;
 
     if (count === 1) {
       const dx = next.x - prev.x;
       const dy = next.y - prev.y;
-      // Drag-right turns the camera to the right (azimuth grows).
-      // Drag-up pitches the view down (elevation grows).
-      state.setAzimuth(a => a + dx * ORBIT_SENSITIVITY);
-      state.setElevation(e =>
-        Math.max(-ELEV_LIMIT, Math.min(ELEV_LIMIT, e - dy * ORBIT_SENSITIVITY)),
-      );
+      if (e.shiftKey) {
+        applyPan(dx, dy, el);
+      } else {
+        // Drag-right turns the camera right (azimuth grows); drag-up pitches down.
+        state.setAzimuth(a => a + dx * ORBIT_SENSITIVITY);
+        state.setElevation(prevEl =>
+          Math.max(-ELEV_LIMIT, Math.min(ELEV_LIMIT, prevEl - dy * ORBIT_SENSITIVITY)),
+        );
+      }
     } else if (count >= 2) {
       const others = [...pointers.current.entries()].filter(([id]) => id !== e.pointerId);
       const other = others[0]?.[1];
       if (other) {
         const newDist = Math.hypot(next.x - other.x, next.y - other.y);
+        const newCentroid = { x: (next.x + other.x) / 2, y: (next.y + other.y) / 2 };
+
         if (lastPinchDist.current != null && newDist > 1e-3) {
           clampedZoomScale(lastPinchDist.current / newDist);
         }
+        if (lastCentroid.current != null) {
+          applyPan(
+            newCentroid.x - lastCentroid.current.x,
+            newCentroid.y - lastCentroid.current.y,
+            el,
+          );
+        }
         lastPinchDist.current = newDist;
+        lastCentroid.current  = newCentroid;
       }
     }
 
@@ -74,7 +109,10 @@ export function useGestureRotation(state: ParticleState) {
 
   const onPointerUp = (e: React.PointerEvent) => {
     pointers.current.delete(e.pointerId);
-    if (pointers.current.size < 2) lastPinchDist.current = null;
+    if (pointers.current.size < 2) {
+      lastPinchDist.current = null;
+      lastCentroid.current  = null;
+    }
   };
 
   const onWheel = (e: React.WheelEvent) => {

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -25,6 +25,13 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // these without touching the 4D quaternion rotation.
   const [azimuth, setAzimuth] = useState(0);
   const [elevation, setElevation] = useState(0);
+  // Pan offset: shifts the look-at target away from the origin. 2-finger drag
+  // (or Shift+drag on desktop) updates these. Position and look-at both
+  // translate by this vector, so the visible scene appears to follow the
+  // finger (Maps convention).
+  const [panX, setPanX] = useState(0);
+  const [panY, setPanY] = useState(0);
+  const [panZ, setPanZ] = useState(0);
   const [size, setSize] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.size);
   const [opacity, setOpacity] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.opacity);
   const [intensity, setIntensity] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.intensity);
@@ -103,6 +110,9 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     cameraZ, setCameraZ,
     azimuth, setAzimuth,
     elevation, setElevation,
+    panX, setPanX,
+    panY, setPanY,
+    panZ, setPanZ,
     size, setSize,
     opacity, setOpacity,
     intensity, setIntensity,

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -68,19 +68,23 @@ export function useUniformSync(state: ParticleState): void {
   useEffect(() => {
     const cam = cameraRef.current;
     if (!cam) return;
-    // Place the camera on a sphere of radius cameraZ around the origin, then
-    // look at the origin. azimuth = 0, elevation = 0 reproduces the original
-    // straight-back position (0, 0, cameraZ).
+    // Place the camera on a sphere of radius cameraZ around the pan target,
+    // then look at the pan target. azimuth = 0, elevation = 0, pan = (0,0,0)
+    // reproduces the original straight-back position (0, 0, cameraZ).
     const r = state.cameraZ;
     const az = state.azimuth;
     const el = state.elevation;
+    const tx = state.panX, ty = state.panY, tz = state.panZ;
     cam.position.set(
-      r * Math.cos(el) * Math.sin(az),
-      r * Math.sin(el),
-      r * Math.cos(el) * Math.cos(az),
+      tx + r * Math.cos(el) * Math.sin(az),
+      ty + r * Math.sin(el),
+      tz + r * Math.cos(el) * Math.cos(az),
     );
-    cam.lookAt(0, 0, 0);
-  }, [state.cameraZ, state.azimuth, state.elevation]);
+    cam.lookAt(tx, ty, tz);
+    // Keep the world matrix fresh so basis-vector reads from elsewhere
+    // (e.g. the gesture hook computing pan) reflect the new orientation.
+    cam.updateMatrixWorld(true);
+  }, [state.cameraZ, state.azimuth, state.elevation, state.panX, state.panY, state.panZ]);
 
   useEffect(() => {
     if (rendererRef.current) {

--- a/src/lib/particles/useViewControls.ts
+++ b/src/lib/particles/useViewControls.ts
@@ -60,6 +60,9 @@ export function useViewControls(state: ParticleState) {
     // Camera also returns to its default vantage point.
     state.setAzimuth(0);
     state.setElevation(0);
+    state.setPanX(0);
+    state.setPanY(0);
+    state.setPanZ(0);
   }
 
   function handleViewType(t: ProjectionMode) {


### PR DESCRIPTION
## Summary

Camera orbit alone forces the look-at point at the origin. Once you
zoom in, there's no way to recenter on an off-axis feature. This adds
pan as a camera-only operation (consistent with the existing "gestures
never touch 4D rotation" philosophy from PR #158).

**Bindings** — standard Maps / Three.js `OrbitControls` semantics:

| Input | Effect |
|---|---|
| 2-finger drag (translation component) | Pan |
| 2-finger pinch (distance component) | Zoom — both work together in a single gesture |
| 1-finger drag + Shift | Pan on desktop |
| 1-finger drag (no Shift) | Orbit (unchanged) |

Drag direction: drag right → scene follows your finger right (look-at
target moves left). Matches Google Maps / OrbitControls' right-button
pan.

## Implementation

- **`useParticleState`** gains `panX`, `panY`, `panZ` (default 0). 
- **`useUniformSync`** camera-position effect now offsets both
  `camera.position` and the `lookAt` call by the pan vector. With
  `pan = (0, 0, 0)` behavior is identical to before. After `lookAt` it
  calls `updateMatrixWorld(true)` so the next read of camera basis
  vectors (by the pan handler) is fresh.
- **`useGestureRotation`** gains `applyPan(dxPx, dyPx, el)` — converts
  the screen drag to a world translation using the camera's right/up
  basis vectors and `worldPerPixel = (2 · cameraZ · tan(fov/2)) / clientHeight`,
  so the pan feels the same at any zoom.
- **2-finger pointer state** now also tracks `lastCentroid`. Pinch
  (distance delta) zooms and centroid (translation delta) pans, both
  driven by the same gesture.
- **`snapToStandardView`** resets pan along with orientation, so the
  "Reset orientation" button truly returns home.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [ ] Real-device touch test — pinch+pan combined in a single gesture, pan during orbit, Reset clears pan.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_