### PR TITLE
AppShell ƒ picker + PlaneTransform curve floater

### DIFF
--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -310,6 +310,11 @@ export default function ComplexParticles({
       functionFormula={displayFormula}
       functionPicker={functionPicker}
       variantExtras={variantExtras}
+      functionList={{
+        names: functionNames,
+        currentIndex: functionIndex,
+        onChangeIndex: setFunctionIndex,
+      }}
       readme={readmeText}
     />
   );

--- a/src/animations/PlaneTransform/PlaneCurveFloater.css
+++ b/src/animations/PlaneTransform/PlaneCurveFloater.css
@@ -1,0 +1,132 @@
+.pcf {
+  position: absolute;
+  bottom: 16px;
+  left: 16px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(12, 12, 16, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  min-width: 200px;
+}
+
+.pcf-collapsed { padding: 4px; }
+
+.pcf-toggle {
+  background: transparent;
+  border: none;
+  color: #f0f0f3;
+  font-size: 16px;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pcf-toggle:hover { background: rgba(255,255,255,0.08); }
+
+.pcf-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pcf-title {
+  font-size: 11px;
+  color: #9b9ba3;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pcf-close {
+  background: transparent;
+  border: none;
+  color: #9b9ba3;
+  cursor: pointer;
+  font-size: 16px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pcf-close:hover { background: rgba(255,255,255,0.08); color: #f0f0f3; }
+
+.pcf-row {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.pcf-label {
+  font-size: 10px;
+  color: #9b9ba3;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pcf-draw-btn {
+  width: 100%;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: rgba(255,255,255,0.06);
+  color: #f0f0f3;
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.pcf-draw-btn:hover { background: rgba(255,255,255,0.12); }
+.pcf-draw-btn-active {
+  background: var(--cp-accent, #ffd400);
+  color: #000;
+  border-color: var(--cp-accent, #ffd400);
+}
+
+.pcf-curve-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
+}
+
+.pcf-curve-btn {
+  padding: 6px 4px;
+  border-radius: 5px;
+  border: 1px solid rgba(255,255,255,0.1);
+  background: rgba(255,255,255,0.04);
+  color: #f0f0f3;
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  text-align: center;
+}
+.pcf-curve-btn:hover { background: rgba(255,255,255,0.12); }
+
+.pcf-clear {
+  width: 100%;
+  padding: 6px;
+  border-radius: 6px;
+  border: 1px solid rgba(255,255,255,0.12);
+  background: transparent;
+  color: #f0f0f3;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  cursor: pointer;
+}
+.pcf-clear:hover { background: rgba(255,255,255,0.08); }
+.pcf-clear:disabled { color: #4a4a52; cursor: not-allowed; }
+.pcf-clear:disabled:hover { background: transparent; }

--- a/src/animations/PlaneTransform/PlaneCurveFloater.tsx
+++ b/src/animations/PlaneTransform/PlaneCurveFloater.tsx
@@ -1,0 +1,98 @@
+import { useState } from 'react';
+import './PlaneCurveFloater.css';
+
+export type StandardCurveName =
+  | 'circle'
+  | 'square'
+  | 'horizontal'
+  | 'vertical'
+  | 'diagonal'
+  | 'spiral'
+  | 'lemniscate'
+  | 'cross'
+  | 'cardioid';
+
+export const STANDARD_CURVES: { id: StandardCurveName; label: string }[] = [
+  { id: 'circle',     label: 'Circle' },
+  { id: 'square',     label: 'Square' },
+  { id: 'horizontal', label: 'X-axis' },
+  { id: 'vertical',   label: 'Y-axis' },
+  { id: 'diagonal',   label: 'Diag' },
+  { id: 'cross',      label: 'Cross' },
+  { id: 'spiral',     label: 'Spiral' },
+  { id: 'lemniscate', label: '∞' },
+  { id: 'cardioid',   label: 'Heart' },
+];
+
+export interface PlaneCurveFloaterProps {
+  drawMode: boolean;
+  onToggleDraw: () => void;
+  onStandardCurve: (id: StandardCurveName) => void;
+  onClear: () => void;
+  hasCurve: boolean;
+}
+
+/** Floating panel for the Plane Transform module. Drives the curve overlay
+ *  on the input pane: pick a stock curve, toggle freehand drawing, or clear
+ *  the current curve. Mirrors the look of QuarterTurnFloater. */
+export default function PlaneCurveFloater({
+  drawMode, onToggleDraw, onStandardCurve, onClear, hasCurve,
+}: PlaneCurveFloaterProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <div className="pcf pcf-collapsed">
+        <button
+          className="pcf-toggle"
+          onClick={() => setOpen(true)}
+          aria-label="Show curve drawing panel"
+          title="Curve"
+        >✎</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pcf">
+      <div className="pcf-header">
+        <span className="pcf-title">Curve</span>
+        <button
+          className="pcf-close"
+          onClick={() => setOpen(false)}
+          aria-label="Hide curve panel"
+        >×</button>
+      </div>
+
+      <div className="pcf-row">
+        <button
+          className={`pcf-draw-btn ${drawMode ? 'pcf-draw-btn-active' : ''}`}
+          onClick={onToggleDraw}
+          aria-pressed={drawMode}
+        >
+          {drawMode ? '● Drawing — tap to stop' : '✎ Draw on input'}
+        </button>
+      </div>
+
+      <div className="pcf-row">
+        <div className="pcf-label">Standard curves</div>
+        <div className="pcf-curve-grid">
+          {STANDARD_CURVES.map(c => (
+            <button
+              key={c.id}
+              className="pcf-curve-btn"
+              onClick={() => onStandardCurve(c.id)}
+              title={c.id}
+            >{c.label}</button>
+          ))}
+        </div>
+      </div>
+
+      <button
+        className="pcf-clear"
+        onClick={onClear}
+        disabled={!hasCurve}
+      >Clear</button>
+    </div>
+  );
+}

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -1,11 +1,16 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
-import { ShellSettings, useAppHeader } from '../../components/AppShell';
+import { ShellSettings, useAppHeader, useAppFunctions } from '../../components/AppShell';
 import { Section, Slider, Pills, Select } from '../../components/ControlPanel';
 import Readme from '../../components/Readme';
 import readmeText from './README.md?raw';
-import { functionNames, functionFormulas, POW_PQ_INDEX } from '../../lib/complexMath';
+import {
+  functionNames, functionFormulas, POW_PQ_INDEX,
+  applyComplexBranch, complexPowRational,
+} from '../../lib/complexMath';
 import { vertexShader, fragmentShader } from './shaders';
+import PlaneCurveFloater, { type StandardCurveName } from './PlaneCurveFloater';
+import { buildStandardCurve, type CurvePoint } from './standardCurves';
 
 type ColourMode = 0 | 1 | 2;
 const COLOUR_MODE_LABELS: Record<ColourMode, string> = {
@@ -42,12 +47,22 @@ export default function PlaneTransform() {
   const [colourMode, setColourMode] = useState<ColourMode>(0);
   const [saturation, setSaturation] = useState(0.85);
   const [intensity, setIntensity] = useState(1.0);
+  const [curve, setCurve] = useState<CurvePoint[]>([]);
+  const [drawMode, setDrawMode] = useState(false);
 
   const fnName = functionNames[functionIndex];
   const fnFormula = functionIndex === POW_PQ_INDEX
     ? `z^(${expP}/${expQ})`
     : functionFormulas[fnName];
   useAppHeader(fnName, fnFormula);
+  useAppFunctions({
+    names: functionNames,
+    current: fnName,
+    onChange: (name) => {
+      const i = functionNames.indexOf(name);
+      if (i >= 0) setFunctionIndex(i);
+    },
+  });
 
   // Containers + refs for the two panes.
   const wrapperRef = useRef<HTMLDivElement>(null);
@@ -194,12 +209,30 @@ export default function PlaneTransform() {
     }
   }, [viewExtent, functionIndex, expP, expQ, branchIndex, pointSize, colourMode, saturation, intensity]);
 
+  // Map a curve through the active complex function to get the output polyline.
+  const outputCurve = useMemo<CurvePoint[]>(() => {
+    if (curve.length === 0) return [];
+    const tmp = new THREE.Vector2();
+    return curve.map(([x, y]) => {
+      tmp.set(x, y);
+      const w = functionIndex === POW_PQ_INDEX
+        ? complexPowRational(tmp, expP, expQ === 0 ? 1 : expQ)
+        : applyComplexBranch(tmp, functionIndex, branchIndex);
+      return [w.x, w.y] as CurvePoint;
+    });
+  }, [curve, functionIndex, expP, expQ, branchIndex]);
+
+  const handleStandardCurve = (id: StandardCurveName) => {
+    setCurve(buildStandardCurve(id, viewExtent));
+  };
+
   const PaneLabel = ({ children }: { children: React.ReactNode }) => (
     <div style={{
       position: 'absolute', top: 8, left: 12,
       color: '#9b9ba3', fontSize: 12, letterSpacing: 0.06,
       fontFamily: 'ui-monospace, SF Mono, Menlo, monospace',
       textTransform: 'uppercase', pointerEvents: 'none', userSelect: 'none',
+      zIndex: 2,
     }}>{children}</div>
   );
 
@@ -226,13 +259,35 @@ export default function PlaneTransform() {
           background: '#1a1a22',
         }}
       >
-        <div ref={inputMountRef} style={paneStyle}>
+        <InputPane
+          mountRef={inputMountRef}
+          viewExtent={viewExtent}
+          drawMode={drawMode}
+          curve={curve}
+          onAppendCurve={(pt, fresh) => {
+            setCurve(prev => fresh ? [pt] : [...prev, pt]);
+          }}
+          onWheelZoom={(factor) => setViewExtent(v => Math.min(20, Math.max(0.2, v * factor)))}
+        >
           <PaneLabel>Input · z = x + iy</PaneLabel>
-        </div>
-        <div ref={outputMountRef} style={paneStyle}>
+        </InputPane>
+        <OutputPane
+          mountRef={outputMountRef}
+          viewExtent={viewExtent}
+          curve={outputCurve}
+          onWheelZoom={(factor) => setViewExtent(v => Math.min(20, Math.max(0.2, v * factor)))}
+        >
           <PaneLabel>Output · w = f(z)</PaneLabel>
-        </div>
+        </OutputPane>
       </div>
+
+      <PlaneCurveFloater
+        drawMode={drawMode}
+        onToggleDraw={() => setDrawMode(d => !d)}
+        onStandardCurve={handleStandardCurve}
+        onClear={() => { setCurve([]); setDrawMode(false); }}
+        hasCurve={curve.length > 0}
+      />
 
       <ShellSettings>
         <Section title="Function" icon="ƒ" defaultOpen>
@@ -298,6 +353,217 @@ export default function PlaneTransform() {
         </Section>
       </ShellSettings>
     </>
+  );
+}
+
+/* ------------------------------------------------------------------ *
+ *  Pane sub-components.                                              *
+ *  Both render the Three.js canvas + an SVG overlay sized to the     *
+ *  centered square in which the renderer draws. The input pane also  *
+ *  owns the pointer handlers that capture freehand curve strokes.    *
+ * ------------------------------------------------------------------ */
+
+function useInscribedSquare(ref: React.RefObject<HTMLDivElement>) {
+  const [box, setBox] = useState({ w: 0, h: 0, size: 0, offX: 0, offY: 0 });
+  useEffect(() => {
+    const el = ref.current; if (!el) return;
+    const update = () => {
+      const r = el.getBoundingClientRect();
+      const size = Math.min(r.width, r.height);
+      setBox({
+        w: r.width, h: r.height, size,
+        offX: (r.width - size) / 2,
+        offY: (r.height - size) / 2,
+      });
+    };
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [ref]);
+  return box;
+}
+
+interface PaneCommon {
+  mountRef: React.RefObject<HTMLDivElement>;
+  viewExtent: number;
+  curve: CurvePoint[];
+  onWheelZoom: (factor: number) => void;
+  children?: React.ReactNode;
+}
+
+function CurveSvg({ box, viewExtent, points }: {
+  box: { w: number; h: number; size: number; offX: number; offY: number };
+  viewExtent: number;
+  points: CurvePoint[];
+}) {
+  if (box.size === 0 || points.length === 0) return null;
+  const cx = box.offX + box.size / 2;
+  const cy = box.offY + box.size / 2;
+  const sx = box.size / (2 * viewExtent);
+  // Clip wildly-large points (e.g. 1/z near origin) so the path stays inside
+  // the SVG; matches the shader's `length(pos) > 1e3` cap.
+  const MAX = 1e3;
+  const d = points.map(([x, y], i) => {
+    const cx0 = Math.max(-MAX, Math.min(MAX, x));
+    const cy0 = Math.max(-MAX, Math.min(MAX, y));
+    const px = cx + cx0 * sx;
+    const py = cy - cy0 * sx;
+    return `${i === 0 ? 'M' : 'L'} ${px.toFixed(2)} ${py.toFixed(2)}`;
+  }).join(' ');
+  return (
+    <svg
+      width={box.w} height={box.h}
+      style={{ position: 'absolute', inset: 0, pointerEvents: 'none', zIndex: 1 }}
+    >
+      <path d={d} stroke="#ffffff" strokeOpacity={0.9} strokeWidth={2}
+            fill="none" strokeLinejoin="round" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+function InputPane({
+  mountRef, viewExtent, drawMode, curve, onAppendCurve, onWheelZoom, children,
+}: PaneCommon & {
+  drawMode: boolean;
+  onAppendCurve: (pt: CurvePoint, fresh: boolean) => void;
+}) {
+  const box = useInscribedSquare(mountRef);
+  const drawingRef = useRef(false);
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchRef = useRef<{ dist: number } | null>(null);
+
+  const toMath = (clientX: number, clientY: number): CurvePoint | null => {
+    const el = mountRef.current; if (!el || box.size === 0) return null;
+    const r = el.getBoundingClientRect();
+    const sx = box.size / (2 * viewExtent);
+    const cx = r.left + box.offX + box.size / 2;
+    const cy = r.top  + box.offY + box.size / 2;
+    return [(clientX - cx) / sx, -(clientY - cy) / sx];
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+
+    if (pointersRef.current.size >= 2) {
+      // Starting a pinch — drop any in-progress freehand stroke.
+      drawingRef.current = false;
+      const pts = [...pointersRef.current.values()];
+      pinchRef.current = { dist: Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y) };
+      return;
+    }
+
+    if (drawMode) {
+      const p = toMath(e.clientX, e.clientY);
+      if (!p) return;
+      drawingRef.current = true;
+      onAppendCurve(p, true);
+    }
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    const rec = pointersRef.current.get(e.pointerId);
+    if (!rec) return;
+    rec.x = e.clientX; rec.y = e.clientY;
+
+    if (pointersRef.current.size >= 2 && pinchRef.current) {
+      const pts = [...pointersRef.current.values()];
+      const newDist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+      if (newDist > 1e-3 && pinchRef.current.dist > 1e-3) {
+        const factor = pinchRef.current.dist / newDist;
+        onWheelZoom(factor);
+      }
+      pinchRef.current.dist = newDist;
+      return;
+    }
+
+    if (drawingRef.current) {
+      const p = toMath(e.clientX, e.clientY);
+      if (p) onAppendCurve(p, false);
+    }
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    pointersRef.current.delete(e.pointerId);
+    if (pointersRef.current.size < 2) pinchRef.current = null;
+    if (pointersRef.current.size === 0) drawingRef.current = false;
+  };
+
+  const onWheel = (e: React.WheelEvent) => {
+    const factor = Math.exp(e.deltaY * 0.0015);
+    onWheelZoom(factor);
+  };
+
+  return (
+    <div
+      ref={mountRef}
+      style={{
+        ...paneStyle,
+        cursor: drawMode ? 'crosshair' : 'default',
+        touchAction: 'none',
+      }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onWheel={onWheel}
+    >
+      {children}
+      <CurveSvg box={box} viewExtent={viewExtent} points={curve} />
+    </div>
+  );
+}
+
+function OutputPane({
+  mountRef, viewExtent, curve, onWheelZoom, children,
+}: PaneCommon) {
+  const box = useInscribedSquare(mountRef);
+  const pointersRef = useRef(new Map<number, { x: number; y: number }>());
+  const pinchRef = useRef<{ dist: number } | null>(null);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    pointersRef.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
+    if (pointersRef.current.size === 2) {
+      const pts = [...pointersRef.current.values()];
+      pinchRef.current = { dist: Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y) };
+    }
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const rec = pointersRef.current.get(e.pointerId);
+    if (!rec) return;
+    rec.x = e.clientX; rec.y = e.clientY;
+    if (pointersRef.current.size >= 2 && pinchRef.current) {
+      const pts = [...pointersRef.current.values()];
+      const newDist = Math.hypot(pts[0].x - pts[1].x, pts[0].y - pts[1].y);
+      if (newDist > 1e-3 && pinchRef.current.dist > 1e-3) {
+        onWheelZoom(pinchRef.current.dist / newDist);
+      }
+      pinchRef.current.dist = newDist;
+    }
+  };
+  const onPointerUp = (e: React.PointerEvent) => {
+    pointersRef.current.delete(e.pointerId);
+    if (pointersRef.current.size < 2) pinchRef.current = null;
+  };
+  const onWheel = (e: React.WheelEvent) => {
+    onWheelZoom(Math.exp(e.deltaY * 0.0015));
+  };
+
+  return (
+    <div
+      ref={mountRef}
+      style={{ ...paneStyle, touchAction: 'none' }}
+      onPointerDown={onPointerDown}
+      onPointerMove={onPointerMove}
+      onPointerUp={onPointerUp}
+      onPointerCancel={onPointerUp}
+      onWheel={onWheel}
+    >
+      {children}
+      <CurveSvg box={box} viewExtent={viewExtent} points={curve} />
+    </div>
   );
 }
 

--- a/src/animations/PlaneTransform/standardCurves.ts
+++ b/src/animations/PlaneTransform/standardCurves.ts
@@ -1,0 +1,116 @@
+import type { StandardCurveName } from './PlaneCurveFloater';
+
+export type CurvePoint = [number, number];
+
+/** Build one of the named stock curves at a scale appropriate for the
+ *  current viewExtent. All curves are sampled densely enough that even highly
+ *  warping functions render smooth output polylines (gamma, 1/z, etc.). */
+export function buildStandardCurve(id: StandardCurveName, viewExtent: number): CurvePoint[] {
+  const r = viewExtent * 0.6;
+  const pts: CurvePoint[] = [];
+
+  switch (id) {
+    case 'circle': {
+      const N = 256;
+      for (let i = 0; i <= N; i++) {
+        const t = (i / N) * Math.PI * 2;
+        pts.push([r * Math.cos(t), r * Math.sin(t)]);
+      }
+      return pts;
+    }
+    case 'square': {
+      const side = r;
+      const perEdge = 64;
+      const corners: CurvePoint[] = [
+        [-side, -side], [ side, -side], [ side,  side], [-side,  side], [-side, -side],
+      ];
+      for (let e = 0; e < 4; e++) {
+        const [x0, y0] = corners[e];
+        const [x1, y1] = corners[e + 1];
+        for (let i = 0; i < perEdge; i++) {
+          const a = i / perEdge;
+          pts.push([x0 + (x1 - x0) * a, y0 + (y1 - y0) * a]);
+        }
+      }
+      pts.push(corners[0]);
+      return pts;
+    }
+    case 'horizontal': {
+      const N = 256;
+      const span = viewExtent * 0.95;
+      for (let i = 0; i <= N; i++) {
+        pts.push([-span + (2 * span) * (i / N), 0]);
+      }
+      return pts;
+    }
+    case 'vertical': {
+      const N = 256;
+      const span = viewExtent * 0.95;
+      for (let i = 0; i <= N; i++) {
+        pts.push([0, -span + (2 * span) * (i / N)]);
+      }
+      return pts;
+    }
+    case 'diagonal': {
+      const N = 256;
+      const span = viewExtent * 0.7;
+      for (let i = 0; i <= N; i++) {
+        const a = -span + (2 * span) * (i / N);
+        pts.push([a, a]);
+      }
+      return pts;
+    }
+    case 'cross': {
+      // Two perpendicular line segments through the origin, joined by an
+      // invisible jump — we lift the pen by leaving the segments as one
+      // continuous polyline that revisits the origin in the middle.
+      const N = 128;
+      const span = viewExtent * 0.85;
+      for (let i = 0; i <= N; i++) pts.push([-span + (2 * span) * (i / N), 0]);
+      for (let i = 0; i <= N; i++) pts.push([0, -span + (2 * span) * (i / N)]);
+      return pts;
+    }
+    case 'spiral': {
+      const N = 600;
+      const turns = 4;
+      for (let i = 0; i <= N; i++) {
+        const t = (i / N) * turns * Math.PI * 2;
+        const rad = (i / N) * r;
+        pts.push([rad * Math.cos(t), rad * Math.sin(t)]);
+      }
+      return pts;
+    }
+    case 'lemniscate': {
+      // Bernoulli lemniscate: r² = a² cos(2θ), traced symmetrically.
+      const N = 400;
+      const a = r;
+      for (let i = 0; i <= N; i++) {
+        const t = -Math.PI / 2 + (i / N) * Math.PI;
+        const c = Math.cos(2 * t);
+        if (c < 0) continue;
+        const rad = a * Math.sqrt(c);
+        pts.push([rad * Math.cos(t), rad * Math.sin(t)]);
+      }
+      // Other lobe.
+      for (let i = N; i >= 0; i--) {
+        const t = Math.PI / 2 + (i / N) * Math.PI;
+        const c = Math.cos(2 * t);
+        if (c < 0) continue;
+        const rad = a * Math.sqrt(c);
+        pts.push([rad * Math.cos(t), rad * Math.sin(t)]);
+      }
+      return pts;
+    }
+    case 'cardioid': {
+      const N = 400;
+      const a = r * 0.5;
+      for (let i = 0; i <= N; i++) {
+        const t = (i / N) * Math.PI * 2;
+        const rad = a * (1 - Math.cos(t));
+        pts.push([rad * Math.cos(t), rad * Math.sin(t)]);
+      }
+      return pts;
+    }
+  }
+  return pts;
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -11,6 +11,18 @@ export interface AppDescriptor {
   icon?: string;
 }
 
+/** Apps register their function picker via useAppFunctions so the AppShell's
+ *  top-bar ƒ button can show / change the active function without the user
+ *  having to dig into the Settings tab. */
+export interface AppFunctionsRegistration {
+  /** List of function names in the order to display. */
+  names: readonly string[];
+  /** Currently-selected function name. */
+  current: string;
+  /** Called when the user picks a different function from the drawer. */
+  onChange: (name: string) => void;
+}
+
 export interface AppShellState {
   /** Title shown in the bar (defaults to the registered AppDescriptor name). */
   title?: string;
@@ -25,6 +37,9 @@ export interface AppShellState {
   setHasSettings: (v: boolean) => void;
   setHasActions: (v: boolean) => void;
   setHeader: (h: { title?: string; subtitle?: string }) => void;
+  /** Function registration (or null when the active app has no function picker). */
+  functions: AppFunctionsRegistration | null;
+  setFunctions: (reg: AppFunctionsRegistration | null) => void;
 }
 
 const AppShellContext = createContext<AppShellState | null>(null);
@@ -36,7 +51,7 @@ export interface AppShellProps {
   children: React.ReactNode;
 }
 
-type Tab = 'apps' | 'settings' | 'actions';
+type Tab = 'apps' | 'functions' | 'settings' | 'actions';
 
 export function AppShell({ apps, currentHash, onNavigate, children }: AppShellProps) {
   const [open, setOpen] = useState(false);
@@ -44,6 +59,7 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
   const [header, setHeader] = useState<{ title?: string; subtitle?: string }>({});
   const [hasSettings, setHasSettings] = useState(false);
   const [hasActions, setHasActions] = useState(false);
+  const [functions, setFunctions] = useState<AppFunctionsRegistration | null>(null);
   const settingsTargetRef = useRef<HTMLDivElement | null>(null);
   const actionsTargetRef = useRef<HTMLDivElement | null>(null);
 
@@ -52,7 +68,7 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     setHeader({});
     setHasSettings(false);
     setHasActions(false);
-    // After app switch, keep the drawer closed; re-snap tab to apps if user opens it.
+    setFunctions(null);
     setTab('apps');
   }, [currentHash]);
 
@@ -66,6 +82,7 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
   const current = apps.find(a => a.hash === currentHash) ?? apps[0];
   const titleName = header.title ?? current?.name ?? '';
   const subtitle = header.subtitle;
+  const hasFunctions = functions != null;
 
   const ctx = useMemo<AppShellState>(() => ({
     title: header.title,
@@ -77,7 +94,9 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     setHasSettings,
     setHasActions,
     setHeader,
-  }), [header.title, header.subtitle, hasSettings, hasActions]);
+    functions,
+    setFunctions,
+  }), [header.title, header.subtitle, hasSettings, hasActions, functions]);
 
   const openWithTab = useCallback((t: Tab) => { setTab(t); setOpen(true); }, []);
 
@@ -91,6 +110,12 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
             title="Apps"
             onClick={() => openWithTab('apps')}
           >☰</button>
+          <button
+            className={`as-bar-btn ${hasFunctions ? '' : 'as-bar-btn-dim'}`}
+            aria-label="Function"
+            title="Function"
+            onClick={() => openWithTab('functions')}
+          >ƒ</button>
           <button
             className="as-bar-title"
             onClick={() => openWithTab(hasSettings ? 'settings' : 'apps')}
@@ -129,6 +154,10 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
               onClick={() => setTab('apps')}
             >Apps</button>
             <button
+              className={`as-tab ${tab === 'functions' ? 'as-active' : ''} ${!hasFunctions ? 'as-empty-tab' : ''}`}
+              onClick={() => setTab('functions')}
+            >Function</button>
+            <button
               className={`as-tab ${tab === 'settings' ? 'as-active' : ''} ${!hasSettings ? 'as-empty-tab' : ''}`}
               onClick={() => setTab('settings')}
             >Settings</button>
@@ -138,15 +167,27 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
             >Actions</button>
           </div>
 
-          {/* Mount all three panels but only show the active one. The Settings/
-              Actions panes own DOM refs that child apps portal into; tearing
-              them down on tab switch would re-create them and lose portal
-              contents. So we toggle visibility, not mount state. */}
+          {/* Mount all panels but only show the active one; the Settings/
+              Actions panes own DOM refs that child apps portal into. */}
           <div className="as-tab-body" style={{ display: tab === 'apps' ? 'block' : 'none' }}>
             <AppList apps={apps} currentHash={currentHash} onPick={(h) => {
               onNavigate(h);
               setOpen(false);
             }} />
+          </div>
+          <div className="as-tab-body" style={{ display: tab === 'functions' ? 'block' : 'none' }}>
+            {functions ? (
+              <FunctionList
+                names={functions.names}
+                current={functions.current}
+                onPick={(name) => {
+                  functions.onChange(name);
+                  setOpen(false);
+                }}
+              />
+            ) : (
+              <div className="as-empty">No function picker for this view.</div>
+            )}
           </div>
           <div className="as-tab-body" style={{ display: tab === 'settings' ? 'block' : 'none' }}>
             <div ref={settingsTargetRef} />
@@ -181,6 +222,25 @@ function AppList({ apps, currentHash, onPick }: {
   );
 }
 
+function FunctionList({ names, current, onPick }: {
+  names: readonly string[]; current: string; onPick: (name: string) => void;
+}) {
+  return (
+    <div className="as-app-list">
+      {names.map(name => (
+        <button
+          key={name}
+          className={`as-app-item ${name === current ? 'as-active' : ''}`}
+          onClick={() => onPick(name)}
+        >
+          <span className="as-app-item-icon">ƒ</span>
+          <span className="as-app-item-name">{name}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
 /* ------------------------------------------------------------ *
  * Hooks and portal slots for app authors.                       *
  * ------------------------------------------------------------ */
@@ -198,6 +258,22 @@ export function useAppHeader(title: string | undefined, subtitle?: string) {
     if (!shell) return;
     shell.setHeader({ title, subtitle });
   }, [shell, title, subtitle]);
+}
+
+/** Register the active function list / current selection / change handler so
+ *  the top-bar ƒ button and the Function drawer tab can drive it. Apps that
+ *  don't have a function picker simply never call this — the button stays
+ *  dimmed and the tab shows an empty-state message. */
+export function useAppFunctions(reg: AppFunctionsRegistration | null) {
+  const shell = useContext(AppShellContext);
+  const names = reg?.names;
+  const current = reg?.current;
+  const onChange = reg?.onChange;
+  useEffect(() => {
+    if (!shell) return;
+    shell.setFunctions(reg ? { names: reg.names, current: reg.current, onChange: reg.onChange } : null);
+    return () => shell.setFunctions(null);
+  }, [shell, names, current, onChange]);
 }
 
 /** Render children into the drawer's Settings tab. */

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Canvas3D from './Canvas3D';
 import Readme from './Readme';
 import { Section, Slider, Pills, Select, Checkbox } from './ControlPanel';
-import { ShellSettings, ShellActions, useAppHeader } from './AppShell';
+import { ShellSettings, ShellActions, useAppHeader, useAppFunctions } from './AppShell';
 import QuarterTurnFloater from '../controls/QuarterTurnFloater';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../config/defaults';
 import { useResponsive } from '../styles/responsive';
@@ -30,18 +30,34 @@ export interface ParticleViewerShellProps {
   functionFormula: string;
   functionPicker: React.ReactNode;
   variantExtras?: React.ReactNode;
+  /** Optional registration for the top-bar ƒ function picker. Apps that have
+   *  a flat list of named functions should pass it; the drawer's Function tab
+   *  will mirror the Settings → Function selector. */
+  functionList?: {
+    names: readonly string[];
+    currentIndex: number;
+    onChangeIndex: (i: number) => void;
+  };
   readme: string;
 }
 
 export default function ParticleViewerShell({
   state, controls, onMount,
-  functionName, functionFormula, functionPicker, variantExtras, readme,
+  functionName, functionFormula, functionPicker, variantExtras, functionList, readme,
 }: ParticleViewerShellProps) {
   const { isMobile, isTablet } = useResponsive();
   const compact = isMobile || isTablet;
   const gestures = useGestureRotation(state);
 
   useAppHeader(functionName, functionFormula);
+  useAppFunctions(functionList ? {
+    names: functionList.names,
+    current: functionList.names[functionList.currentIndex] ?? '',
+    onChange: (name) => {
+      const i = functionList.names.indexOf(name);
+      if (i >= 0) functionList.onChangeIndex(i);
+    },
+  } : null);
 
   return (
     <>


### PR DESCRIPTION
## Summary

- **AppShell**: 4th top-bar button (ƒ) and matching drawer tab (Function) so users can switch the active function without opening Settings. Apps register their picker via the new `useAppFunctions({ names, current, onChange })` hook; the button dims out for apps with no function picker.
- **ComplexParticles + PlaneTransform**: both register `functionNames` (same order, from `lib/complexMath`), so the top-bar ƒ drives the function in either app.
- **PlaneTransform — curve floater**: bottom-left floating panel with a freehand Draw toggle, a 3×3 grid of stock curves (Circle, Square, X-axis, Y-axis, Diag, Cross, Spiral, ∞, Heart/cardioid), and Clear. The drawn or chosen curve renders as a white SVG polyline on the input pane and is mapped through the active function (branch-aware) on the output pane.
- **PlaneTransform — zoom**: wheel and two-finger pinch on either pane adjust `viewExtent`; panes stay synchronized.

## Test plan

- [x] `npm run build` clean (TypeScript strict + Vite production build)
- [x] Playwright visual probes for PlaneTransform with each stock curve (Circle / Spiral / Heart) — input polyline maps correctly through `exp`, `sin`, `sqrt` (branch-aware)
- [x] ƒ drawer tab opens on both ComplexParticles and PlaneTransform; selecting a name in either app updates the visualization and the bar title
- [ ] Manual pinch zoom on a touch device
- [ ] Freehand draw on a touch device

---
_Generated by [Claude Code](https://claude.ai/code/session_0181chzZAs7YGePbpXW3myhL)_