### PR TITLE
ControlPanel: force dark color-scheme on dropdown popups

### DIFF
--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -218,6 +218,18 @@
   padding: 6px 8px;
   font-size: 13px;
   width: 100%;
+  /* Tell the browser to render this widget's OS-native bits (the closed
+     control on some platforms, the dropdown popup with the options) in dark
+     mode. Without this, dark-mode OS users see light-on-light text in the
+     popup. */
+  color-scheme: dark;
+}
+/* Some browsers (Firefox, older Chromium) honour the option's own colors
+   in the popup; specifying them keeps the list readable even if
+   color-scheme is ignored. */
+.cp-row select option {
+  background: #0c0c10;
+  color: #f0f0f3;
 }
 .cp-row input[type="number"] { padding: 4px 6px; }
 .cp-row input[type="checkbox"] {


### PR DESCRIPTION
## Summary

Reported: the Function dropdown shows light-on-light text when the
user's OS is in dark mode.

The closed `<select>` widget picks up our CSS correctly, but the
OS-native dropdown popup that opens on click is governed by the page's
`color-scheme` property, which we never set — so the browser picks
whatever the OS prefers. On macOS dark mode that's a light popup with
our light text inside it.

Two layered fixes on `.cp-row select` in `ControlPanel.css`:

- **`color-scheme: dark`** — tells the browser to render this control's
  native bits, including the option list, in dark mode regardless of OS
  preference.
- **`.cp-row select option { background: #0c0c10; color: #f0f0f3 }`** —
  belt-and-braces: Firefox and older Chromium honour per-option colours
  in the popup, so this keeps the list readable even where
  `color-scheme` is ignored.

Light-themed pages (StableMarriage, AgenticSorting) aren't affected
because they use their own `<select>` styling, not `.cp-row`.

## Test plan

- [x] `vite build` clean.
- [ ] Real-device check on macOS Dark Mode: open the Settings drawer in Complex Particles, click the Function picker, confirm options read as light text on dark background.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_