### PR TITLE
Fractals: fix path-layer y-flip + add explicit Trace mode

### DIFF
--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -39,9 +39,10 @@ export function screenToComplex(
   const rect = canvas.getBoundingClientRect();
   const x = (e.clientX - rect.left) / rect.width;
   const y = (e.clientY - rect.top) / rect.height;
+  // Screen-Y down; math (imag) up.
   return {
     real: v.xMin + (v.xMax - v.xMin) * x,
-    imag: v.yMin + (v.yMax - v.yMin) * y,
+    imag: v.yMax - (v.yMax - v.yMin) * y,
   };
 }
 
@@ -224,8 +225,9 @@ export default function FractalPane({
     const size = Math.min(rect.width, rect.height);
     const offsetX = (rect.width - size) / 2;
     const offsetY = (rect.height - size) / 2;
+    // Math-Y points up; screen-Y points down. yMax sits at the top of the pane.
     const x = offsetX + ((markC.real - view.xMin) / (view.xMax - view.xMin)) * size;
-    const y = offsetY + ((markC.imag - view.yMin) / (view.yMax - view.yMin)) * size;
+    const y = offsetY + ((view.yMax - markC.imag) / (view.yMax - view.yMin)) * size;
     return {
       position: 'absolute',
       left: `${x}px`,
@@ -243,7 +245,7 @@ export default function FractalPane({
     const offsetX = (rect.width - size) / 2;
     const offsetY = (rect.height - size) / 2;
     const x = offsetX + ((c.real - view.xMin) / (view.xMax - view.xMin)) * size;
-    const y = offsetY + ((c.imag - view.yMin) / (view.yMax - view.yMin)) * size;
+    const y = offsetY + ((view.yMax - c.imag) / (view.yMax - view.yMin)) * size;
     return { x, y };
   };
 

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -43,6 +43,10 @@ export default function FractalsGPU() {
   const [insidePalette, setInsidePalette] = useState(0);
   const [offset, setOffset] = useState(0);
   const [animating, setAnimating] = useState(false);
+  /** When true, a tap/click on the canvas traces an iteration orbit from
+   *  that point. When false, taps do nothing (so panning doesn't spawn
+   *  unwanted trajectories). Default off. */
+  const [tracing, setTracing] = useState(false);
 
   useEffect(() => setIterInput(String(iter)), [iter]);
   useEffect(() => setPowerInput(String(power)), [power]);
@@ -224,8 +228,10 @@ export default function FractalsGPU() {
     (fx: number, fy: number) => {
       const canvas = rendererRef.current?.domElement;
       if (!canvas) return { x: 0, y: 0 };
-      const scale = canvas.width / (view.xMax - view.xMin);
-      return { x: (fx - view.xMin) * scale, y: (fy - view.yMin) * scale };
+      const scaleX = canvas.width  / (view.xMax - view.xMin);
+      const scaleY = canvas.height / (view.yMax - view.yMin);
+      // Math-Y points up but canvas-Y grows downward, so flip: yMax → 0, yMin → height.
+      return { x: (fx - view.xMin) * scaleX, y: (view.yMax - fy) * scaleY };
     },
     [view]
   );
@@ -305,8 +311,17 @@ export default function FractalsGPU() {
       const canvas = rendererRef.current?.domElement;
       return canvas ? normalizeView(v, canvas) : v;
     },
-    onTap: tracePath,
+    // Tracing is opt-in via the action toggle. Without this gate, every tap
+    // before a pan would spawn a stray orbit.
+    onTap: tracing ? tracePath : undefined,
   });
+
+  const clearPath = useCallback(() => {
+    pathRef.current = null;
+    const canvas = overlayRef.current;
+    const ctx = overlayCtxRef.current;
+    if (canvas && ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+  }, []);
 
   const reset = useCallback(() => {
     const canvas = rendererRef.current?.domElement;
@@ -480,13 +495,39 @@ export default function FractalsGPU() {
         <Section title="About" icon="ⓘ">
           <Readme markdown={readmeText} />
           <div style={{ fontSize: 11, color: 'var(--cp-fg-dim)', marginTop: 8 }}>
-            {isMobile ? 'Pinch to zoom · drag to pan · tap to trace' : 'Wheel to zoom · drag to pan · click to trace'}
+            Drag to pan · pinch or wheel to zoom. Open Actions and toggle
+            "Trace mode" to spawn iteration paths by tap/click.
           </div>
         </Section>
       </ShellSettings>
 
       <ShellActions>
         <div className="cp-section-body">
+          <button
+            style={{
+              padding: '12px 16px', borderRadius: 6,
+              border: tracing ? '1px solid var(--cp-accent)' : '1px solid var(--cp-border)',
+              background: tracing ? 'rgba(255, 212, 0, 0.18)' : 'rgba(255,255,255,0.06)',
+              color: 'var(--cp-fg)', cursor: 'pointer', fontSize: 14, fontWeight: 600,
+              textAlign: 'left',
+            }}
+            onClick={() => setTracing(t => !t)}
+          >
+            {tracing ? 'Trace mode: tap to spawn orbit' : 'Trace mode (off)'}
+          </button>
+          <button
+            style={{
+              padding: '12px 16px', borderRadius: 6,
+              border: '1px solid var(--cp-border)',
+              background: 'rgba(255,255,255,0.06)', color: 'var(--cp-fg)',
+              cursor: pathRef.current ? 'pointer' : 'not-allowed',
+              fontSize: 14, opacity: pathRef.current ? 1 : 0.5,
+              textAlign: 'left',
+            }}
+            onClick={clearPath}
+          >
+            Clear orbit
+          </button>
           <button
             className="cp-pills"
             style={{

--- a/src/lib/useViewportGestures.ts
+++ b/src/lib/useViewportGestures.ts
@@ -43,20 +43,26 @@ const WHEEL_ZOOM_FACTOR = 0.0015; // factor = exp(deltaY * WHEEL_ZOOM_FACTOR)
 function screenToMath(view: ViewBounds, px: number, py: number, el: HTMLElement): Point2 {
   const w = el.clientWidth;
   const h = el.clientHeight;
+  // Screen Y grows downward; math Y in the fractals/complex viewers grows
+  // upward (the fragment shader maps vUv.y = 1 — top of screen — to yMax).
   return {
     x: view.xMin + (view.xMax - view.xMin) * (px / w),
-    y: view.yMin + (view.yMax - view.yMin) * (py / h),
+    y: view.yMax - (view.yMax - view.yMin) * (py / h),
   };
 }
 
 function panView(view: ViewBounds, dxPx: number, dyPx: number, el: HTMLElement): ViewBounds {
   const sx = (view.xMax - view.xMin) / el.clientWidth;
   const sy = (view.yMax - view.yMin) / el.clientHeight;
+  // Drag right (dxPx > 0) shifts the view left so the scene follows the finger.
+  // For y: drag down (dyPx > 0) — finger moves toward bottom of screen — must
+  // shift the view UP in math space (yMax/yMin both increase), since screen-Y
+  // and math-Y point in opposite directions.
   return {
     xMin: view.xMin - dxPx * sx,
     xMax: view.xMax - dxPx * sx,
-    yMin: view.yMin - dyPx * sy,
-    yMax: view.yMax - dyPx * sy,
+    yMin: view.yMin + dyPx * sy,
+    yMax: view.yMax + dyPx * sy,
   };
 }
 
@@ -66,15 +72,18 @@ function zoomViewAtPixel(view: ViewBounds, factor: number, px: number, py: numbe
   const h = el.clientHeight;
   const tx = px / w;
   const ty = py / h;
+  // (fx, fy) is the math point under the pixel — held fixed by the zoom.
   const fx = view.xMin + (view.xMax - view.xMin) * tx;
-  const fy = view.yMin + (view.yMax - view.yMin) * ty;
+  const fy = view.yMax - (view.yMax - view.yMin) * ty;
   const newW = (view.xMax - view.xMin) * factor;
   const newH = (view.yMax - view.yMin) * factor;
   return {
     xMin: fx - newW * tx,
     xMax: fx + newW * (1 - tx),
-    yMin: fy - newH * ty,
-    yMax: fy + newH * (1 - ty),
+    // The pivot's math-y = fy; tx of new width sits to the left, ty of new
+    // height sits ABOVE (because math-Y is flipped from screen-Y).
+    yMin: fy - newH * (1 - ty),
+    yMax: fy + newH * ty,
   };
 }
 


### PR DESCRIPTION
## Summary

Two reported issues with the Fractals viewer:

1. **The orbit path didn't track the fractal during pan/zoom.**
2. **Mobile users kept "spawning point trajectories by accident"** — any
   stray tap before a pan triggered a trace.

### Root cause for (1): screen-Y vs math-Y flip

The fragment shader maps `vUv.y = 1` (top of screen) to `yMax` in math
space, so math-Y points up while screen-Y points down. Three helpers
conflated them:

- **`useViewportGestures.screenToMath` / `panView` / `zoomViewAtPixel`** —
  Now flip:
  - `fy = yMax - (yMax - yMin) * py / h`
  - Pan: `dyPx > 0` (drag down) shifts view UP in math (`yMin/yMax` both
    increase), so the scene follows your finger.
  - Zoom: pivot's `ty` is mirrored vertically.
- **`FractalsGPU.fractalToScreen`** — Used `(fy - yMin) * scale`, putting
  `yMin` at the top instead of the bottom. Now `(yMax - fy) * scaleY`.
- **`Correspondence/FractalPane`** — `toScreen` + `crossStyle` had the
  same flip. Fixed so the `markC` indicator and SVG-rendered drawn path
  align with the rendered fractal. The unused `screenToComplex` export
  was fixed for consistency.

After the fix: the path's starting point sits under the cursor, and as
you pan the path moves with the underlying fractal feature.

### Fix for (2): explicit Trace mode

Tracing is now an opt-in toggle in the Actions drawer:

- **Trace mode (off)** — default. Tap/click does nothing; pan and zoom
  work cleanly.
- **Trace mode (on)** — tap or click spawns an iteration orbit from
  that point.
- **Clear orbit** — removes the current orbit.

The About hint in the Settings drawer updated to describe the new flow.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [x] **No-accidental-trace**: with tracing off, a center-canvas click leaves the overlay at zero non-zero alpha pixels.
- [x] **Trace mode + click spawns orbit**: 1947 non-zero overlay pixels after enabling and clicking.
- [x] **Path tracks pan**: after a 160-px diagonal pan, the same path remains visible (1947 pixels — anchored to the same math point, redrawn at new screen coords). Screenshot shows the orbit threading through the main cardioid, matching the Mandelbrot feature it originates from.
- [ ] Real-device touch confirmation — pinch+pan smoothness, tap latency.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_