### PR TITLE
AgenticSorting: arena scales with viewport (dvh-based)

### DIFF
--- a/src/animations/AgenticSorting/agenticSorting.css
+++ b/src/animations/AgenticSorting/agenticSorting.css
@@ -329,7 +329,13 @@
   border: 2px solid #0f172a;
   border-radius: 24px;
   padding: 24px;
-  height: 500px;
+  /* Scale with the visible viewport: at least 280 px so bars stay readable,
+     at most 640 px so the arena doesn't dominate large monitors. dvh tracks
+     iOS Safari's URL bar; vh is the fallback for older browsers. */
+  height: 60vh;
+  height: 60dvh;
+  min-height: 280px;
+  max-height: 640px;
   position: relative;
   overflow: hidden;
   box-shadow: 0 12px 40px rgba(0, 0, 0, 0.4);
@@ -337,8 +343,14 @@
 
 @media (max-width: 600px) {
   .as-arena {
-    height: 320px;
+    /* Reserve more relative space on phones, where every pixel matters and
+       the user wants the visualization front-and-center. */
+    height: 55vh;
+    height: 55dvh;
+    min-height: 220px;
+    max-height: 500px;
     padding: 12px;
+    border-radius: 16px;
   }
 }
 


### PR DESCRIPTION
## Summary

The agentic-sorting arena was hard-coded to 500 px on desktop and
320 px on mobile, so on a tall monitor the bars felt tiny, and on a
tall phone it still left big gaps above and below.

Switch to dynamic-viewport units with min/max clamps so the arena
claims a sensible fraction of whatever screen it lands on:

| Breakpoint | Sizing | Min | Max |
|---|---|---|---|
| Desktop | `60dvh` | 280 px | 640 px |
| ≤ 600 px wide | `55dvh` | 220 px | 500 px |

`100vh` fallback kept for browsers that predate `dvh` (Safari < 15.4,
Chrome < 108, Firefox < 101).

## Test plan

Measured arena heights via Playwright at four viewports:

| Viewport | Before | After | Δ |
|---|---|---|---|
| 390 × 700 (short phone) | 320 | 385 | +20% |
| 390 × 844 (tall phone) | 320 | 464 | +45% |
| 1280 × 800 (desktop) | 500 | 480 | ~same |
| 1280 × 1440 (tall desk) | 500 | 640 | +28% |

- [x] `vite build` clean.
- [x] Screenshot at 390 × 844 shows the arena dominating the upper half cleanly; legend cards still fit below.
- [ ] Real-device check on a phone in portrait + landscape orientations.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_