### PR TITLE
AgenticSorting: bars/dots toggle + drop redundant in-page headers

### DIFF
--- a/src/animations/AgenticSorting/AgenticSorting.tsx
+++ b/src/animations/AgenticSorting/AgenticSorting.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
 import {
-  Play, Pause, RotateCcw, Zap, Users,
-  Target, Activity
+  Play, Pause, RotateCcw, Zap, Users, Target,
 } from 'lucide-react';
 import './agenticSorting.css';
 import { useAppHeader } from '../../components/AppShell';
@@ -69,6 +68,10 @@ export default function AgenticSorting() {
   const [itemCount, setItemCount] = useState(60);
   const [simulationSpeed, setSimulationSpeed] = useState(20);
   const [isRunning, setIsRunning] = useState(false);
+  /** Visualisation mode: bars (full-length rectangles from the midline) or
+   *  dots (a small circle at each agent's value). Dots stay readable at
+   *  high agent counts where adjacent bars start to merge. */
+  const [display, setDisplay] = useState<'bars' | 'dots'>('bars');
 
   const [weights, setWeights] = useState<Weights>({
     standard: 20,
@@ -257,10 +260,8 @@ export default function AgenticSorting() {
   return (
     <div className="as-app">
       <header className="as-header">
-        <h1>
-          <Activity size={28} />
-          AGENTIC SORTING LAB
-        </h1>
+        {/* The app's name lives in the AppShell bar above; this header keeps
+            just a short subtitle for context. */}
         <p>Concurrent behavioral sorting simulation</p>
       </header>
 
@@ -308,6 +309,19 @@ export default function AgenticSorting() {
                 onChange={(e) => setSimulationSpeed(parseInt(e.target.value))}
                 className="as-slider as-slider-speed"
               />
+            </div>
+
+            <div className="as-display-toggle" role="group" aria-label="Display mode">
+              <button
+                className={`as-display-btn ${display === 'bars' ? 'as-display-btn-active' : ''}`}
+                onClick={() => setDisplay('bars')}
+                aria-pressed={display === 'bars'}
+              >Bars</button>
+              <button
+                className={`as-display-btn ${display === 'dots' ? 'as-display-btn-active' : ''}`}
+                onClick={() => setDisplay('dots')}
+                aria-pressed={display === 'dots'}
+              >Dots</button>
             </div>
           </div>
 
@@ -367,8 +381,13 @@ export default function AgenticSorting() {
                   style={{ width: `${100 / items.length}%` }}
                 >
                   <div
-                    className={getBarClass(item)}
-                    style={{
+                    className={`${getBarClass(item)}${display === 'dots' ? ' as-bar-dot' : ''}`}
+                    // Bars: column from the midline, length = |value|/2 %.
+                    // Dots: a small circle at vertical position = 50% + value/2,
+                    //       offset by half the dot size (set in CSS) to center.
+                    style={display === 'dots' ? {
+                      bottom: `calc(${50 + item.value / 2}% - var(--as-dot-size) / 2)`,
+                    } : {
                       height: `${Math.abs(item.value) / 2}%`,
                       top: item.value < 0 ? '50.1%' : undefined,
                       bottom: item.value < 0 ? undefined : '50.1%',

--- a/src/animations/AgenticSorting/agenticSorting.css
+++ b/src/animations/AgenticSorting/agenticSorting.css
@@ -392,7 +392,22 @@
   width: 75%;
   border-radius: 999px;
   position: absolute;
-  transition: height 0.15s, background 0.15s;
+  transition: height 0.15s, background 0.15s, bottom 0.15s;
+}
+
+/* Dot variant: a small fixed-size circle whose vertical position is set
+   inline. The component reads --as-dot-size to center it on its value. */
+:root { --as-dot-size: 10px; }
+.as-bar.as-bar-dot {
+  width: var(--as-dot-size);
+  height: var(--as-dot-size);
+  border-radius: 50%;
+  left: 50%;
+  transform: translateX(-50%);
+  top: auto;
+}
+@media (max-width: 600px) {
+  :root { --as-dot-size: 8px; }
 }
 
 .as-bar-swapping {
@@ -405,6 +420,35 @@
   background: #facc15;
   box-shadow: 0 0 10px rgba(250, 204, 21, 0.6);
   z-index: 10;
+}
+
+/* Display-mode toggle (Bars / Dots) sitting in the controls card */
+.as-display-toggle {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+  padding: 4px;
+  background: #1e293b;
+  border-radius: 8px;
+}
+.as-display-btn {
+  flex: 1;
+  padding: 8px 12px;
+  border: none;
+  background: transparent;
+  color: #94a3b8;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  cursor: pointer;
+  border-radius: 6px;
+  transition: background 0.15s, color 0.15s;
+}
+.as-display-btn:hover { color: #e2e8f0; }
+.as-display-btn-active {
+  background: #334155;
+  color: #fff;
 }
 
 .as-arena-label {

--- a/src/animations/StableMarriage/StableMarriage.tsx
+++ b/src/animations/StableMarriage/StableMarriage.tsx
@@ -4,7 +4,6 @@ import {
   AlertTriangle,
   ArrowDownUp,
   BarChart2,
-  Box,
   FastForward,
   FlaskConical,
   Grid,
@@ -1179,10 +1178,9 @@ export default function StableMarriage() {
   return (
     <div className="sm-app">
       <header className="sm-header">
+        {/* The app's name lives in the AppShell bar above. Keep just a short
+            subtitle for context, alongside the Visualizer / Lab toggle. */}
         <div>
-          <h1>
-            <Box size={22} /> Stable Marriage Lab
-          </h1>
           <p>Explore how proposal bias and preference consensus shape stable matches.</p>
         </div>
         <div className="sm-mode-toggle">


### PR DESCRIPTION
## Summary

Two changes that travel together since they touch the same two apps.

### 1. Bars / Dots display toggle (AgenticSorting)

A new toggle in the controls card lets you switch between rendering
each agent as a full-length **bar** (current behaviour — extends from
the midline) or as a small **dot** at the agent's value. Dots stay
readable at high agent counts where adjacent bars merge into a wall
of colour, and they make the visualisation read as a scatter-plot
instead of a histogram.

Implementation: a single `display: 'bars' | 'dots'` state. The bar
`<div>` inside each column either gets the existing inline
`height/top/bottom` style (bars) or just a `bottom: calc(50% + value/2 - dot-size/2)`
that places the dot at its value (dots). CSS adds `.as-bar-dot` for
the circle shape (10 px desktop, 8 px ≤ 600 px) via a
`--as-dot-size` custom property.

### 2. Drop the redundant in-page `<h1>` on AgenticSorting + StableMarriage

The AppShell bar already shows "Agentic Sorting" / "Stable Marriage"
right above the page; the in-page H1 was just repeating the same
string in a much bigger font, eating vertical real estate on mobile
in particular. Both apps keep their descriptive subtitle paragraph
for context.

The now-unused `Box` (StableMarriage) and `Activity` (AgenticSorting)
icon imports are removed.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [x] Playwright at 1280×800 + 390×844: zero console errors on Agentic + Stable in default mode.
- [x] After clicking "DOTS" in Agentic at 1280×800: `.as-bar-dot` count is 60 (matches `itemCount`); screenshot shows colourful scatter-plot.
- [x] Stable Marriage on phone (390×844): no double-title; subtitle and Visualizer/Lab toggle sit cleanly under the AppShell bar.
- [ ] Real-device check — dot size on a high-DPI phone.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_