### PR TITLE
AppShell: three explicit top-bar buttons (Apps / Settings / Actions)

### DIFF
--- a/src/components/AppShell.css
+++ b/src/components/AppShell.css
@@ -68,6 +68,9 @@
 }
 .as-bar-btn:hover { background: var(--as-hover); }
 .as-bar-btn:focus-visible { outline: 2px solid var(--as-accent); outline-offset: 2px; }
+/* Dim a bar button when its tab has no content (still clickable; the tab
+   itself shows a "No settings/actions for this view" message). */
+.as-bar-btn-dim { opacity: 0.4; }
 
 .as-bar-title {
   flex: 1;

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -85,7 +85,12 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     <AppShellContext.Provider value={ctx}>
       <div className="as-shell">
         <header className="as-bar">
-          <button className="as-bar-btn" aria-label="Open menu" onClick={() => openWithTab('apps')}>≡</button>
+          <button
+            className="as-bar-btn"
+            aria-label="Apps"
+            title="Apps"
+            onClick={() => openWithTab('apps')}
+          >☰</button>
           <button
             className="as-bar-title"
             onClick={() => openWithTab(hasSettings ? 'settings' : 'apps')}
@@ -94,9 +99,18 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
             <span className="as-bar-title-name">{titleName}</span>
             {subtitle && <span className="as-bar-title-formula">{subtitle}</span>}
           </button>
-          {hasActions && (
-            <button className="as-bar-btn" aria-label="Show actions" onClick={() => openWithTab('actions')}>▶</button>
-          )}
+          <button
+            className={`as-bar-btn ${hasSettings ? '' : 'as-bar-btn-dim'}`}
+            aria-label="Settings"
+            title="Settings"
+            onClick={() => openWithTab('settings')}
+          >⚙</button>
+          <button
+            className={`as-bar-btn ${hasActions ? '' : 'as-bar-btn-dim'}`}
+            aria-label="Actions"
+            title="Actions"
+            onClick={() => openWithTab('actions')}
+          >▶</button>
         </header>
 
         <div className="as-content">


### PR DESCRIPTION
## Summary

The bar previously had a single `≡` button that opened a drawer with
tabs for Apps / Settings / Actions. Now the bar exposes all three
affordances as separate icon buttons:

| Button | Effect |
|---|---|
| `☰` | Opens drawer on Apps tab |
| Title | Still clickable as shortcut to Settings |
| `⚙` | Opens drawer directly on Settings tab |
| `▶` | Opens drawer directly on Actions tab |

Each button opens the drawer to its tab in one click — no in-drawer
tab switching required for the common case. When a tab is empty for
the current view (e.g. Möbius has no Settings), its bar button is
dimmed (opacity 0.4) but still clickable — the tab body shows the
existing "No settings for this view" message.

In-drawer tabs are kept so users can switch between tabs without
closing/reopening the drawer.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [x] Screenshot at 390×844 shows all three icon buttons (☰ left, ⚙ + ▶ right) plus the title in the middle.
- [x] Tapping ⚙ opens the drawer with the Settings tab pre-selected (yellow underline on Settings).
- [ ] Dim state for empty-tab buttons on routes without Actions or Settings — visually confirm on real device.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_