### PR TITLE
ComplexParticles: colored axis letters, surface Drop axis, expose grid bounds

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -165,7 +165,7 @@ export default function ComplexParticles({
       });
       state.texturesRef.current = textures;
 
-      const geometry = createParticleGeometry(state.particleCount);
+      const geometry = createParticleGeometry(state.particleCount, state.gridExtent);
       state.geometryRef.current = geometry;
 
       state.materialsRef.current = [];

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -56,6 +56,12 @@ export default function ParticleViewerShell({
         onTurn={controls.turn}
         onRotateBy={controls.rotateBy}
         onReset={controls.snapToStandardView}
+        getAxisColor={(letter) => {
+          const key = letter.toLowerCase() as 'x' | 'y' | 'u' | 'v';
+          return `hsl(${((AXIS_COLORS[key] + state.hueShift) % 1) * 360},100%,60%)`;
+        }}
+        dropAxis={state.dropAxis}
+        onDropAxisChange={controls.handleDropAxis}
       />
 
       <ShellSettings>
@@ -70,12 +76,6 @@ export default function ParticleViewerShell({
             options={viewTypes.map(([name, code]) => ({ value: code, label: name }))}
             value={state.viewType}
             onChange={controls.handleViewType}
-          />
-          <Pills
-            label="Drop axis"
-            options={dropModes.map(d => ({ value: d, label: d.replace('Drop', '') }))}
-            value={state.dropAxis}
-            onChange={controls.handleDropAxis}
           />
           <Pills
             label="Motion"
@@ -172,6 +172,9 @@ export default function ParticleViewerShell({
           <Slider label="Particle count" value={state.particleCount}
             min={R.particleCount.min} max={R.particleCount.max} step={R.particleCount.step}
             onChange={state.setParticleCount} format={v => `${(v / 1000).toFixed(0)}k`} />
+          <Slider label="Grid extent (±)" value={state.gridExtent}
+            min={R.gridExtent.min} max={R.gridExtent.max} step={R.gridExtent.step}
+            onChange={state.setGridExtent} format={v => v.toFixed(1)} />
           <Slider label="Axis width" value={state.axisWidth}
             min={R.axisWidth.min} max={R.axisWidth.max} step={R.axisWidth.step}
             onChange={state.setAxisWidth} format={v => v.toFixed(1)} />
@@ -195,18 +198,35 @@ export default function ParticleViewerShell({
           >
             Reset orientation
           </button>
+
+          <div className="cp-row-label" style={{ marginTop: 8, marginBottom: 4 }}>Drop axis</div>
+          <Pills
+            options={dropModes.map(d => ({ value: d, label: d.replace('Drop', '') }))}
+            value={state.dropAxis}
+            onChange={controls.handleDropAxis}
+          />
+
           <div className="cp-row-label" style={{ marginTop: 8, marginBottom: 4 }}>4D quarter turns</div>
           <div className="cp-quarter">
             <div />
             <div className="cp-quarter-label" style={{ textAlign: 'center' }}>↻</div>
             <div className="cp-quarter-label" style={{ textAlign: 'center' }}>↺</div>
-            {planes.map(p => (
-              <React.Fragment key={p}>
-                <div className="cp-quarter-label" style={{ alignSelf: 'center' }}>{p}</div>
-                <button onClick={() => controls.turn(p, 1)}>↻ {p}</button>
-                <button onClick={() => controls.turn(p, -1)}>↺ {p}</button>
-              </React.Fragment>
-            ))}
+            {planes.map(p => {
+              const colorOf = (letter: string) => {
+                const key = letter.toLowerCase() as 'x' | 'y' | 'u' | 'v';
+                return `hsl(${((AXIS_COLORS[key] + state.hueShift) % 1) * 360},100%,60%)`;
+              };
+              return (
+                <React.Fragment key={p}>
+                  <div className="cp-quarter-label" style={{ alignSelf: 'center' }}>
+                    <span style={{ color: colorOf(p[0]) }}>{p[0]}</span>
+                    <span style={{ color: colorOf(p[1]) }}>{p[1]}</span>
+                  </div>
+                  <button onClick={() => controls.turn(p, 1)}>↻ {p}</button>
+                  <button onClick={() => controls.turn(p, -1)}>↺ {p}</button>
+                </React.Fragment>
+              );
+            })}
           </div>
         </div>
       </ShellActions>

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -35,12 +35,14 @@ export const COMPLEX_PARTICLES_DEFAULTS = {
     shimmer: 0,
     hueShift: 0,
     jitter: 0.1,
-    axisWidth: 5
+    axisWidth: 5,
+    /** Half-side of the sampled (x, y) grid; default ±4. */
+    gridExtent: 4,
   },
   defaultParticleCount: 80000,
   ranges: {
     saturation: { min: 0, max: 1, step: 0.01 },
-    particleCount: { min: 1000, max: 80000, step: 1000 },
+    particleCount: { min: 1000, max: 250000, step: 1000 },
     size: { min: 0.2, max: 5, step: 0.1 },
     opacity: { min: 0, max: 1, step: 0.01 },
     intensity: { min: 0.5, max: 2, step: 0.05 },
@@ -48,6 +50,7 @@ export const COMPLEX_PARTICLES_DEFAULTS = {
     jitter: { min: 0, max: 0.5, step: 0.005 },
     hueShift: { min: 0, max: 1, step: 0.01 },
     cameraZ: { min: 2, max: 50, step: 0.1 },
-    axisWidth: { min: 0.5, max: 5, step: 0.1 }
+    axisWidth: { min: 0.5, max: 5, step: 0.1 },
+    gridExtent: { min: 1, max: 12, step: 0.5 },
   }
 };

--- a/src/controls/QuarterTurnFloater.css
+++ b/src/controls/QuarterTurnFloater.css
@@ -66,6 +66,42 @@
 .qtb-btn:hover { background: rgba(255,255,255,0.12); }
 .qtb-btn:active { background: var(--cp-accent, #ffd400); color: #000; }
 
+/* Plane labels (e.g. "XY") render each letter in its axis color when a
+   getAxisColor prop is provided. The two child spans sit side by side. */
+.qtb-plane {
+  display: inline-flex;
+  gap: 1px;
+  font-weight: 700;
+}
+
+.qtb-row-drop {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid rgba(255,255,255,0.08);
+}
+.qtb-drop-buttons {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 3px;
+}
+.qtb-drop-btn {
+  height: 28px;
+  border-radius: 5px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.06);
+  color: #f0f0f3;
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+.qtb-drop-btn:hover { background: rgba(255,255,255,0.12); }
+.qtb-drop-btn-active {
+  background: var(--cp-accent, #ffd400);
+  color: #000;
+  border-color: var(--cp-accent, #ffd400);
+}
+
 .qtb-row-reset {
   margin-top: 4px;
   padding-top: 6px;

--- a/src/controls/QuarterTurnFloater.tsx
+++ b/src/controls/QuarterTurnFloater.tsx
@@ -2,24 +2,36 @@ import { useEffect, useRef, useState } from 'react';
 import { planes, Plane } from '@/math/constants';
 import './QuarterTurnFloater.css';
 
+export type AxisLetter = 'X' | 'Y' | 'U' | 'V';
+export type DropAxis = 'None' | 'DropX' | 'DropY' | 'DropU' | 'DropV';
+
 export interface QuarterTurnFloaterProps {
   /** Tap callback — animated 90° turn. */
   onTurn: (p: Plane, dir: 1 | -1) => void;
   /** Optional continuous-rotation callback driven by the floater's rAF loop. */
   onRotateBy?: (p: Plane, theta: number) => void;
   onReset?: () => void;
+  /** Optional per-axis colour, e.g. `axis => 'hsl(...)`. When provided, plane
+   *  labels render each letter in its axis colour. */
+  getAxisColor?: (axis: AxisLetter) => string;
+  /** Currently-selected drop axis (or 'None'). When provided, a Drop-axis
+   *  button row appears under the quarter-turn grid. */
+  dropAxis?: DropAxis;
+  /** Setter for the drop-axis selection. */
+  onDropAxisChange?: (d: DropAxis) => void;
 }
 
 const HOLD_THRESHOLD_MS = 220;     // how long before tap becomes hold
 const HOLD_RATE_RAD_PER_S = 1.5;   // ~86°/sec while holding
 
 /**
- * Floating cluster of unit-rotation buttons for the six 4D planes. Tap a
- * button for an animated 90° quarter turn. Press and hold to rotate
- * continuously in that plane (∼86°/sec). Includes a Reset orientation row.
- * Starts collapsed; tap the ↻ chip to expand.
+ * Floating cluster of unit-rotation buttons for the six 4D planes, plus an
+ * optional drop-axis row. Tap a quarter-turn button for an animated 90° turn,
+ * press-and-hold to rotate continuously. Starts collapsed; tap ↻ to expand.
  */
-export default function QuarterTurnFloater({ onTurn, onRotateBy, onReset }: QuarterTurnFloaterProps) {
+export default function QuarterTurnFloater({
+  onTurn, onRotateBy, onReset, getAxisColor, dropAxis, onDropAxisChange,
+}: QuarterTurnFloaterProps) {
   const [open, setOpen] = useState(false);
 
   if (!open) {
@@ -51,9 +63,36 @@ export default function QuarterTurnFloater({ onTurn, onRotateBy, onReset }: Quar
         <div className="qtb-label">↻</div>
         <div className="qtb-label">↺</div>
         {planes.map(p => (
-          <Row key={p} plane={p} onTurn={onTurn} onRotateBy={onRotateBy} />
+          <Row key={p} plane={p} onTurn={onTurn} onRotateBy={onRotateBy} getAxisColor={getAxisColor} />
         ))}
       </div>
+
+      {dropAxis !== undefined && onDropAxisChange && (
+        <div className="qtb-row-drop">
+          <div className="qtb-label" style={{ marginBottom: 4 }}>Drop axis</div>
+          <div className="qtb-drop-buttons">
+            <button
+              className={`qtb-drop-btn ${dropAxis === 'None' ? 'qtb-drop-btn-active' : ''}`}
+              onClick={() => onDropAxisChange('None')}
+              aria-pressed={dropAxis === 'None'}
+            >None</button>
+            {(['X', 'Y', 'U', 'V'] as const).map(letter => {
+              const key: DropAxis = `Drop${letter}`;
+              const active = dropAxis === key;
+              return (
+                <button
+                  key={letter}
+                  className={`qtb-drop-btn ${active ? 'qtb-drop-btn-active' : ''}`}
+                  onClick={() => onDropAxisChange(key)}
+                  aria-pressed={active}
+                  style={getAxisColor && !active ? { color: getAxisColor(letter) } : undefined}
+                >{letter}</button>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
       {onReset && (
         <div className="qtb-row-reset">
           <button className="qtb-reset" onClick={onReset}>Reset orientation</button>
@@ -64,15 +103,20 @@ export default function QuarterTurnFloater({ onTurn, onRotateBy, onReset }: Quar
 }
 
 function Row({
-  plane, onTurn, onRotateBy,
+  plane, onTurn, onRotateBy, getAxisColor,
 }: {
   plane: Plane;
   onTurn: (p: Plane, d: 1 | -1) => void;
   onRotateBy?: (p: Plane, theta: number) => void;
+  getAxisColor?: (axis: AxisLetter) => string;
 }) {
+  const [a, b] = [plane[0] as AxisLetter, plane[1] as AxisLetter];
   return (
     <>
-      <div className="qtb-label" style={{ alignSelf: 'center' }}>{plane}</div>
+      <div className="qtb-label qtb-plane" style={{ alignSelf: 'center' }}>
+        <span style={getAxisColor ? { color: getAxisColor(a) } : undefined}>{a}</span>
+        <span style={getAxisColor ? { color: getAxisColor(b) } : undefined}>{b}</span>
+      </div>
       <HoldButton plane={plane} direction={1} onTurn={onTurn} onRotateBy={onRotateBy} label="↻" />
       <HoldButton plane={plane} direction={-1} onTurn={onTurn} onRotateBy={onRotateBy} label="↺" />
     </>
@@ -129,7 +173,7 @@ function HoldButton({
 
   const onPointerUp = () => {
     const wasHeld = stop();
-    if (!wasHeld) onTurn(plane, direction); // simple tap → animated quarter turn
+    if (!wasHeld) onTurn(plane, direction);
   };
 
   const onPointerCancel = () => { stop(); };

--- a/src/lib/particles/createParticleGeometry.ts
+++ b/src/lib/particles/createParticleGeometry.ts
@@ -1,17 +1,21 @@
 import * as THREE from 'three';
 
-export function createParticleGeometry(particleCount: number): THREE.BufferGeometry {
+/** Build a square grid of `particleCount` points spread over a 2 × extent box,
+ *  i.e. x and z each range over [-extent, +extent]. The previous behavior
+ *  used a hard-coded extent of 4 (the grid spanned 8 × 8). */
+export function createParticleGeometry(particleCount: number, extent: number = 4): THREE.BufferGeometry {
   const side = Math.sqrt(particleCount);
   const geometry = new THREE.BufferGeometry();
   const positions = new Float32Array(particleCount * 3);
   const sizes = new Float32Array(particleCount).fill(1);
   const seeds = new Float32Array(particleCount * 4);
+  const span = extent * 2;
   let i = 0;
   for (let ix = 0; ix < side; ix++) {
     for (let iz = 0; iz < side; iz++) {
-      positions[3 * i] = (ix / side - 0.5) * 8;
+      positions[3 * i] = (ix / side - 0.5) * span;
       positions[3 * i + 1] = 0;
-      positions[3 * i + 2] = (iz / side - 0.5) * 8;
+      positions[3 * i + 2] = (iz / side - 0.5) * span;
       for (let k = 0; k < 4; k++) {
         seeds[4 * i + k] = Math.random();
       }
@@ -24,17 +28,22 @@ export function createParticleGeometry(particleCount: number): THREE.BufferGeome
   return geometry;
 }
 
-export function rebuildGeometryBuffers(geometry: THREE.BufferGeometry, particleCount: number): void {
+export function rebuildGeometryBuffers(
+  geometry: THREE.BufferGeometry,
+  particleCount: number,
+  extent: number = 4,
+): void {
   const side = Math.sqrt(particleCount);
   const pos = new Float32Array(particleCount * 3);
   const sizes = new Float32Array(particleCount).fill(1);
   const seeds = new Float32Array(particleCount * 4);
+  const span = extent * 2;
   let i = 0;
   for (let ix = 0; ix < side; ix++) {
     for (let iz = 0; iz < side; iz++) {
-      pos[3 * i] = (ix / side - 0.5) * 8;
+      pos[3 * i] = (ix / side - 0.5) * span;
       pos[3 * i + 1] = 0;
-      pos[3 * i + 2] = (iz / side - 0.5) * 8;
+      pos[3 * i + 2] = (iz / side - 0.5) * span;
       for (let k = 0; k < 4; k++) {
         seeds[4 * i + k] = Math.random();
       }

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -39,6 +39,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   const [hueShift, setHueShift] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.hueShift);
   const [jitter, setJitter] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.jitter);
   const [axisWidth, setAxisWidth] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.axisWidth);
+  /** Half-side of the sampled grid in input-space units. */
+  const [gridExtent, setGridExtent] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.gridExtent);
   const [objectMode, setObjectMode] = useState(false);
   const [shapeIndex, setShapeIndex] = useState(1);
   const [textureIndex, setTextureIndex] = useState(0);
@@ -120,6 +122,7 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     hueShift, setHueShift,
     jitter, setJitter,
     axisWidth, setAxisWidth,
+    gridExtent, setGridExtent,
     objectMode, setObjectMode,
     shapeIndex, setShapeIndex,
     textureIndex, setTextureIndex,

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -119,7 +119,7 @@ export function useUniformSync(state: ParticleState): void {
 
   useEffect(() => {
     if (geometryRef.current) {
-      rebuildGeometryBuffers(geometryRef.current, state.particleCount);
+      rebuildGeometryBuffers(geometryRef.current, state.particleCount, state.gridExtent);
     }
-  }, [state.particleCount]);
+  }, [state.particleCount, state.gridExtent]);
 }


### PR DESCRIPTION
## Summary

Three additions and one move on the Complex Particles viewer.

### 1. Coloured axis letters on the quarter-turn buttons

The `QuarterTurnFloater` plane labels (`XY`, `XU`, `XV`, `YU`, `YV`,
`UV`) now render each letter in its axis's HSL colour, tracked
through the current `hueShift`. The 4D quarter-turn list inside the
Actions drawer gets the same treatment. The floater takes a new
`getAxisColor` prop so the colour mapping lives in one place
(`ParticleViewerShell`, where `hueShift` is).

Screenshot HTML probe:
```html
<span style="color: rgb(255, 51, 51);">X</span>
<span style="color: rgb(153, 255, 51);">Y</span>
```

### 2. Drop axis on screen + in Actions

Moved the Drop axis pills out of the Camera section of Settings into:

- The **Actions** drawer (Pills row, same as before).
- The **`QuarterTurnFloater`** itself — a new row under the
  quarter-turn grid with **None / X / Y / U / V** buttons. Each letter
  is tinted with its axis colour; the active one inverts to the
  yellow accent. New floater props `dropAxis` and `onDropAxisChange`
  surface the same handler as the drawer pills.

### 3. Grid extent slider

A new **Grid extent (±)** slider in the Detail section lets you widen
or narrow the sampled (x, y) box. Default ±4 (the previous hard-coded
value), range 1–12 in 0.5 steps. `createParticleGeometry` and
`rebuildGeometryBuffers` gain an `extent` argument with a
backward-compatible default of 4; `useUniformSync` now rebuilds the
buffers when `gridExtent` changes.

### 4. Higher particle-count ceiling

`COMPLEX_PARTICLES_DEFAULTS.ranges.particleCount.max` bumped from
80 000 to **250 000** so the slider can drive higher input density.
The default (80 000) is unchanged.

## Adaptive density (the discussion item from the request)

> *wondering if there is a way to make the density dependent on the
> local rate of change so that the resultant plot is smoother*

This is doable but **not trivial enough to fold in here** — the
implementation changes the relationship between geometry, function,
and state in a way that's worth a separate review.

The cleanest approach is **importance sampling** by `|f'(z)|`:

1. Generate `kN` (e.g. 4 N) uniform candidates in the grid.
2. For each, compute `|f'(z)| ≈ |f(z + h) − f(z)| / |h|` using the CPU
   helpers already in `src/lib/complexMath.ts`.
3. Sample `N` of them with weight `|f'(z)|^α` (α tunes how aggressive
   the bias is; α = 1 puts samples roughly proportional to output-space
   density).

Tradeoffs and questions worth deciding before I implement:

- Geometry rebuild already happens on `particleCount`/`gridExtent`
  changes. Adaptive density adds a dependency on `functionIndex` (and
  `expP/expQ` for `z^(p/q)`), which means every function switch pays
  the rebuild cost (≈ 50–150 ms for 80 K particles). Acceptable?
- Should it be an opt-in toggle in Detail (default off so the math
  surprise stays opt-in), or always on?
- α as a slider (more vs less stretching compensation), or a fixed 1?
- What about functions with singularities (e.g. `1/z`)? `|f'|` blows
  up near 0; we'd want a clamp.

Happy to ship it on a fresh branch once you pick a direction.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [x] Playwright probe: floater's first plane label has two `<span>` children with `color: rgb(255, 51, 51)` (X axis red) and `color: rgb(153, 255, 51)` (Y axis green-yellow). Drop-axis row has 5 buttons.
- [x] Screenshot confirms the floater shows colored XY / XU / … rows and a Drop-axis row at the bottom with None highlighted.
- [ ] Real-device check that very high particle counts (200K+) render OK on a phone.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_