### PR TITLE
Add Plane Transform module: f as a transformation of the plane

### DIFF
--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -1,0 +1,312 @@
+import React, { useEffect, useMemo, useRef, useState } from 'react';
+import * as THREE from 'three';
+import { ShellSettings, useAppHeader } from '../../components/AppShell';
+import { Section, Slider, Pills, Select } from '../../components/ControlPanel';
+import Readme from '../../components/Readme';
+import readmeText from './README.md?raw';
+import { functionNames, functionFormulas, POW_PQ_INDEX } from '../../lib/complexMath';
+import { vertexShader, fragmentShader } from './shaders';
+
+type ColourMode = 0 | 1 | 2;
+const COLOUR_MODE_LABELS: Record<ColourMode, string> = {
+  0: 'Smooth',
+  1: 'Tiles',
+  2: 'Grid only',
+};
+
+interface PaneRefs {
+  renderer?: THREE.WebGLRenderer;
+  scene?: THREE.Scene;
+  camera?: THREE.OrthographicCamera;
+  material?: THREE.ShaderMaterial;
+  points?: THREE.Points;
+}
+
+/**
+ * Plane-transform viewer: shows how a complex function sends the (x, y) input
+ * plane to the (u, v) output plane. Two square panes, side-by-side on a wide
+ * canvas, stacked top-bottom on a tall one. Same point cloud renders into
+ * both panes — the second pane's vertex shader runs the selected function so
+ * each colored point ends up at its f(z) location.
+ */
+export default function PlaneTransform() {
+  const [functionIndex, setFunctionIndex] = useState(() =>
+    Math.max(0, functionNames.indexOf('sin')),
+  );
+  const [expP, setExpP] = useState(1);
+  const [expQ, setExpQ] = useState(2);
+  const [branchIndex, setBranchIndex] = useState(0);
+  const [density, setDensity] = useState(240);          // points per side
+  const [pointSize, setPointSize] = useState(2.5);
+  const [viewExtent, setViewExtent] = useState(3);      // half-side of visible square
+  const [colourMode, setColourMode] = useState<ColourMode>(0);
+  const [saturation, setSaturation] = useState(0.85);
+  const [intensity, setIntensity] = useState(1.0);
+
+  const fnName = functionNames[functionIndex];
+  const fnFormula = functionIndex === POW_PQ_INDEX
+    ? `z^(${expP}/${expQ})`
+    : functionFormulas[fnName];
+  useAppHeader(fnName, fnFormula);
+
+  // Containers + refs for the two panes.
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const inputMountRef  = useRef<HTMLDivElement>(null);
+  const outputMountRef = useRef<HTMLDivElement>(null);
+  const inputPane  = useRef<PaneRefs>({});
+  const outputPane = useRef<PaneRefs>({});
+  const geometryRef = useRef<THREE.BufferGeometry>();
+
+  // Detect landscape vs portrait container shape so the panes stack correctly.
+  const [horizontal, setHorizontal] = useState(true);
+  useEffect(() => {
+    const el = wrapperRef.current;
+    if (!el) return;
+    const update = () => {
+      const r = el.getBoundingClientRect();
+      setHorizontal(r.width >= r.height);
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // Build the point cloud whenever the density or visible extent changes.
+  // Points are sampled in math coords so the vertex shader can just divide by
+  // viewExtent for the input pane and apply f then divide for the output pane.
+  useEffect(() => {
+    const n = density * density;
+    const inputPos = new Float32Array(n * 2);
+    const seeds    = new Float32Array(n * 4);
+    let k = 0;
+    for (let i = 0; i < density; i++) {
+      for (let j = 0; j < density; j++) {
+        const x = (i / (density - 1) - 0.5) * 2 * viewExtent;
+        const y = (j / (density - 1) - 0.5) * 2 * viewExtent;
+        inputPos[2 * k]     = x;
+        inputPos[2 * k + 1] = y;
+        seeds[4 * k]     = Math.random();
+        seeds[4 * k + 1] = Math.random();
+        seeds[4 * k + 2] = Math.random();
+        seeds[4 * k + 3] = Math.random();
+        k++;
+      }
+    }
+    const geom = new THREE.BufferGeometry();
+    geom.setAttribute('inputPos', new THREE.BufferAttribute(inputPos, 2));
+    geom.setAttribute('position', new THREE.BufferAttribute(new Float32Array(n * 3), 3));
+    geom.setAttribute('seed',     new THREE.BufferAttribute(seeds, 4));
+    geometryRef.current = geom;
+
+    if (inputPane.current.points)  inputPane.current.points.geometry  = geom;
+    if (outputPane.current.points) outputPane.current.points.geometry = geom;
+
+    return () => geom.dispose();
+  }, [density, viewExtent]);
+
+  // Mount and tear down both renderers.
+  useEffect(() => {
+    function mount(target: HTMLDivElement, transform: 0 | 1, store: React.MutableRefObject<PaneRefs>) {
+      const renderer = new THREE.WebGLRenderer({ antialias: true });
+      renderer.setPixelRatio(window.devicePixelRatio);
+      renderer.setClearColor(0x0c0c10);
+      target.appendChild(renderer.domElement);
+      renderer.domElement.style.display = 'block';
+      renderer.domElement.style.width = '100%';
+      renderer.domElement.style.height = '100%';
+
+      const scene = new THREE.Scene();
+      const camera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0, 1);
+      const material = new THREE.ShaderMaterial({
+        uniforms: {
+          viewExtent:    { value: viewExtent },
+          transform:     { value: transform },
+          functionType:  { value: functionIndex },
+          exponentP:     { value: expP },
+          exponentQ:     { value: expQ === 0 ? 1 : expQ },
+          branchIndex:   { value: branchIndex },
+          pointSize:     { value: pointSize },
+          colorMode:     { value: colourMode },
+          saturation:    { value: saturation },
+          intensity:     { value: intensity },
+        },
+        vertexShader,
+        fragmentShader,
+      });
+      const points = new THREE.Points(geometryRef.current!, material);
+      scene.add(points);
+      store.current = { renderer, scene, camera, material, points };
+    }
+
+    if (inputMountRef.current)  mount(inputMountRef.current,  0, inputPane);
+    if (outputMountRef.current) mount(outputMountRef.current, 1, outputPane);
+
+    let raf = 0;
+    const tick = () => {
+      const renderPane = (pane: PaneRefs, mountEl: HTMLDivElement | null) => {
+        if (!pane.renderer || !pane.scene || !pane.camera || !mountEl) return;
+        const r = mountEl.getBoundingClientRect();
+        // Render the canvas as a square that fits the smaller of the
+        // container's two dimensions, so the (x, y) view stays isotropic.
+        const size = Math.min(r.width, r.height);
+        if (size > 0 && (pane.renderer.domElement.width !== size * window.devicePixelRatio
+                      || pane.renderer.domElement.height !== size * window.devicePixelRatio)) {
+          pane.renderer.setSize(size, size, false);
+          pane.renderer.domElement.style.width  = `${size}px`;
+          pane.renderer.domElement.style.height = `${size}px`;
+        }
+        pane.renderer.render(pane.scene, pane.camera);
+      };
+      renderPane(inputPane.current,  inputMountRef.current);
+      renderPane(outputPane.current, outputMountRef.current);
+      raf = requestAnimationFrame(tick);
+    };
+    raf = requestAnimationFrame(tick);
+
+    return () => {
+      cancelAnimationFrame(raf);
+      for (const pane of [inputPane.current, outputPane.current]) {
+        pane.renderer?.dispose();
+        if (pane.renderer?.domElement.parentNode) {
+          pane.renderer.domElement.parentNode.removeChild(pane.renderer.domElement);
+        }
+      }
+      inputPane.current  = {};
+      outputPane.current = {};
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Sync uniforms when state changes.
+  useEffect(() => {
+    for (const pane of [inputPane.current, outputPane.current]) {
+      const m = pane.material; if (!m) continue;
+      m.uniforms.viewExtent.value   = viewExtent;
+      m.uniforms.functionType.value = functionIndex;
+      m.uniforms.exponentP.value    = expP;
+      m.uniforms.exponentQ.value    = expQ === 0 ? 1 : expQ;
+      m.uniforms.branchIndex.value  = branchIndex;
+      m.uniforms.pointSize.value    = pointSize;
+      m.uniforms.colorMode.value    = colourMode;
+      m.uniforms.saturation.value   = saturation;
+      m.uniforms.intensity.value    = intensity;
+    }
+  }, [viewExtent, functionIndex, expP, expQ, branchIndex, pointSize, colourMode, saturation, intensity]);
+
+  const PaneLabel = ({ children }: { children: React.ReactNode }) => (
+    <div style={{
+      position: 'absolute', top: 8, left: 12,
+      color: '#9b9ba3', fontSize: 12, letterSpacing: 0.06,
+      fontFamily: 'ui-monospace, SF Mono, Menlo, monospace',
+      textTransform: 'uppercase', pointerEvents: 'none', userSelect: 'none',
+    }}>{children}</div>
+  );
+
+  const isPow = functionIndex === POW_PQ_INDEX;
+  const isMulti = functionIndex === 1 /* sqrt */
+               || functionIndex === 3 /* ln */
+               || functionIndex === 14 /* branchSqrtPoly */
+               || isPow;
+
+  const colourPills = useMemo(() => (
+    [0, 1, 2] as ColourMode[]
+  ).map(m => ({ value: m, label: COLOUR_MODE_LABELS[m] })), []);
+
+  return (
+    <>
+      <div
+        ref={wrapperRef}
+        style={{
+          position: 'absolute', inset: 0,
+          display: 'flex',
+          flexDirection: horizontal ? 'row' : 'column',
+          alignItems: 'stretch',
+          gap: 1,
+          background: '#1a1a22',
+        }}
+      >
+        <div ref={inputMountRef} style={paneStyle}>
+          <PaneLabel>Input · z = x + iy</PaneLabel>
+        </div>
+        <div ref={outputMountRef} style={paneStyle}>
+          <PaneLabel>Output · w = f(z)</PaneLabel>
+        </div>
+      </div>
+
+      <ShellSettings>
+        <Section title="Function" icon="ƒ" defaultOpen>
+          <Select
+            label="Function"
+            options={functionNames.map((n, i) => ({ value: i, label: n }))}
+            value={functionIndex}
+            onChange={setFunctionIndex}
+          />
+          {isPow && (
+            <div style={{ display: 'flex', gap: 8 }}>
+              <label className="cp-row" style={{ flex: 1 }}>
+                <div className="cp-row-label"><span>p</span></div>
+                <input type="number" value={expP} step={1}
+                  onChange={e => setExpP(parseInt(e.target.value, 10) || 0)} />
+              </label>
+              <label className="cp-row" style={{ flex: 1 }}>
+                <div className="cp-row-label"><span>q</span></div>
+                <input type="number" value={expQ} step={1}
+                  onChange={e => setExpQ(parseInt(e.target.value, 10) || 1)} />
+              </label>
+            </div>
+          )}
+          {isMulti && (
+            <Select
+              label="Branch index"
+              options={[-2, -1, 0, 1, 2].map(b => ({ value: b, label: String(b) }))}
+              value={branchIndex}
+              onChange={setBranchIndex}
+            />
+          )}
+        </Section>
+
+        <Section title="Colour" icon="◐" defaultOpen>
+          <Pills
+            label="Mode"
+            options={colourPills}
+            value={colourMode}
+            onChange={setColourMode}
+          />
+          <Slider label="Saturation" value={saturation}
+            min={0} max={1} step={0.01}
+            onChange={setSaturation} format={v => v.toFixed(2)} />
+          <Slider label="Intensity" value={intensity}
+            min={0.3} max={1.5} step={0.05}
+            onChange={setIntensity} format={v => v.toFixed(2)} />
+        </Section>
+
+        <Section title="View" icon="◑">
+          <Slider label="Extent (±)" value={viewExtent}
+            min={0.5} max={10} step={0.5}
+            onChange={setViewExtent} format={v => v.toFixed(1)} />
+          <Slider label="Point size" value={pointSize}
+            min={1} max={6} step={0.5}
+            onChange={setPointSize} format={v => v.toFixed(1)} />
+          <Slider label="Density (per side)" value={density}
+            min={40} max={400} step={20}
+            onChange={setDensity} format={v => `${v}×${v}`} />
+        </Section>
+
+        <Section title="About" icon="ⓘ">
+          <Readme markdown={readmeText} />
+        </Section>
+      </ShellSettings>
+    </>
+  );
+}
+
+const paneStyle: React.CSSProperties = {
+  flex: 1,
+  position: 'relative',
+  background: '#0c0c10',
+  overflow: 'hidden',
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+};

--- a/src/animations/PlaneTransform/README.md
+++ b/src/animations/PlaneTransform/README.md
@@ -1,0 +1,35 @@
+# Plane transform
+
+Visualises a complex function `f : ℂ → ℂ` as a transformation of the
+plane: the left (or top) pane shows a colored grid of input points
+`z = x + iy`; the right (or bottom) pane shows the same colored points
+at their output positions `w = f(z)`. The colors are carried with each
+point, so you can trace how regions of the input map across the
+output.
+
+## Coloring modes
+
+* **Smooth** — hue ramps with `arg(z)`; lightness ramps in log-radius
+  bands. Gives concentric "rainbow rings".
+* **Tiles** — discrete polar tiles (12 sectors × log-radius rings)
+  with alternating lightness. Easier to count sectors.
+* **Grid only** — bright rays at every `π/6` and bright rings at
+  integer multiples of `e^0.5`; rest is dark. Reads as a polar grid.
+
+## Tips
+
+* The **Density** slider controls how many points per side are sampled
+  (200×200 = 40K points). Higher density = smoother coverage, slower
+  rebuild.
+* The **Extent (±)** slider controls how much of `ℂ` is visible — the
+  visible square is `[-extent, +extent] × [-extent, +extent]`.
+* For multi-valued functions (`sqrt`, `ln`, `√(z(z-1)(z+1))`, `z^(p/q)`),
+  use the **Branch index** selector to step through the sheets.
+
+## Why two panes?
+
+This visualisation is the classical "domain coloring" diagram from
+textbooks like Needham's *Visual Complex Analysis* and Wegert's
+*Visual Complex Functions*. The 4D-embedded view in
+[Complex Particles](#/) shows the function's graph; this view shows
+its action — which regions stretch, fold, and meet at branch points.

--- a/src/animations/PlaneTransform/shaders/index.ts
+++ b/src/animations/PlaneTransform/shaders/index.ts
@@ -1,0 +1,157 @@
+// Plane-transform shader pair. The vertex shader runs the selected complex
+// function on each input point, optionally; the fragment shader paints the
+// point with the chosen annular colouring scheme.
+
+export const vertexShader = `
+attribute vec2 inputPos;
+attribute vec4 seed;
+
+uniform float viewExtent;
+uniform int   transform;
+uniform int   functionType;
+uniform int   exponentP;
+uniform int   exponentQ;
+uniform int   branchIndex;
+uniform float pointSize;
+
+varying vec2 vSourcePos;
+
+// ---------- Complex helpers (matched to ComplexParticles' shader) ----------
+vec2 complexSqrt    (vec2 z){float r=length(z);float t=atan(z.y,z.x);float sr=sqrt(r);return vec2(sr*cos(t*0.5),sr*sin(t*0.5));}
+vec2 complexSquare  (vec2 z){return vec2(z.x*z.x-z.y*z.y, 2.*z.x*z.y);}
+vec2 complexLn      (vec2 z){float r=length(z);float t=atan(z.y,z.x);return vec2(log(r),t);}
+vec2 complexExp     (vec2 z){float ex=exp(z.x);return vec2(ex*cos(z.y),ex*sin(z.y));}
+vec2 complexSin     (vec2 z){vec2 iz=vec2(-z.y,z.x);vec2 e1=complexExp(iz);vec2 e2=complexExp(-iz);vec2 d=e1-e2;return vec2(d.y*0.5,-d.x*0.5);}
+vec2 complexCos     (vec2 z){vec2 iz=vec2(-z.y,z.x);vec2 e1=complexExp(iz);vec2 e2=complexExp(-iz);vec2 s=e1+e2;return vec2(s.x*0.5,s.y*0.5);}
+vec2 complexTan     (vec2 z){vec2 s=complexSin(z);vec2 c=complexCos(z);float d=c.x*c.x+c.y*c.y;if(d<1e-4)d=1e-4;return vec2((s.x*c.x+s.y*c.y)/d,(s.y*c.x-s.x*c.y)/d);}
+vec2 complexInv     (vec2 z){float d=z.x*z.x+z.y*z.y;if(d<1e-4)d=1e-4;return vec2(z.x/d,-z.y/d);}
+vec2 complexMul     (vec2 a, vec2 b){return vec2(a.x*b.x - a.y*b.y, a.x*b.y + a.y*b.x);}
+vec2 complexCube    (vec2 z){return vec2(z.x*z.x*z.x - 3.0*z.x*z.y*z.y, 3.0*z.x*z.x*z.y - z.y*z.y*z.y);}
+vec2 complexReciprocalCube(vec2 z){float d=dot(z,z);if(d<1e-6)d=1e-6;vec2 z3=complexCube(z);d=d*d*d;return vec2(z3.x/d, -z3.y/d);}
+vec2 complexJoukowski(vec2 z){vec2 inv=complexInv(z);return vec2(0.5*(z.x+inv.x),0.5*(z.y+inv.y));}
+vec2 complexRational22(vec2 z){vec2 num=vec2(z.x*z.x - z.y*z.y + 1.0, 2.0*z.x*z.y);vec2 den=vec2(z.x*z.x - z.y*z.y - 1.0, 2.0*z.x*z.y);vec2 invd=complexInv(den);return vec2(num.x*invd.x - num.y*invd.y, num.x*invd.y + num.y*invd.x);}
+vec2 complexEssentialExpInv(vec2 z){float r2=dot(z,z);if(r2<1e-6)r2=1e-6;vec2 inv=vec2(z.x/r2,-z.y/r2);return complexExp(inv);}
+
+vec2 complexSqrtBranch(vec2 z, int b){
+  float r=length(z); float t=atan(z.y,z.x);
+  float sr=sqrt(r);
+  t = t*0.5 + float(b)*3.14159265359;
+  return vec2(sr*cos(t), sr*sin(t));
+}
+vec2 complexLnBranch(vec2 z, int b){
+  float r=length(z); float t=atan(z.y,z.x)+float(b)*6.28318530718;
+  return vec2(log(r), t);
+}
+vec2 complexBranchSqrtPoly(vec2 z, int b){
+  vec2 a=vec2(z.x-1.0, z.y); vec2 bb=vec2(z.x+1.0, z.y);
+  vec2 p=vec2(z.x*a.x - z.y*a.y, z.x*a.y + z.y*a.x);
+  vec2 q=vec2(p.x*bb.x - p.y*bb.y, p.x*bb.y + p.y*bb.x);
+  return complexSqrtBranch(q, b);
+}
+vec2 complexGamma(vec2 z){
+  const float PI = 3.141592653589793;
+  vec2 logZ = complexLn(z);
+  vec2 t = complexMul(z - vec2(0.5, 0.0), logZ) - z + vec2(0.5*log(2.0*PI), 0.0);
+  return complexExp(t);
+}
+vec2 complexCbrt(vec2 z){float r=length(z);float a=atan(z.y,z.x);float rr=pow(r, 1.0/3.0);return vec2(rr*cos(a/3.0), rr*sin(a/3.0));}
+vec2 complexZMinus1OverZPlus1(vec2 z){vec2 num=vec2(z.x-1.0, z.y);vec2 denInv=complexInv(vec2(z.x+1.0, z.y));return vec2(num.x*denInv.x - num.y*denInv.y, num.x*denInv.y + num.y*denInv.x);}
+vec2 complexPowRational(vec2 z, int p, int q){
+  float r=length(z); if(r<1e-6) return vec2(0.0);
+  int qSafe = q==0 ? 1 : q;
+  float pq = float(p)/float(qSafe);
+  float t = atan(z.y, z.x) + float(branchIndex)*6.28318530718;
+  float rpq = pow(r, pq);
+  float ang = t*pq;
+  return vec2(rpq*cos(ang), rpq*sin(ang));
+}
+
+vec2 applyComplex(vec2 z, int t){
+  if(t==0)  return z;
+  if(t==1)  return complexSqrtBranch(z, branchIndex);
+  if(t==2)  return complexSquare(z);
+  if(t==3)  return complexLnBranch(z, branchIndex);
+  if(t==4)  return complexExp(z);
+  if(t==5)  return complexSin(z);
+  if(t==6)  return complexCos(z);
+  if(t==7)  return complexTan(z);
+  if(t==8)  return complexInv(z);
+  if(t==9)  return complexCube(z);
+  if(t==10) return complexReciprocalCube(z);
+  if(t==11) return complexJoukowski(z);
+  if(t==12) return complexRational22(z);
+  if(t==13) return complexEssentialExpInv(z);
+  if(t==14) return complexBranchSqrtPoly(z, branchIndex);
+  if(t==15) return complexGamma(z);
+  if(t==16) return complexCbrt(z);
+  if(t==17) return complexZMinus1OverZPlus1(z);
+  if(t==18) return complexPowRational(z, exponentP, exponentQ);
+  return z;
+}
+
+void main(){
+  vSourcePos = inputPos;
+  vec2 pos = transform == 1 ? applyComplex(inputPos, functionType) : inputPos;
+  // Clip giants so we don't lose all colour to one stray point at infinity.
+  if(length(pos) > 1e3) pos = normalize(pos)*1e3;
+  // Map to clip space using viewExtent (= half-side of the visible square).
+  gl_Position = vec4(pos / viewExtent, 0.0, 1.0);
+  gl_PointSize = pointSize;
+}
+`;
+
+export const fragmentShader = `
+precision highp float;
+
+uniform int   colorMode;   // 0 = smooth, 1 = discrete tiles, 2 = grid only
+uniform float saturation;
+uniform float intensity;
+varying vec2 vSourcePos;
+
+const float TAU = 6.28318530718;
+const float PI  = 3.14159265359;
+
+vec3 hsv2rgb(vec3 c){
+  vec4 K = vec4(1.0, 2.0/3.0, 1.0/3.0, 3.0);
+  vec3 p = abs(fract(c.xxx + K.xyz)*6.0 - K.www);
+  return c.z * mix(K.xxx, clamp(p - K.xxx, 0.0, 1.0), c.y);
+}
+
+vec3 colourFor(vec2 z, int mode){
+  float r = length(z);
+  float a = atan(z.y, z.x);
+  float hue = fract(a / TAU + 1.0);
+
+  if(mode == 0){
+    // Smooth annular: hue from arg, lightness banded by log r mod 1.
+    float band = fract(log(r + 1e-3) / 0.5);
+    float v = 0.35 + 0.55 * band;
+    return hsv2rgb(vec3(hue, saturation, v));
+  } else if(mode == 1){
+    // Discrete tiles: 8 angular sectors × log-radius rings, alternating
+    // lightness so neighboring tiles read distinctly.
+    int sector = int(floor((a + PI) / (TAU / 12.0)));
+    int ring   = int(floor(log(r + 1e-3) / 0.5));
+    float sectorHue = float(sector) / 12.0;
+    int parity = int(mod(float(ring), 2.0));
+    float lightness = parity == 0 ? 0.55 : 0.28;
+    return hsv2rgb(vec3(sectorHue, saturation, lightness));
+  } else {
+    // Grid only: dark background, bright stripes near integer radii and
+    // ray angles. Lines glow with the local hue.
+    float ringD  = abs(log(r + 1e-3) / 0.5 - floor(log(r + 1e-3) / 0.5 + 0.5));
+    float rayD   = abs(a / (PI / 6.0) - floor(a / (PI / 6.0) + 0.5));
+    float ring = smoothstep(0.08, 0.0, ringD);
+    float ray  = smoothstep(0.05, 0.0, rayD);
+    float onGrid = max(ring, ray);
+    return hsv2rgb(vec3(hue, saturation, 0.8)) * onGrid;
+  }
+}
+
+void main(){
+  vec2 d = gl_PointCoord - vec2(0.5);
+  if(dot(d,d) > 0.25) discard;        // round sprite
+  vec3 col = colourFor(vSourcePos, colorMode) * intensity;
+  gl_FragColor = vec4(col, 1.0);
+}
+`;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,12 +6,14 @@ import { AppShell, AppDescriptor } from './components/AppShell';
 const FractalsGPU = React.lazy(() => import('./animations/FractalsGPU/FractalsGPU'));
 const Fractals2D = React.lazy(() => import('./animations/Fractals/Fractals2D'));
 const Correspondence = React.lazy(() => import('./animations/Correspondence/Correspondence'));
+const PlaneTransform = React.lazy(() => import('./animations/PlaneTransform/PlaneTransform'));
 const MobiusWalk = React.lazy(() => import('./animations/MobiusWalk/MobiusWalk'));
 const StableMarriage = React.lazy(() => import('./animations/StableMarriage/StableMarriage'));
 const AgenticSorting = React.lazy(() => import('./animations/AgenticSorting/AgenticSorting'));
 
 const apps: AppDescriptor[] = [
   { hash: '/', name: 'Complex Particles', icon: '✦' },
+  { hash: '/plane-transform', name: 'Plane Transform', icon: '↦' },
   { hash: '/fractals', name: 'Fractals', icon: '◯' },
   { hash: '/correspondence', name: 'Mandelbrot ↔ Julia', icon: '⇄' },
   { hash: '/mobius', name: 'Möbius Walk', icon: '∞' },
@@ -21,6 +23,7 @@ const apps: AppDescriptor[] = [
 
 const routes: Record<string, React.ComponentType> = {
   '/': App,
+  '/plane-transform': PlaneTransform,
   '/fractals': FractalsGPU,
   '/fractals-cpu': Fractals2D,
   '/correspondence': Correspondence,


### PR DESCRIPTION
## Summary

New module at **`#/plane-transform`** — shows a complex function as it
acts on the input plane. The classic `z ↔ f(z)` side-by-side from
Needham / Wegert, rendered as a colored point cloud.

### Layout

A single wrapper holds two square panes that share one geometry
buffer.

- **Landscape** container (wrapper width ≥ height): side-by-side.
- **Portrait** container: stacked top-to-bottom.

A `ResizeObserver` on the wrapper drives the swap — so a desktop
window that gets tall, or a phone rotated to landscape, both end up
with the natural orientation. No window-level logic.

### What you see

| Pane | Position | Colour |
|---|---|---|
| Left / top | `(x, y)` — the input point | Carried by the point |
| Right / bottom | `f(x + iy)` — the image | Same colour as the input point |

So you can trace any colored region in the input pane to its image in
the output: see where branches cuts open, where the function stretches
the plane, etc.

### Settings (drawer)

- **Function** — same dispatch as Complex Particles (`applyComplex`
  + `complexPowRational`); all 18 named functions plus `z^(p/q)` with
  `p` / `q` inputs. Branch-index selector appears for the multi-valued
  ones (sqrt, ln, branchSqrtPoly, powPQ).
- **Colour** — Pills choose between:
  - **Smooth** — hue = arg(z); log-radius bands for lightness.
  - **Tiles** — 12 polar sectors × log-radius rings with alternating
    lightness.
  - **Grid only** — bright rays at every π/6 and bright rings at
    integer multiples of e^0.5 on dark background.
- **View** — Extent (±), point size, density (N × N). Geometry
  rebuilds when density or extent changes so math coords stay
  anchored.

### Implementation

- `src/animations/PlaneTransform/PlaneTransform.tsx` — two
  `THREE.WebGLRenderer`s, two `ShaderMaterial`s sharing one geometry.
  The vertex shader's `transform` uniform switches between identity
  (input pane) and `applyComplex(z, functionType)` (output pane),
  then divides by `viewExtent` for clip space.
- `src/animations/PlaneTransform/shaders/index.ts` — mirrors
  ComplexParticles' GLSL for the 18 named functions; fragment shader
  does the three colouring modes.
- `src/animations/PlaneTransform/README.md` — user-facing notes,
  rendered in the About section.

Route registered in `src/index.tsx` with icon `↦`.

## Test plan

- [x] `tsc --noEmit` + `vite build` clean.
- [x] Playwright at 1280×800 and 390×844: 2 canvases mount, bar title shows the function name, zero console errors.
- [x] Screenshot at landscape: both panes side by side, sin(z) maps the colored square into the expected vase shape.
- [x] Screenshot at portrait (390×844): stacked top-bottom.
- [ ] Real-device touch — pan/pinch is not wired yet (no useViewportGestures yet). The visible region is controlled by the Extent slider.

## Follow-ups worth considering

- Wire `useViewportGestures` on the input pane so pinching the left pane drives `viewExtent`. Both panes already share `viewExtent`, so the output pane will follow naturally.
- Add a "lock zoom across panes" toggle for when you want the right pane to zoom independently.
- A small grid-overlay (always-on, in addition to the point cloud) for the input pane, so the colored rings have explicit polar grid lines.

https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_