### PR TITLE
Add a menu/landing screen at the default route

### DIFF
--- a/src/animations/AgenticSorting/AgenticSorting.tsx
+++ b/src/animations/AgenticSorting/AgenticSorting.tsx
@@ -3,7 +3,8 @@ import {
   Play, Pause, RotateCcw, Zap, Users, Target,
 } from 'lucide-react';
 import './agenticSorting.css';
-import { useAppHeader } from '../../components/AppShell';
+import { useAppHeader, useAppExplainer } from '../../components/AppShell';
+import explainerText from './EXPLAINER.md?raw';
 
 type AgentType = 'standard' | 'blindDate' | 'nomadic' | 'patrolling' | 'perfectionist';
 
@@ -65,6 +66,7 @@ type Weights = Record<AgentType, number>;
 
 export default function AgenticSorting() {
   useAppHeader('Agentic Sorting');
+  useAppExplainer(explainerText);
   const [itemCount, setItemCount] = useState(60);
   const [simulationSpeed, setSimulationSpeed] = useState(20);
   const [isRunning, setIsRunning] = useState(false);

--- a/src/animations/AgenticSorting/EXPLAINER.md
+++ b/src/animations/AgenticSorting/EXPLAINER.md
@@ -14,9 +14,9 @@ global property (sortedness) arising from purely local actions.
 
 | Agent | Local rule | Classic sort it echoes |
 |---|---|---|
-| **Standard** | compare a random *adjacent* neighbour, swap if out of order | Bubble sort |
-| **Blind Date** | compare a random agent *anywhere*, swap if misordered | randomised compare-swap |
-| **Nomadic** | drift left while smaller than the left neighbour | Insertion sort |
+| **Standard** | compare a random *adjacent* neighbor, swap if out of order | Bubble sort |
+| **Blind Date** | compare a random agent *anywhere*, swap if misordered | randomized compare-swap |
+| **Nomadic** | drift left while smaller than the left neighbor | Insertion sort |
 | **Patrolling** | keep a heading, swap on contact, reverse when settled | Cocktail-shaker sort |
 | **Perfectionist** | scan the whole right tail, pull the minimum into place | Selection sort |
 
@@ -29,7 +29,7 @@ global property (sortedness) arising from purely local actions.
 - **Mixed populations** often beat any single type. Long-range movers
   (Blind Date, Perfectionist) do the coarse work while local refiners
   (Standard, Patrolling, Nomadic) clean up behind them — a division of
-  labour.
+  labor.
 
 ## The knobs
 

--- a/src/animations/AgenticSorting/EXPLAINER.md
+++ b/src/animations/AgenticSorting/EXPLAINER.md
@@ -1,0 +1,38 @@
+# Agentic Sorting
+
+What if sorting weren't one top-down algorithm, but **many little agents**
+each following a simple local rule? Order emerges from their interaction.
+
+## Emergent sorting
+
+Each slot in the array holds an **agent**. On every cycle a random subset
+"wakes up" and applies its own rule — a swap or a move. No agent has a global
+view, yet the array still marches toward sorted order. That's *emergence*: a
+global property (sortedness) arising from purely local actions.
+
+## The strategies — and their classic analogues
+
+| Agent | Local rule | Classic sort it echoes |
+|---|---|---|
+| **Standard** | compare a random *adjacent* neighbour, swap if out of order | Bubble sort |
+| **Blind Date** | compare a random agent *anywhere*, swap if misordered | randomised compare-swap |
+| **Nomadic** | drift left while smaller than the left neighbour | Insertion sort |
+| **Patrolling** | keep a heading, swap on contact, reverse when settled | Cocktail-shaker sort |
+| **Perfectionist** | scan the whole right tail, pull the minimum into place | Selection sort |
+
+## Why mixes win
+
+- **Blind Date** converges fastest on its own: by comparing across long
+  distances it removes large-scale disorder in single jumps.
+- **Perfectionist** is expensive per wake-up (a full scan) but places an
+  element exactly, once it fires.
+- **Mixed populations** often beat any single type. Long-range movers
+  (Blind Date, Perfectionist) do the coarse work while local refiners
+  (Standard, Patrolling, Nomadic) clean up behind them — a division of
+  labour.
+
+## The knobs
+
+- **Global density** — how many agents fill the array.
+- **Processing delay** — milliseconds between simulation cycles.
+- **Population mix** — the relative proportion of each strategy.

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import ParticleViewerShell from '../../components/ParticleViewerShell';
 import { Select } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
+import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import { vertexShader, fragmentShader } from './shaders';
 import { loadParticleTextures } from '../../lib/textures';
@@ -316,6 +317,7 @@ export default function ComplexParticles({
         onChangeIndex: setFunctionIndex,
       }}
       readme={readmeText}
+      explainer={explainerText}
     />
   );
 }

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -22,7 +22,7 @@ directly, so the view *projects* it down into the 3-D scene on screen.
 ## Projection modes
 
 - **Perspective** — a 4-D camera divide: `(x, y, u, v)` maps to
-  `(x, y, u) / (3 + v)`. Points with larger `v` shrink toward the centre,
+  `(x, y, u) / (3 + v)`. Points with larger `v` shrink toward the center,
   just as a 3-D camera makes distant things look smaller.
 - **Stereographic** — first place every point on the unit 3-sphere (scale it
   to length 1), then project from the pole: `(x, y, u) / (1 − v)`. It's the
@@ -47,9 +47,9 @@ unit quaternions `a` (left) and `b` (right). Picking them independently
 reaches every 4-D rotation. Rotating *before* projecting is what lets you
 view the 4-D shape from new angles.
 
-## Colour (domain colouring)
+## Color (domain coloring)
 
-Colour encodes a complex number's **argument** (its angle) as hue and its
-**magnitude** as brightness. Switch **Colour by** between *Domain* (colour by
-the input `z`) and *Range* (colour by the output `f(z)`) to see how the
+Color encodes a complex number's **argument** (its angle) as hue and its
+**magnitude** as brightness. Switch **Color by** between *Domain* (color by
+the input `z`) and *Range* (color by the output `f(z)`) to see how the
 function rearranges the plane.

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -1,0 +1,55 @@
+# Complex Particles
+
+This view draws a complex function **f : ℂ → ℂ** as a cloud of particles.
+
+## A function whose graph lives in 4D
+
+A real function `y = g(x)` has a 2-D graph: one axis for the input, one for
+the output. A **complex** function needs *two* axes for its input
+`z = x + iy` and *two* for its output `w = f(z) = u + iv`, so its natural
+graph lives in **four dimensions**:
+
+| Axis | Meaning |
+|---|---|
+| **x** | Re z — real part of the input |
+| **y** | Im z — imaginary part of the input |
+| **u** | Re f(z) — real part of the output |
+| **v** | Im f(z) — imaginary part of the output |
+
+Every particle sits at the 4-D point **(x, y, u, v)**. We can't look at 4-D
+directly, so the view *projects* it down into the 3-D scene on screen.
+
+## Projection modes
+
+- **Perspective** — a 4-D camera divide: `(x, y, u, v)` maps to
+  `(x, y, u) / (3 + v)`. Points with larger `v` shrink toward the centre,
+  just as a 3-D camera makes distant things look smaller.
+- **Stereographic** — first place every point on the unit 3-sphere (scale it
+  to length 1), then project from the pole: `(x, y, u) / (1 − v)`. It's the
+  4-D analogue of flattening a globe into a map, and it's *conformal* —
+  small shapes keep their form.
+- **Hopf** — uses the **Hopf fibration**, the famous map S³ → S² that fills
+  the 3-sphere with interlocking circles (the *Hopf fibers*). Whole circles
+  collapse to single directions, so the linking and twisting of the data
+  shows up as nested tori.
+- **Drop axis** — the bluntest projection: just forget one of the four
+  coordinates and keep the other three (an orthographic slice).
+
+## 4-D rotations (the quarter-turn controls)
+
+In 3-D you rotate *around an axis*; in 4-D you rotate *in a plane*. There are
+six coordinate planes — **xy, xu, xv, yu, yv, uv** — and a quarter-turn in,
+say, the **xu** plane swaps the input's real axis with the output's real
+axis, mixing domain and range.
+
+These turns use **quaternions**: a 4-D rotation is `p ↦ a · p · b̄` for two
+unit quaternions `a` (left) and `b` (right). Picking them independently
+reaches every 4-D rotation. Rotating *before* projecting is what lets you
+view the 4-D shape from new angles.
+
+## Colour (domain colouring)
+
+Colour encodes a complex number's **argument** (its angle) as hue and its
+**magnitude** as brightness. Switch **Colour by** between *Domain* (colour by
+the input `z`) and *Range* (colour by the output `f(z)`) to see how the
+function rearranges the plane.

--- a/src/animations/ComplexParticles/README.md
+++ b/src/animations/ComplexParticles/README.md
@@ -1,29 +1,29 @@
 # Complex Particles
 
-Visualises a complex map `z → f(z)` using domain colouring in four
+Visualizes a complex map `z → f(z)` using domain coloring in four
 dimensions. Each particle sits at the 4D point `(Re z, Im z, Re f(z),
 Im f(z))` and is projected to 3D using perspective, stereographic, or
-Hopf projection, plus optional drop-axis views. Particle colour
+Hopf projection, plus optional drop-axis views. Particle color
 encodes either the input or the output complex number.
 
 ## Function
 
 Pick any of the standard analytic functions from the dropdown, or
-choose **powPQ** to enter integer `p` and `q` and visualise `z^(p/q)`.
+choose **powPQ** to enter integer `p` and `q` and visualize `z^(p/q)`.
 
 ## Branches
 
 Multi-valued functions (`sqrt`, `ln`, `√(z(z-1)(z+1))`, and `z^(p/q)`
 when `p/q` is non-integer) admit multiple branches. Increase **Branches**
 to 2 or 3 to render several sheets simultaneously, set each sheet's
-branch index, and choose whether to differentiate them by colour,
+branch index, and choose whether to differentiate them by color,
 intensity, or particle shape.
 
 ## Controls
 
 - **Camera** — projection mode, drop axis, motion (free or fixed),
   distance, and quarter-turn buttons for the six coordinate planes.
-- **Colour** — domain vs range colouring, four colour styles (HSV,
+- **Color** — domain vs range coloring, four color styles (HSV,
   modulus bands, phase-only, dual-hue CVD), hue shift, saturation.
 - **Particles** — size, opacity, intensity, sprite shape (sphere /
   hexagon / pyramid), texture (procedural checker / speckled / stone /

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -1,11 +1,12 @@
 import React, { useState, useRef, useEffect } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
 import { useResponsive } from '../../styles/responsive';
-import { ShellSettings, ShellActions, useAppHeader } from '../../components/AppShell';
+import { ShellSettings, ShellActions, useAppHeader, useAppExplainer } from '../../components/AppShell';
 import { Section, Slider, Select } from '../../components/ControlPanel';
 import Readme from '../../components/Readme';
 import PlaybackFloater from './PlaybackFloater';
 import readmeText from './README.md?raw';
+import explainerText from './EXPLAINER.md?raw';
 
 export default function Correspondence() {
   const { isMobile } = useResponsive();
@@ -110,6 +111,7 @@ export default function Correspondence() {
   };
 
   useAppHeader('Mandelbrot ↔ Julia', `c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i`);
+  useAppExplainer(explainerText);
 
   // The action controls live in two places at once: the drawer's Actions tab
   // and the on-screen PlaybackFloater. Defining them once keeps both in sync.

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -27,6 +27,7 @@ export default function Correspondence() {
   const pausedRef = useRef(false);
   const animRef = useRef<number>();
   const progressRef = useRef(0);
+  const [progress, setProgress] = useState(0); // 0..1 position along the c-path
   const [playing, setPlaying] = useState(false);
   const playingRef = useRef(false);
 
@@ -42,19 +43,24 @@ export default function Correspondence() {
 
   const handlePathChange = (pts: Complex[]) => {
     setPath(pts);
+    progressRef.current = 0;
+    setProgress(0);
   };
 
   const playPath = () => {
     if (path.length < 2) return;
     cancelAnimationFrame(animRef.current!);
-    progressRef.current = 0;
+    // Resume from the current scrubbed position if we're partway through,
+    // otherwise start from the top.
+    if (progressRef.current >= path.length - 1) progressRef.current = 0;
+    setProgress(progressRef.current / (path.length - 1));
     setPaused(false);
     setPlaying(true);
 
     const step = () => {
       if (!playingRef.current) return;
       if (!pausedRef.current) {
-        const idx = Math.floor(progressRef.current);
+        const idx = Math.min(Math.floor(progressRef.current), path.length - 2);
         const t = progressRef.current - idx;
         const p0 = path[idx];
         const p1 = path[idx + 1];
@@ -66,9 +72,12 @@ export default function Correspondence() {
         progressRef.current += speedRef.current;
         if (progressRef.current >= path.length - 1) {
           setC(path[path.length - 1]);
+          progressRef.current = path.length - 1;
+          setProgress(1);
           setPlaying(false);
           return;
         }
+        setProgress(progressRef.current / (path.length - 1));
       }
       animRef.current = requestAnimationFrame(step);
     };
@@ -79,6 +88,25 @@ export default function Correspondence() {
     setPlaying(false);
     setPaused(false);
     cancelAnimationFrame(animRef.current!);
+  };
+
+  // Jump to a normalized position (0..1) along the path. Used by the floater's
+  // side scrubber; grabbing it while playing pauses so the user stays in control.
+  const seek = (t01: number) => {
+    if (path.length < 2) return;
+    const maxPos = path.length - 1;
+    const pos = Math.max(0, Math.min(maxPos, t01 * maxPos));
+    progressRef.current = pos;
+    setProgress(pos / maxPos);
+    if (playingRef.current) setPaused(true);
+    const idx = Math.min(Math.floor(pos), maxPos - 1);
+    const t = pos - idx;
+    const p0 = path[idx];
+    const p1 = path[idx + 1];
+    setC({
+      real: p0.real * (1 - t) + p1.real * t,
+      imag: p0.imag * (1 - t) + p1.imag * t,
+    });
   };
 
   useAppHeader('Mandelbrot ↔ Julia', `c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i`);
@@ -101,7 +129,7 @@ export default function Correspondence() {
       <ActionButton
         label="Clear path"
         disabled={path.length === 0}
-        onClick={() => setPath([])}
+        onClick={() => { stopPath(); setPath([]); progressRef.current = 0; setProgress(0); }}
       />
       <ActionButton
         label={playing ? 'Stop playback' : 'Play path'}
@@ -164,7 +192,12 @@ export default function Correspondence() {
         </div>
       </div>
 
-      <PlaybackFloater title="Playback">
+      <PlaybackFloater
+        title="Playback"
+        progress={progress}
+        onScrub={seek}
+        scrubDisabled={path.length < 2}
+      >
         {playbackControls}
       </PlaybackFloater>
 

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef, useEffect } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
 import { useResponsive } from '../../styles/responsive';
-import { ShellSettings, ShellActions, useAppHeader, useAppExplainer } from '../../components/AppShell';
+import { ShellSettings, ShellActions, useAppHeader, useAppExplainer, useActionFloaterOff } from '../../components/AppShell';
 import { Section, Slider, Select } from '../../components/ControlPanel';
 import Readme from '../../components/Readme';
 import PlaybackFloater from './PlaybackFloater';
@@ -113,6 +113,7 @@ export default function Correspondence() {
 
   useAppHeader('Mandelbrot ↔ Julia', `c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i`);
   useAppExplainer(explainerText);
+  useActionFloaterOff(); // we ship our own PlaybackFloater (with the scrubber)
 
   // The action controls live in two places at once: the drawer's Actions tab
   // and the on-screen PlaybackFloater. Defining them once keeps both in sync.

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -7,6 +7,7 @@ import Readme from '../../components/Readme';
 import PlaybackFloater from './PlaybackFloater';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
+import { PALETTE_OPTIONS } from '../../lib/colormaps';
 
 export default function Correspondence() {
   const { isMobile } = useResponsive();
@@ -213,12 +214,7 @@ export default function Correspondence() {
 
         <Section title="Mandelbrot palette" icon="◐" defaultOpen>
           <Select label="Palette"
-            options={[
-              { value: 0, label: 'Rainbow' },
-              { value: 1, label: 'Fire' },
-              { value: 2, label: 'Ocean' },
-              { value: 3, label: 'Gray' },
-            ]}
+            options={PALETTE_OPTIONS}
             value={paletteM} onChange={setPaletteM} />
           <Slider label="Offset" value={offsetM}
             min={0} max={255} step={1}
@@ -227,12 +223,7 @@ export default function Correspondence() {
 
         <Section title="Julia palette" icon="◑">
           <Select label="Palette"
-            options={[
-              { value: 0, label: 'Rainbow' },
-              { value: 1, label: 'Fire' },
-              { value: 2, label: 'Ocean' },
-              { value: 3, label: 'Gray' },
-            ]}
+            options={PALETTE_OPTIONS}
             value={paletteJ} onChange={setPaletteJ} />
           <Slider label="Offset" value={offsetJ}
             min={0} max={255} step={1}

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -4,6 +4,7 @@ import { useResponsive } from '../../styles/responsive';
 import { ShellSettings, ShellActions, useAppHeader } from '../../components/AppShell';
 import { Section, Slider, Select } from '../../components/ControlPanel';
 import Readme from '../../components/Readme';
+import PlaybackFloater from './PlaybackFloater';
 import readmeText from './README.md?raw';
 
 export default function Correspondence() {
@@ -82,6 +83,44 @@ export default function Correspondence() {
 
   useAppHeader('Mandelbrot ↔ Julia', `c = ${c.real.toFixed(3)} ${c.imag >= 0 ? '+' : '-'} ${Math.abs(c.imag).toFixed(3)}i`);
 
+  // The action controls live in two places at once: the drawer's Actions tab
+  // and the on-screen PlaybackFloater. Defining them once keeps both in sync.
+  // Speed lives here (an action) rather than in Settings.
+  const playbackControls = (
+    <>
+      <ActionButton
+        label={selecting ? 'Tap Mandelbrot to pick…' : 'Pick Julia c by tap'}
+        active={selecting}
+        onClick={() => setSelecting(true)}
+      />
+      <ActionButton
+        label={drawingPath ? 'Finish drawing path' : 'Draw c-path'}
+        active={drawingPath}
+        onClick={() => setDrawingPath(p => !p)}
+      />
+      <ActionButton
+        label="Clear path"
+        disabled={path.length === 0}
+        onClick={() => setPath([])}
+      />
+      <ActionButton
+        label={playing ? 'Stop playback' : 'Play path'}
+        primary
+        disabled={path.length < 2}
+        onClick={playing ? stopPath : playPath}
+      />
+      {playing && (
+        <ActionButton
+          label={paused ? 'Resume' : 'Pause'}
+          onClick={() => setPaused(p => !p)}
+        />
+      )}
+      <Slider label="Speed" value={speed}
+        min={0.005} max={0.5} step={0.005}
+        onChange={setSpeed} format={v => v.toFixed(3)} />
+    </>
+  );
+
   return (
     <>
       <div style={{
@@ -124,6 +163,10 @@ export default function Correspondence() {
           </div>
         </div>
       </div>
+
+      <PlaybackFloater title="Playback">
+        {playbackControls}
+      </PlaybackFloater>
 
       <ShellSettings>
         <Section title="Iterations" icon="↻" defaultOpen>
@@ -176,12 +219,6 @@ export default function Correspondence() {
           </div>
         </Section>
 
-        <Section title="Path playback" icon="▷">
-          <Slider label="Speed" value={speed}
-            min={0.005} max={0.5} step={0.005}
-            onChange={setSpeed} format={v => v.toFixed(3)} />
-        </Section>
-
         <Section title="About" icon="ⓘ">
           <Readme markdown={readmeText} />
           <div style={{ fontSize: 11, color: 'var(--cp-fg-dim)', marginTop: 8 }}>
@@ -192,33 +229,7 @@ export default function Correspondence() {
 
       <ShellActions>
         <div className="cp-section-body">
-          <ActionButton
-            label={selecting ? 'Tap Mandelbrot to pick…' : 'Pick Julia c by tap'}
-            active={selecting}
-            onClick={() => setSelecting(true)}
-          />
-          <ActionButton
-            label={drawingPath ? 'Finish drawing path' : 'Draw c-path'}
-            active={drawingPath}
-            onClick={() => setDrawingPath(p => !p)}
-          />
-          <ActionButton
-            label="Clear path"
-            disabled={path.length === 0}
-            onClick={() => setPath([])}
-          />
-          <ActionButton
-            label={playing ? 'Stop playback' : 'Play path'}
-            primary
-            disabled={path.length < 2}
-            onClick={playing ? stopPath : playPath}
-          />
-          {playing && (
-            <ActionButton
-              label={paused ? 'Resume' : 'Pause'}
-              onClick={() => setPaused(p => !p)}
-            />
-          )}
+          {playbackControls}
         </div>
       </ShellActions>
     </>

--- a/src/animations/Correspondence/EXPLAINER.md
+++ b/src/animations/Correspondence/EXPLAINER.md
@@ -1,0 +1,38 @@
+# Mandelbrot ↔ Julia
+
+Two fractals from one rule, **`z ↦ z² + c`**, shown side by side. The left
+pane is the **Mandelbrot set**; the right is the **Julia set** for the
+currently selected `c`.
+
+## The two questions
+
+- **Mandelbrot (left):** fix `z₀ = 0`, vary `c`. A point `c` is in the set if
+  the orbit `0 → c → c² + c → …` stays bounded.
+- **Julia (right):** fix `c`, vary the starting point `z₀`. The Julia set is
+  the boundary between starting points that stay bounded and those that
+  escape.
+
+## Why they correspond
+
+The Mandelbrot set is a **map of every Julia set at once**. Reading a `c` off
+the left pane and dropping it into the right is exactly the relationship:
+
+- Pick `c` **inside** the Mandelbrot set → the Julia set is **connected**
+  (a single piece).
+- Pick `c` **outside** → the Julia set shatters into a **dust** of
+  disconnected points (a Cantor set).
+
+This is the *Fundamental Dichotomy*: a Julia set is connected **exactly when**
+its `c` lies in the Mandelbrot set.
+
+Even the local *shape* matches. Near a point on the Mandelbrot boundary, the
+Mandelbrot set and the matching Julia set look almost identical (a theorem of
+Tan Lei, at so-called Misiurewicz points). Choosing `c` right on the boundary
+gives the most intricate Julia sets.
+
+## Controls
+
+Tap **Pick Julia c**, then tap the Mandelbrot to choose `c`. Or draw a
+**c-path** and play it back: the Julia set morphs continuously as `c` traces
+your curve. The scrubber on the side of the playback panel seeks along the
+path.

--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useCallback, useState } from 'react';
 import * as THREE from 'three';
 import { useViewportGestures } from '../../lib/useViewportGestures';
+import { PALETTE_GLSL } from '../../lib/colormaps';
 
 export interface Complex {
   real: number;
@@ -83,23 +84,7 @@ export default function FractalPane({
     uniform int power;
     uniform int palette;
     uniform float offset;
-    vec3 paletteColor(float t, int scheme){
-      if(scheme==0){
-        return vec3(
-          sin(0.024*(t)+0.0)*0.5+0.5,
-          sin(0.024*(t)+2.0)*0.5+0.5,
-          sin(0.024*(t)+4.0)*0.5+0.5
-        );
-      }else if(scheme==1){
-        float r = min(255.0, t*3.0);
-        float g = clamp(t*3.0-255.0,0.0,255.0);
-        float b = max(0.0,t*3.0-510.0);
-        return vec3(r,g,b)/255.0;
-      }else if(scheme==2){
-        return vec3(0.0, t/2.0, t)/255.0;
-      }
-      return vec3(t,t,t)/255.0;
-    }
+    ${PALETTE_GLSL}
     void main(){
       vec2 pos = vec2(mix(view.x,view.y,vUv.x), mix(view.z,view.w,vUv.y));
       vec2 z = fType==0 ? vec2(0.0) : pos;

--- a/src/animations/Correspondence/PlaybackFloater.css
+++ b/src/animations/Correspondence/PlaybackFloater.css
@@ -1,10 +1,11 @@
-/* PlaybackFloater — bottom-right floating panel for the Correspondence
-   action controls. Shares the visual language of PlaneCurveFloater. */
+/* PlaybackFloater — draggable floating panel (default: bottom-left) for the
+   Correspondence action controls, with a vertical scrubber down the side.
+   Shares the visual language of PlaneCurveFloater. */
 
 .pf {
   position: absolute;
   bottom: 16px;
-  right: 16px;
+  left: 16px;
   z-index: 30;
   display: flex;
   flex-direction: column;
@@ -17,11 +18,11 @@
   padding: 10px;
   box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-  width: 230px;
+  width: 248px;
   max-width: calc(100vw - 32px);
 }
 
-.pf-collapsed { padding: 4px; }
+.pf-collapsed { padding: 4px; width: auto; }
 
 .pf-toggle {
   background: transparent;
@@ -38,13 +39,25 @@
 }
 .pf-toggle:hover { background: rgba(255, 255, 255, 0.08); }
 
+/* Header doubles as the drag handle. */
 .pf-header {
   display: flex;
-  justify-content: space-between;
   align-items: center;
+  gap: 6px;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+}
+.pf-header:active { cursor: grabbing; }
+
+.pf-grip {
+  color: #6b6b73;
+  font-size: 13px;
+  line-height: 1;
 }
 
 .pf-title {
+  flex: 1;
   font-size: 11px;
   color: #9b9ba3;
   font-weight: 700;
@@ -67,9 +80,65 @@
 }
 .pf-close:hover { background: rgba(255, 255, 255, 0.08); color: #f0f0f3; }
 
-/* The action buttons + speed slider are rendered as children; stack them. */
+/* Controls column + scrubber column, side by side. */
+.pf-main {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+}
+
 .pf-body {
+  flex: 1;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+/* ---- Vertical scrubber ---- */
+.pf-scrubber {
+  flex-shrink: 0;
+  width: 22px;
+  display: flex;
+  justify-content: center;
+  padding: 2px 0;
+  cursor: ns-resize;
+  touch-action: none;
+}
+.pf-scrubber-disabled {
+  opacity: 0.4;
+  cursor: default;
+  pointer-events: none;
+}
+
+.pf-scrubber-track {
+  position: relative;
+  width: 6px;
+  border-radius: 3px;
+  background: rgba(255, 255, 255, 0.12);
+  /* Slightly inset so the thumb at the extremes isn't clipped. */
+  margin: 8px 0;
+  flex: 1;
+}
+
+.pf-scrubber-fill {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  border-radius: 3px;
+  background: var(--cp-accent, #ffd400);
+}
+
+.pf-scrubber-thumb {
+  position: absolute;
+  left: 50%;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #fff;
+  border: 2px solid var(--cp-accent, #ffd400);
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.5);
+  transform: translate(-50%, 50%);
+  pointer-events: none;
 }

--- a/src/animations/Correspondence/PlaybackFloater.css
+++ b/src/animations/Correspondence/PlaybackFloater.css
@@ -22,15 +22,34 @@
   max-width: calc(100vw - 32px);
 }
 
-.pf-collapsed { padding: 4px; width: auto; }
+.pf-collapsed {
+  padding: 3px;
+  width: auto;
+  flex-direction: row;
+  align-items: center;
+  gap: 2px;
+}
+
+.pf-grip-collapsed {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  border-radius: 6px;
+  padding: 0 2px;
+}
+.pf-grip-collapsed:hover { background: rgba(255, 255, 255, 0.06); }
+.pf-grip-collapsed:active { cursor: grabbing; }
 
 .pf-toggle {
   background: transparent;
   border: none;
-  color: #f0f0f3;
-  font-size: 16px;
-  width: 36px;
-  height: 36px;
+  color: var(--cp-accent, #ffd400);
+  font-size: 14px;
+  width: 34px;
+  height: 34px;
   border-radius: 6px;
   cursor: pointer;
   display: flex;

--- a/src/animations/Correspondence/PlaybackFloater.css
+++ b/src/animations/Correspondence/PlaybackFloater.css
@@ -1,0 +1,75 @@
+/* PlaybackFloater — bottom-right floating panel for the Correspondence
+   action controls. Shares the visual language of PlaneCurveFloater. */
+
+.pf {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  z-index: 30;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  background: rgba(12, 12, 16, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  padding: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  width: 230px;
+  max-width: calc(100vw - 32px);
+}
+
+.pf-collapsed { padding: 4px; }
+
+.pf-toggle {
+  background: transparent;
+  border: none;
+  color: #f0f0f3;
+  font-size: 16px;
+  width: 36px;
+  height: 36px;
+  border-radius: 6px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pf-toggle:hover { background: rgba(255, 255, 255, 0.08); }
+
+.pf-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.pf-title {
+  font-size: 11px;
+  color: #9b9ba3;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pf-close {
+  background: transparent;
+  border: none;
+  color: #9b9ba3;
+  cursor: pointer;
+  font-size: 16px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.pf-close:hover { background: rgba(255, 255, 255, 0.08); color: #f0f0f3; }
+
+/* The action buttons + speed slider are rendered as children; stack them. */
+.pf-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}

--- a/src/animations/Correspondence/PlaybackFloater.tsx
+++ b/src/animations/Correspondence/PlaybackFloater.tsx
@@ -1,0 +1,46 @@
+import React, { useState } from 'react';
+import './PlaybackFloater.css';
+
+export interface PlaybackFloaterProps {
+  /** Title shown in the panel header and the collapsed button tooltip. */
+  title?: string;
+  /** Glyph for the collapsed toggle button. */
+  icon?: string;
+  children: React.ReactNode;
+}
+
+/** A collapsible floating panel pinned to the bottom-right of the view, giving
+ *  the Correspondence playback/action controls an always-on-screen home that
+ *  doesn't require opening the drawer. Mirrors the look of PlaneCurveFloater. */
+export default function PlaybackFloater({
+  title = 'Playback', icon = '▷', children,
+}: PlaybackFloaterProps) {
+  const [open, setOpen] = useState(false);
+
+  if (!open) {
+    return (
+      <div className="pf pf-collapsed">
+        <button
+          className="pf-toggle"
+          onClick={() => setOpen(true)}
+          aria-label={`Show ${title} panel`}
+          title={title}
+        >{icon}</button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="pf">
+      <div className="pf-header">
+        <span className="pf-title">{title}</span>
+        <button
+          className="pf-close"
+          onClick={() => setOpen(false)}
+          aria-label={`Hide ${title} panel`}
+        >×</button>
+      </div>
+      <div className="pf-body">{children}</div>
+    </div>
+  );
+}

--- a/src/animations/Correspondence/PlaybackFloater.tsx
+++ b/src/animations/Correspondence/PlaybackFloater.tsx
@@ -1,4 +1,5 @@
 import React, { useRef, useState } from 'react';
+import { useFloaterDrag } from '../../components/useFloaterDrag';
 import './PlaybackFloater.css';
 
 export interface PlaybackFloaterProps {
@@ -18,43 +19,13 @@ export interface PlaybackFloaterProps {
 /** A collapsible, draggable floating panel pinned (by default) to the
  *  bottom-left of the view. It gives the Correspondence action controls an
  *  always-on-screen home, with a vertical scrubber down the side for seeking
- *  the c-path playback. Drag the header to reposition it anywhere in the view. */
+ *  the c-path playback. Drag the header (or the collapsed grip) to reposition
+ *  it anywhere in the view. */
 export default function PlaybackFloater({
-  title = 'Playback', icon = '▷', progress, onScrub, scrubDisabled, children,
+  title = 'Playback', icon = '▶', progress, onScrub, scrubDisabled, children,
 }: PlaybackFloaterProps) {
   const [open, setOpen] = useState(false);
-  // null → anchored to the default corner via CSS; otherwise absolute px.
-  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
-  const panelRef = useRef<HTMLDivElement>(null);
-
-  /* ---- Reposition: drag by the header ---- */
-  const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(null);
-
-  const clampToParent = (x: number, y: number) => {
-    const el = panelRef.current;
-    const parent = el?.offsetParent as HTMLElement | null;
-    if (!el || !parent) return { x, y };
-    const maxX = Math.max(0, parent.clientWidth - el.offsetWidth);
-    const maxY = Math.max(0, parent.clientHeight - el.offsetHeight);
-    return { x: Math.max(0, Math.min(maxX, x)), y: Math.max(0, Math.min(maxY, y)) };
-  };
-
-  const onHeaderPointerDown = (e: React.PointerEvent) => {
-    // Let the close button work without starting a drag.
-    if ((e.target as HTMLElement).closest('.pf-close')) return;
-    const el = panelRef.current;
-    if (!el) return;
-    dragRef.current = { startX: e.clientX, startY: e.clientY, baseX: el.offsetLeft, baseY: el.offsetTop };
-    setPos({ x: el.offsetLeft, y: el.offsetTop });
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
-    e.preventDefault();
-  };
-  const onHeaderPointerMove = (e: React.PointerEvent) => {
-    const d = dragRef.current;
-    if (!d) return;
-    setPos(clampToParent(d.baseX + (e.clientX - d.startX), d.baseY + (e.clientY - d.startY)));
-  };
-  const onHeaderPointerUp = () => { dragRef.current = null; };
+  const { panelRef, posStyle, dragHandlers } = useFloaterDrag();
 
   /* ---- Side scrubber ---- */
   const trackRef = useRef<HTMLDivElement>(null);
@@ -76,13 +47,10 @@ export default function PlaybackFloater({
   const onScrubMove = (e: React.PointerEvent) => { if (scrubbing.current) scrubFromY(e.clientY); };
   const onScrubUp = () => { scrubbing.current = false; };
 
-  const posStyle: React.CSSProperties = pos
-    ? { left: pos.x, top: pos.y, right: 'auto', bottom: 'auto' }
-    : {};
-
   if (!open) {
     return (
       <div className="pf pf-collapsed" ref={panelRef} style={posStyle}>
+        <span className="pf-grip pf-grip-collapsed" title="Drag to move" {...dragHandlers}>⠿</span>
         <button
           className="pf-toggle"
           onClick={() => setOpen(true)}
@@ -97,14 +65,8 @@ export default function PlaybackFloater({
 
   return (
     <div className="pf" ref={panelRef} style={posStyle}>
-      <div
-        className="pf-header"
-        onPointerDown={onHeaderPointerDown}
-        onPointerMove={onHeaderPointerMove}
-        onPointerUp={onHeaderPointerUp}
-        onPointerCancel={onHeaderPointerUp}
-      >
-        <span className="pf-grip" aria-hidden="true">⠿</span>
+      <div className="pf-header" {...dragHandlers}>
+        <span className="pf-grip" title="Drag to move">⠿</span>
         <span className="pf-title">{title}</span>
         <button
           className="pf-close"

--- a/src/animations/Correspondence/PlaybackFloater.tsx
+++ b/src/animations/Correspondence/PlaybackFloater.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import './PlaybackFloater.css';
 
 export interface PlaybackFloaterProps {
@@ -6,20 +6,83 @@ export interface PlaybackFloaterProps {
   title?: string;
   /** Glyph for the collapsed toggle button. */
   icon?: string;
+  /** Current playback position, 0..1, reflected by the side scrubber. */
+  progress: number;
+  /** Called as the user drags the side scrubber (normalized 0..1). */
+  onScrub: (t01: number) => void;
+  /** Greys out the scrubber when there's nothing to scrub. */
+  scrubDisabled?: boolean;
   children: React.ReactNode;
 }
 
-/** A collapsible floating panel pinned to the bottom-right of the view, giving
- *  the Correspondence playback/action controls an always-on-screen home that
- *  doesn't require opening the drawer. Mirrors the look of PlaneCurveFloater. */
+/** A collapsible, draggable floating panel pinned (by default) to the
+ *  bottom-left of the view. It gives the Correspondence action controls an
+ *  always-on-screen home, with a vertical scrubber down the side for seeking
+ *  the c-path playback. Drag the header to reposition it anywhere in the view. */
 export default function PlaybackFloater({
-  title = 'Playback', icon = '▷', children,
+  title = 'Playback', icon = '▷', progress, onScrub, scrubDisabled, children,
 }: PlaybackFloaterProps) {
   const [open, setOpen] = useState(false);
+  // null → anchored to the default corner via CSS; otherwise absolute px.
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+
+  /* ---- Reposition: drag by the header ---- */
+  const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(null);
+
+  const clampToParent = (x: number, y: number) => {
+    const el = panelRef.current;
+    const parent = el?.offsetParent as HTMLElement | null;
+    if (!el || !parent) return { x, y };
+    const maxX = Math.max(0, parent.clientWidth - el.offsetWidth);
+    const maxY = Math.max(0, parent.clientHeight - el.offsetHeight);
+    return { x: Math.max(0, Math.min(maxX, x)), y: Math.max(0, Math.min(maxY, y)) };
+  };
+
+  const onHeaderPointerDown = (e: React.PointerEvent) => {
+    // Let the close button work without starting a drag.
+    if ((e.target as HTMLElement).closest('.pf-close')) return;
+    const el = panelRef.current;
+    if (!el) return;
+    dragRef.current = { startX: e.clientX, startY: e.clientY, baseX: el.offsetLeft, baseY: el.offsetTop };
+    setPos({ x: el.offsetLeft, y: el.offsetTop });
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    e.preventDefault();
+  };
+  const onHeaderPointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d) return;
+    setPos(clampToParent(d.baseX + (e.clientX - d.startX), d.baseY + (e.clientY - d.startY)));
+  };
+  const onHeaderPointerUp = () => { dragRef.current = null; };
+
+  /* ---- Side scrubber ---- */
+  const trackRef = useRef<HTMLDivElement>(null);
+  const scrubbing = useRef(false);
+
+  const scrubFromY = (clientY: number) => {
+    const r = trackRef.current?.getBoundingClientRect();
+    if (!r || r.height === 0) return;
+    // Bottom of the track is the start of the path (0), top is the end (1).
+    onScrub(Math.max(0, Math.min(1, 1 - (clientY - r.top) / r.height)));
+  };
+  const onScrubDown = (e: React.PointerEvent) => {
+    if (scrubDisabled) return;
+    scrubbing.current = true;
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    scrubFromY(e.clientY);
+    e.preventDefault();
+  };
+  const onScrubMove = (e: React.PointerEvent) => { if (scrubbing.current) scrubFromY(e.clientY); };
+  const onScrubUp = () => { scrubbing.current = false; };
+
+  const posStyle: React.CSSProperties = pos
+    ? { left: pos.x, top: pos.y, right: 'auto', bottom: 'auto' }
+    : {};
 
   if (!open) {
     return (
-      <div className="pf pf-collapsed">
+      <div className="pf pf-collapsed" ref={panelRef} style={posStyle}>
         <button
           className="pf-toggle"
           onClick={() => setOpen(true)}
@@ -30,9 +93,18 @@ export default function PlaybackFloater({
     );
   }
 
+  const pct = Math.max(0, Math.min(1, progress)) * 100;
+
   return (
-    <div className="pf">
-      <div className="pf-header">
+    <div className="pf" ref={panelRef} style={posStyle}>
+      <div
+        className="pf-header"
+        onPointerDown={onHeaderPointerDown}
+        onPointerMove={onHeaderPointerMove}
+        onPointerUp={onHeaderPointerUp}
+        onPointerCancel={onHeaderPointerUp}
+      >
+        <span className="pf-grip" aria-hidden="true">⠿</span>
         <span className="pf-title">{title}</span>
         <button
           className="pf-close"
@@ -40,7 +112,27 @@ export default function PlaybackFloater({
           aria-label={`Hide ${title} panel`}
         >×</button>
       </div>
-      <div className="pf-body">{children}</div>
+
+      <div className="pf-main">
+        <div className="pf-body">{children}</div>
+        <div
+          className={`pf-scrubber ${scrubDisabled ? 'pf-scrubber-disabled' : ''}`}
+          onPointerDown={onScrubDown}
+          onPointerMove={onScrubMove}
+          onPointerUp={onScrubUp}
+          onPointerCancel={onScrubUp}
+          role="slider"
+          aria-label="Playback position"
+          aria-valuemin={0}
+          aria-valuemax={100}
+          aria-valuenow={Math.round(pct)}
+        >
+          <div className="pf-scrubber-track" ref={trackRef}>
+            <div className="pf-scrubber-fill" style={{ height: `${pct}%` }} />
+            <div className="pf-scrubber-thumb" style={{ bottom: `${pct}%` }} />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/animations/FractalsGPU/EXPLAINER.md
+++ b/src/animations/FractalsGPU/EXPLAINER.md
@@ -18,11 +18,11 @@ over and over. Either the values stay bounded forever, or they blow up
   takes absolute values of the real and imaginary parts before squaring; the
   Tricorn (the "mandelbar") conjugates `z` each step.
 
-## Escape time and colour
+## Escape time and color
 
 A point counts as escaped once `|z|` passes an **escape radius**. The number
-of steps it took is the **escape time**, and that count drives the colour.
-Smooth colouring blends between whole-number counts using `log|z|`, so the
+of steps it took is the **escape time**, and that count drives the color.
+Smooth coloring blends between whole-number counts using `log|z|`, so the
 bands don't look stepped. The interior — points that never escape within the
 iteration cap — is drawn solid.
 
@@ -32,6 +32,6 @@ iteration cap — is drawn solid.
   Mandelbrot; higher powers give `(k − 1)`-fold symmetry.
 - **Iterations** — how long we test each point before giving up. More
   iterations resolve finer filaments but cost more time.
-- **Colouring mode** — escape velocity, limit magnitude, or a blend of both.
+- **Coloring mode** — escape velocity, limit magnitude, or a blend of both.
 - **Click the fractal** to trace an **orbit**: the path
   `z₀ → z₁ → z₂ → …` for the point you clicked.

--- a/src/animations/FractalsGPU/EXPLAINER.md
+++ b/src/animations/FractalsGPU/EXPLAINER.md
@@ -1,0 +1,37 @@
+# Fractals
+
+These are **escape-time fractals**. Pick a complex number `c` and a starting
+value `z`, then iterate
+
+> `z ↦ zᵏ + c`
+
+over and over. Either the values stay bounded forever, or they blow up
+("escape" to infinity). The boundary between those two fates is a fractal.
+
+## Mandelbrot vs Julia
+
+- **Mandelbrot set** — fix the start at `z₀ = 0` and ask *which `c` stay
+  bounded*. Every pixel is a different `c`; the dark region is the set.
+- **Julia set** — fix `c` and ask *which starting points `z₀` stay bounded*.
+  Every pixel is a different `z₀`. Each `c` has its own Julia set.
+- **Burning Ship / Tricorn** — the same rule with a twist: the Burning Ship
+  takes absolute values of the real and imaginary parts before squaring; the
+  Tricorn (the "mandelbar") conjugates `z` each step.
+
+## Escape time and colour
+
+A point counts as escaped once `|z|` passes an **escape radius**. The number
+of steps it took is the **escape time**, and that count drives the colour.
+Smooth colouring blends between whole-number counts using `log|z|`, so the
+bands don't look stepped. The interior — points that never escape within the
+iteration cap — is drawn solid.
+
+## The knobs
+
+- **Power `k`** — the exponent in `zᵏ + c`. `k = 2` is the classic
+  Mandelbrot; higher powers give `(k − 1)`-fold symmetry.
+- **Iterations** — how long we test each point before giving up. More
+  iterations resolve finer filaments but cost more time.
+- **Colouring mode** — escape velocity, limit magnitude, or a blend of both.
+- **Click the fractal** to trace an **orbit**: the path
+  `z₀ → z₁ → z₂ → …` for the point you clicked.

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -3,6 +3,7 @@ import * as THREE from 'three';
 import Readme from '../../components/Readme';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
+import { PALETTE_GLSL, PALETTE_OPTIONS } from '../../lib/colormaps';
 import { useResponsive } from '../../styles/responsive';
 import { useViewportGestures } from '../../lib/useViewportGestures';
 import { ShellSettings, ShellActions, useAppHeader, useAppExplainer } from '../../components/AppShell';
@@ -91,23 +92,7 @@ export default function FractalsGPU() {
     const int MAX_ITER = 1000;
     const int MAX_POWER = 100;
 
-    vec3 paletteColor(float t, int scheme) {
-      if(scheme==0){
-        return vec3(
-          sin(0.024*(t)+0.0)*0.5+0.5,
-          sin(0.024*(t)+2.0)*0.5+0.5,
-          sin(0.024*(t)+4.0)*0.5+0.5
-        );
-      }else if(scheme==1){
-        float r = min(255.0, t*3.0);
-        float g = clamp(t*3.0-255.0,0.0,255.0);
-        float b = max(0.0,t*3.0-510.0);
-        return vec3(r,g,b)/255.0;
-      }else if(scheme==2){
-        return vec3(0.0, t/2.0, t)/255.0;
-      }
-      return vec3(t,t,t)/255.0;
-    }
+    ${PALETTE_GLSL}
 
     void main(){
       // type: 0=Mandelbrot, 1=Julia, 2=Burning Ship, 3=Tricorn
@@ -467,12 +452,7 @@ export default function FractalsGPU() {
 
         <Section title="Color" icon="◐">
           <Select label="Palette"
-            options={[
-              { value: 0, label: 'Rainbow' },
-              { value: 1, label: 'Fire' },
-              { value: 2, label: 'Ocean' },
-              { value: 3, label: 'Gray' },
-            ]}
+            options={PALETTE_OPTIONS}
             value={palette} onChange={setPalette} />
           <Pills label="Coloring"
             options={[
@@ -484,12 +464,7 @@ export default function FractalsGPU() {
             onChange={setColorMode} />
           {colorMode !== 'escape' && (
             <Select label="Inside palette"
-              options={[
-                { value: 0, label: 'Rainbow' },
-                { value: 1, label: 'Fire' },
-                { value: 2, label: 'Ocean' },
-                { value: 3, label: 'Gray' },
-              ]}
+              options={PALETTE_OPTIONS}
               value={insidePalette} onChange={setInsidePalette} />
           )}
         </Section>

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -465,7 +465,7 @@ export default function FractalsGPU() {
             format={v => String(v)} />
         </Section>
 
-        <Section title="Colour" icon="◐">
+        <Section title="Color" icon="◐">
           <Select label="Palette"
             options={[
               { value: 0, label: 'Rainbow' },
@@ -474,7 +474,7 @@ export default function FractalsGPU() {
               { value: 3, label: 'Gray' },
             ]}
             value={palette} onChange={setPalette} />
-          <Pills label="Colouring"
+          <Pills label="Coloring"
             options={[
               { value: 'escape', label: 'Escape' },
               { value: 'limit', label: 'Limit' },
@@ -539,7 +539,7 @@ export default function FractalsGPU() {
             }}
             onClick={() => setAnimating(a => !a)}
           >
-            {animating ? 'Stop colour cycle' : 'Start colour cycle'}
+            {animating ? 'Stop color cycle' : 'Start color cycle'}
           </button>
           <button
             className="cp-pills"

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import * as THREE from 'three';
 import Readme from '../../components/Readme';
 import readmeText from './README.md?raw';
+import explainerText from './EXPLAINER.md?raw';
 import { useResponsive } from '../../styles/responsive';
 import { useViewportGestures } from '../../lib/useViewportGestures';
-import { ShellSettings, ShellActions, useAppHeader } from '../../components/AppShell';
+import { ShellSettings, ShellActions, useAppHeader, useAppExplainer } from '../../components/AppShell';
 import { Section, Slider, Pills, Select } from '../../components/ControlPanel';
 
 /** GPU accelerated Mandelbrot/Julia viewer using a fragment shader. */
@@ -401,6 +402,7 @@ export default function FractalsGPU() {
   }, [view]);
 
   useAppHeader(TYPE_NAMES[type], FORMULAS[type]);
+  useAppExplainer(explainerText);
 
   return (
     <>

--- a/src/animations/MobiusWalk/EXPLAINER.md
+++ b/src/animations/MobiusWalk/EXPLAINER.md
@@ -15,15 +15,15 @@ continuous loop.
 
 That half-twist makes the surface **non-orientable**: there is no consistent
 global way to say which way is "up", or to tell clockwise from
-anticlockwise. Walk all the way around the corridor and you return
+counterclockwise. Walk all the way around the corridor and you return
 **mirror-reversed** — left and right have swapped. Go around a *second* time
 to come back to normal. That's why the hallway looks ordinary until you
 notice the world has flipped.
 
 ## What you're seeing
 
-The walls are parametrised along the strip, and the gentle iridescent shading
+The walls are parametrized along the strip, and the gentle iridescent shading
 tracks your position around the loop, so you can tell how far around you've
-travelled. The "impossible" feeling — that the far end joins back to the
+traveled. The "impossible" feeling — that the far end joins back to the
 start with a flip — isn't a rendering trick; it's the genuine topology of the
 strip.

--- a/src/animations/MobiusWalk/EXPLAINER.md
+++ b/src/animations/MobiusWalk/EXPLAINER.md
@@ -1,0 +1,29 @@
+# Möbius Walk
+
+A first-person stroll down a corridor built on a **Möbius strip** — a surface
+with only one side and one edge.
+
+## One side, one edge
+
+Take a strip of paper, give one end a **half-twist** (180°), and glue it to
+the other end. The result is the Möbius strip. Trace a finger along the
+middle and you cover what *would* have been both faces without ever lifting
+off: there is only **one side**. Its boundary is likewise a single
+continuous loop.
+
+## Non-orientability
+
+That half-twist makes the surface **non-orientable**: there is no consistent
+global way to say which way is "up", or to tell clockwise from
+anticlockwise. Walk all the way around the corridor and you return
+**mirror-reversed** — left and right have swapped. Go around a *second* time
+to come back to normal. That's why the hallway looks ordinary until you
+notice the world has flipped.
+
+## What you're seeing
+
+The walls are parametrised along the strip, and the gentle iridescent shading
+tracks your position around the loop, so you can tell how far around you've
+travelled. The "impossible" feeling — that the far end joins back to the
+start with a flip — isn't a rendering trick; it's the genuine topology of the
+strip.

--- a/src/animations/MobiusWalk/MobiusWalk.tsx
+++ b/src/animations/MobiusWalk/MobiusWalk.tsx
@@ -4,7 +4,8 @@ import Canvas3D from '@/components/Canvas3D';
 import { makeCorridorGeometry, DEFAULT_PARAMS, paramToFrame } from './corridorGeometry';
 import { corridorMaterial } from './shaders/corridorMaterial';
 import { instantiateObjects } from './objects';
-import { ShellActions, useAppHeader } from '../../components/AppShell';
+import { ShellActions, useAppHeader, useAppExplainer } from '../../components/AppShell';
+import explainerText from './EXPLAINER.md?raw';
 
 export interface MobiusWalkProps {
   speed?: number;
@@ -16,6 +17,7 @@ export default function MobiusWalk({ speed = 2 }: MobiusWalkProps) {
   const [twist, setTwist] = useState(true);
 
   useAppHeader('Möbius Walk', twist ? 'twisted corridor' : 'untwisted corridor');
+  useAppExplainer(explainerText);
 
   const onMount = React.useCallback(({ scene, camera, renderer }: {
     scene: THREE.Scene;

--- a/src/animations/MobiusWalk/README.md
+++ b/src/animations/MobiusWalk/README.md
@@ -1,6 +1,6 @@
 # Mobius Walk
 
-A short on-rails stroll through a subtly twisted corridor. The hallway appears ordinary until you realise left and right have swapped. A gentle iridescent shader colours the walls while small objects line the passage.
+A short on-rails stroll through a subtly twisted corridor. The hallway appears ordinary until you realize left and right have swapped. A gentle iridescent shader colors the walls while small objects line the passage.
 
 Import `MobiusWalk` and mount it like any other `<Canvas3D>` scene.
 

--- a/src/animations/PlaneTransform/EXPLAINER.md
+++ b/src/animations/PlaneTransform/EXPLAINER.md
@@ -1,0 +1,46 @@
+# Plane Transform
+
+Shows a complex function **f : ℂ → ℂ** as a *transformation of the plane*.
+The input pane is a coloured grid of points `z = x + iy`; the output pane
+shows where each point lands, `w = f(z)`.
+
+## Reading the two panes
+
+- **Same colour = same point.** A patch of colour in the input pane tells you
+  *which* input it is; find that colour in the output pane to see where `f`
+  sent it.
+- **Conformal maps** (like `z²`, `eᶻ`, `1/z`) preserve angles: grid lines
+  that cross at right angles in the input still cross at right angles in the
+  output, even where the map stretches and bends them.
+
+## Colour
+
+Hue is the **argument** of `z` (its angle around the origin); brightness and
+the tile pattern encode magnitude. Because the colour rides along with each
+point, you can watch how `f` rotates, stretches, folds, or tears the plane.
+
+## Multi-valued functions and the branch index
+
+Some functions don't have a single answer. **√z**, **ln z**, and
+**z^(p/q)** are *multi-valued*: every nonzero `z` has two square roots and
+infinitely many logarithms.
+
+The culprit is the **argument**. Write `z = r · e^{iθ}`; the angle `θ` is only
+defined up to adding multiples of `2π`. For `√z = √r · e^{iθ/2}`, replacing
+`θ` by `θ + 2π` flips the sign of the root. For `ln z = ln r + iθ`, it shifts
+the imaginary part by `2π`.
+
+To get a single-valued function we pick a **branch** — a consistent choice of
+`θ`. The **branch index** `k` offsets that choice:
+
+| Function | Effect of branch `k` |
+|---|---|
+| √z | adds **k·π** to the angle → `k = 0` and `k = 1` are the two roots |
+| ln z | adds **k·2π** to Im(ln z) → each `k` is a different sheet |
+| z^(p/q) | selects which of the `q` distinct roots you see |
+
+The **branch cut** is the line (here, the negative real axis) where the
+chosen angle jumps by `2π`; you'll see a colour discontinuity along it.
+Stepping the branch index walks you onto the next *sheet* of the function's
+Riemann surface — the multi-storey surface on which the function finally
+becomes single-valued.

--- a/src/animations/PlaneTransform/EXPLAINER.md
+++ b/src/animations/PlaneTransform/EXPLAINER.md
@@ -1,22 +1,22 @@
 # Plane Transform
 
 Shows a complex function **f : ℂ → ℂ** as a *transformation of the plane*.
-The input pane is a coloured grid of points `z = x + iy`; the output pane
+The input pane is a colored grid of points `z = x + iy`; the output pane
 shows where each point lands, `w = f(z)`.
 
 ## Reading the two panes
 
-- **Same colour = same point.** A patch of colour in the input pane tells you
-  *which* input it is; find that colour in the output pane to see where `f`
+- **Same color = same point.** A patch of color in the input pane tells you
+  *which* input it is; find that color in the output pane to see where `f`
   sent it.
 - **Conformal maps** (like `z²`, `eᶻ`, `1/z`) preserve angles: grid lines
   that cross at right angles in the input still cross at right angles in the
   output, even where the map stretches and bends them.
 
-## Colour
+## Color
 
 Hue is the **argument** of `z` (its angle around the origin); brightness and
-the tile pattern encode magnitude. Because the colour rides along with each
+the tile pattern encode magnitude. Because the color rides along with each
 point, you can watch how `f` rotates, stretches, folds, or tears the plane.
 
 ## Multi-valued functions and the branch index
@@ -40,7 +40,7 @@ To get a single-valued function we pick a **branch** — a consistent choice of
 | z^(p/q) | selects which of the `q` distinct roots you see |
 
 The **branch cut** is the line (here, the negative real axis) where the
-chosen angle jumps by `2π`; you'll see a colour discontinuity along it.
+chosen angle jumps by `2π`; you'll see a color discontinuity along it.
 Stepping the branch index walks you onto the next *sheet* of the function's
 Riemann surface — the multi-storey surface on which the function finally
 becomes single-valued.

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import * as THREE from 'three';
-import { ShellSettings, useAppHeader, useAppFunctions } from '../../components/AppShell';
+import { ShellSettings, useAppHeader, useAppFunctions, useAppExplainer } from '../../components/AppShell';
 import { Section, Slider, Pills, Select } from '../../components/ControlPanel';
 import Readme from '../../components/Readme';
 import readmeText from './README.md?raw';
+import explainerText from './EXPLAINER.md?raw';
 import {
   functionNames, functionFormulas, POW_PQ_INDEX,
   applyComplexBranch, complexPowRational,
@@ -55,6 +56,7 @@ export default function PlaneTransform() {
     ? `z^(${expP}/${expQ})`
     : functionFormulas[fnName];
   useAppHeader(fnName, fnFormula);
+  useAppExplainer(explainerText);
   useAppFunctions({
     names: functionNames,
     current: fnName,

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -323,7 +323,7 @@ export default function PlaneTransform() {
           )}
         </Section>
 
-        <Section title="Colour" icon="◐" defaultOpen>
+        <Section title="Color" icon="◐" defaultOpen>
           <Pills
             label="Mode"
             options={colourPills}
@@ -346,8 +346,8 @@ export default function PlaneTransform() {
             min={1} max={6} step={0.5}
             onChange={setPointSize} format={v => v.toFixed(1)} />
           <Slider label="Density (per side)" value={density}
-            min={40} max={400} step={20}
-            onChange={setDensity} format={v => `${v}×${v}`} />
+            min={40} max={900} step={20}
+            onChange={setDensity} format={v => `${v}×${v} (${((v * v) / 1e6).toFixed(2)}M)`} />
         </Section>
 
         <Section title="About" icon="ⓘ">

--- a/src/animations/PlaneTransform/README.md
+++ b/src/animations/PlaneTransform/README.md
@@ -1,6 +1,6 @@
 # Plane transform
 
-Visualises a complex function `f : ℂ → ℂ` as a transformation of the
+Visualizes a complex function `f : ℂ → ℂ` as a transformation of the
 plane: the left (or top) pane shows a colored grid of input points
 `z = x + iy`; the right (or bottom) pane shows the same colored points
 at their output positions `w = f(z)`. The colors are carried with each
@@ -28,7 +28,7 @@ output.
 
 ## Why two panes?
 
-This visualisation is the classical "domain coloring" diagram from
+This visualization is the classical "domain coloring" diagram from
 textbooks like Needham's *Visual Complex Analysis* and Wegert's
 *Visual Complex Functions*. The 4D-embedded view in
 [Complex Particles](#/) shows the function's graph; this view shows

--- a/src/animations/StableMarriage/EXPLAINER.md
+++ b/src/animations/StableMarriage/EXPLAINER.md
@@ -1,0 +1,42 @@
+# Stable Marriage
+
+The **Gale–Shapley** algorithm and the idea of a **stable matching**.
+
+## The problem
+
+Two groups (here "men" and "women") each rank everyone in the other group. A
+**matching** pairs them up. A pair is a **blocking pair** if two people who
+are *not* matched to each other would both rather be together than stay with
+their current partners — an unstable situation, since they'd defect. A
+matching with **no blocking pairs** is **stable**.
+
+## Gale–Shapley
+
+Repeat until everyone is matched:
+
+1. An unmatched proposer proposes to their most-preferred partner among those
+   they haven't asked yet.
+2. The receiver **tentatively** accepts if single, or if they prefer the new
+   proposer to their current tentative partner (dropping the old one).
+3. Rejected proposers move on to their next choice.
+
+**Theorem (Gale & Shapley, 1962):** this always terminates, and the result is
+always **stable**. The *Stability* tab checks this by counting blocking
+pairs — for a completed run, it finds zero.
+
+## Proposer advantage
+
+The side that *proposes* does systematically better. Gale–Shapley produces
+the **proposer-optimal** stable matching: every proposer gets the best
+partner they could have in *any* stable matching, and every receiver gets
+their worst. The **Asker vs Asked** averages make this visible.
+
+## The knobs
+
+- **Consensus** — how much everyone agrees on who is desirable. At 0%,
+  preferences are random noise; at 100%, everyone shares one ranking, so the
+  competition for the same top choices is fiercest.
+- **Proposer bias** — the share of proposals coming from the men's side.
+  Slide it to watch the proposer advantage shift.
+- The **Lab** sweeps consensus for *both* groups and heat-maps the average
+  rank each side ends up with.

--- a/src/animations/StableMarriage/StableMarriage.tsx
+++ b/src/animations/StableMarriage/StableMarriage.tsx
@@ -1013,8 +1013,8 @@ export default function StableMarriage() {
         <DistributionChart
           dataA={rankStats.menRanks}
           dataB={rankStats.womenRanks}
-          colorA="#3b82f6"
-          colorB="#ec4899"
+          colorA="#60a5fa"
+          colorB="#f472b6"
           labelA="Men"
           labelB="Women"
         />

--- a/src/animations/StableMarriage/StableMarriage.tsx
+++ b/src/animations/StableMarriage/StableMarriage.tsx
@@ -20,7 +20,8 @@ import {
   Zap
 } from 'lucide-react';
 import './stableMarriage.css';
-import { useAppHeader } from '../../components/AppShell';
+import { useAppHeader, useAppExplainer } from '../../components/AppShell';
+import explainerText from './EXPLAINER.md?raw';
 
 const MAX_POPULATION = 100;
 const ROW_HEIGHT = 64;
@@ -516,6 +517,7 @@ const DistributionChart = ({
 
 export default function StableMarriage() {
   useAppHeader('Stable Marriage');
+  useAppExplainer(explainerText);
   const [appMode, setAppMode] = useState<'visualizer' | 'lab'>('visualizer');
 
   const [n, setN] = useState(20);

--- a/src/animations/StableMarriage/stableMarriage.css
+++ b/src/animations/StableMarriage/stableMarriage.css
@@ -1,12 +1,30 @@
-:root {
-  color-scheme: light;
-}
+/* Stable Marriage — dark theme, matched to the AppShell chrome.
+   All colours flow from the --sm-* tokens below so the palette stays
+   consistent; the blue/pink/green/amber/purple accents remain semantic
+   (men / women / matched / active proposer / receiver). */
 
 .sm-app {
+  --sm-bg: #0c0c10;
+  --sm-surface: #15151c;
+  --sm-surface-2: #1c1c24;
+  --sm-raised: rgba(255, 255, 255, 0.04);
+  --sm-border: rgba(255, 255, 255, 0.09);
+  --sm-border-strong: rgba(255, 255, 255, 0.16);
+  --sm-fg: #ececf1;
+  --sm-fg-dim: #9b9ba3;
+  --sm-fg-mute: #6b6b73;
+  --sm-blue: #60a5fa;
+  --sm-pink: #f472b6;
+  --sm-green: #34d399;
+  --sm-amber: #fbbf24;
+  --sm-purple: #c084fc;
+  --sm-shadow: 0 8px 24px rgba(0, 0, 0, 0.45);
+
+  color-scheme: dark;
   font-family: 'Inter', system-ui, sans-serif;
-  color: #0f172a;
+  color: var(--sm-fg);
   padding: 32px;
-  background: #f8fafc;
+  background: var(--sm-bg);
   height: 100%;
   overflow-y: auto;
   overflow-x: hidden;
@@ -30,7 +48,7 @@
 
 .sm-header p {
   margin: 0;
-  color: #475569;
+  color: var(--sm-fg-dim);
 }
 
 .sm-mode-toggle {
@@ -39,11 +57,11 @@
 }
 
 .sm-card {
-  background: #ffffff;
+  background: var(--sm-surface);
   border-radius: 16px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--sm-border);
   padding: 20px;
-  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.08);
+  box-shadow: var(--sm-shadow);
 }
 
 .sm-card + .sm-card {
@@ -68,7 +86,7 @@
 
 .sm-card-header p {
   margin: 0;
-  color: #64748b;
+  color: var(--sm-fg-dim);
   font-size: 13px;
 }
 
@@ -81,11 +99,11 @@
   align-items: center;
   gap: 8px;
   cursor: pointer;
-  transition: all 0.2s ease;
+  transition: background 0.2s ease, border-color 0.2s ease, opacity 0.2s ease;
 }
 
 .sm-button:disabled {
-  opacity: 0.5;
+  opacity: 0.45;
   cursor: not-allowed;
 }
 
@@ -94,32 +112,32 @@
   color: #fff;
 }
 
-.sm-button-primary:hover {
+.sm-button-primary:hover:not(:disabled) {
   background: #1d4ed8;
 }
 
 .sm-button-secondary {
-  background: #e2e8f0;
-  color: #0f172a;
+  background: rgba(255, 255, 255, 0.07);
+  color: var(--sm-fg);
 }
 
-.sm-button-secondary:hover {
-  background: #cbd5f5;
+.sm-button-secondary:hover:not(:disabled) {
+  background: rgba(255, 255, 255, 0.13);
 }
 
 .sm-button-outline {
-  background: #ffffff;
-  border: 1px solid #cbd5f5;
-  color: #0f172a;
+  background: transparent;
+  border: 1px solid var(--sm-border-strong);
+  color: var(--sm-fg);
 }
 
-.sm-button-outline:hover {
-  border-color: #94a3b8;
+.sm-button-outline:hover:not(:disabled) {
+  border-color: rgba(255, 255, 255, 0.32);
 }
 
 .sm-button-ghost {
   background: transparent;
-  color: #475569;
+  color: var(--sm-fg-dim);
 }
 
 .sm-controls {
@@ -139,23 +157,31 @@
   flex-direction: column;
   gap: 6px;
   font-size: 13px;
-  color: #475569;
+  color: var(--sm-fg-dim);
 }
 
 .sm-controls input[type='number'] {
   padding: 8px 10px;
   border-radius: 8px;
-  border: 1px solid #cbd5f5;
+  border: 1px solid var(--sm-border);
+  background: var(--sm-surface-2);
+  color: var(--sm-fg);
   font-size: 13px;
+}
+
+.sm-controls input[type='number']:focus-visible {
+  outline: 2px solid var(--sm-blue);
+  outline-offset: 1px;
 }
 
 .sm-controls input[type='range'] {
   width: 100%;
+  accent-color: var(--sm-blue);
 }
 
 .sm-controls span {
   font-size: 12px;
-  color: #1e293b;
+  color: var(--sm-fg);
 }
 
 .sm-toggle {
@@ -164,12 +190,18 @@
   gap: 8px;
 }
 
+.sm-toggle input[type='checkbox'] {
+  accent-color: var(--sm-blue);
+  width: 16px;
+  height: 16px;
+}
+
 .sm-actions {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 12px;
-  border-top: 1px solid #e2e8f0;
+  border-top: 1px solid var(--sm-border);
   padding-top: 16px;
 }
 
@@ -178,7 +210,7 @@
   flex-direction: column;
   gap: 4px;
   font-size: 12px;
-  color: #64748b;
+  color: var(--sm-fg-dim);
 }
 
 .sm-visualizer {
@@ -202,7 +234,7 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  color: #1e293b;
+  color: var(--sm-fg);
 }
 
 .sm-column-list {
@@ -230,37 +262,37 @@
   width: 42px;
   height: 42px;
   border-radius: 50%;
-  border: 2px solid #cbd5f5;
-  background: #ffffff;
+  border: 2px solid var(--sm-border-strong);
+  background: var(--sm-surface-2);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
-  transition: transform 0.2s ease, border-color 0.2s ease;
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
 .sm-person svg {
-  color: #2563eb;
+  color: var(--sm-blue);
 }
 
 .sm-person-row-left .sm-person svg {
-  color: #ec4899;
+  color: var(--sm-pink);
 }
 
 .sm-person-matched {
-  background: #ecfdf5;
-  border-color: #10b981;
+  background: rgba(52, 211, 153, 0.16);
+  border-color: var(--sm-green);
 }
 
 .sm-person-active {
-  border-color: #facc15;
-  box-shadow: 0 0 0 4px rgba(250, 204, 21, 0.4);
+  border-color: var(--sm-amber);
+  box-shadow: 0 0 0 4px rgba(251, 191, 36, 0.35);
   transform: scale(1.08);
 }
 
 .sm-person-target {
-  border-color: #a855f7;
-  box-shadow: 0 0 0 4px rgba(168, 85, 247, 0.35);
+  border-color: var(--sm-purple);
+  box-shadow: 0 0 0 4px rgba(192, 132, 252, 0.32);
   transform: scale(1.08);
 }
 
@@ -276,42 +308,42 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #dbeafe;
-  color: #1d4ed8;
-  border: 1px solid #bfdbfe;
+  background: rgba(37, 99, 235, 0.3);
+  color: #bfdbfe;
+  border: 1px solid rgba(96, 165, 250, 0.5);
 }
 
 .sm-role-badge.asked {
-  background: #ffedd5;
-  color: #c2410c;
-  border-color: #fed7aa;
+  background: rgba(234, 88, 12, 0.28);
+  color: #fdba74;
+  border-color: rgba(251, 146, 60, 0.5);
 }
 
 .sm-rank-badge {
   font-size: 10px;
   padding: 2px 6px;
   border-radius: 999px;
-  border: 1px solid #e2e8f0;
-  background: #f8fafc;
-  color: #334155;
+  border: 1px solid var(--sm-border);
+  background: var(--sm-raised);
+  color: var(--sm-fg-dim);
 }
 
 .rank-best {
-  background: #d1fae5;
-  border-color: #6ee7b7;
-  color: #047857;
+  background: rgba(52, 211, 153, 0.18);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: #6ee7b7;
 }
 
 .rank-mid {
-  background: #dbeafe;
-  border-color: #bfdbfe;
-  color: #1d4ed8;
+  background: rgba(96, 165, 250, 0.18);
+  border-color: rgba(96, 165, 250, 0.4);
+  color: #93c5fd;
 }
 
 .rank-low {
-  background: #fef3c7;
-  border-color: #fde68a;
-  color: #b45309;
+  background: rgba(251, 191, 36, 0.18);
+  border-color: rgba(251, 191, 36, 0.4);
+  color: #fcd34d;
 }
 
 .sm-result-card {
@@ -323,7 +355,7 @@
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  border-bottom: 1px solid #e2e8f0;
+  border-bottom: 1px solid var(--sm-border);
   padding-bottom: 12px;
   margin-bottom: 16px;
 }
@@ -335,8 +367,8 @@
 
 .sm-tabs button {
   border: none;
-  background: #f1f5f9;
-  color: #475569;
+  background: var(--sm-raised);
+  color: var(--sm-fg-dim);
   padding: 6px 10px;
   border-radius: 8px;
   font-size: 12px;
@@ -344,18 +376,24 @@
   align-items: center;
   gap: 6px;
   cursor: pointer;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+
+.sm-tabs button:hover {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--sm-fg);
 }
 
 .sm-tabs button.active {
-  background: #e2e8f0;
-  color: #0f172a;
+  background: rgba(255, 255, 255, 0.12);
+  color: var(--sm-fg);
 }
 
 .sm-result-meta {
   display: flex;
   gap: 12px;
   font-size: 12px;
-  color: #475569;
+  color: var(--sm-fg-dim);
 }
 
 .sm-result-meta span {
@@ -371,25 +409,26 @@
 }
 
 .sm-summary div {
-  background: #f8fafc;
+  background: var(--sm-raised);
   padding: 12px;
   border-radius: 10px;
-  border: 1px solid #e2e8f0;
+  border: 1px solid var(--sm-border);
   display: flex;
   flex-direction: column;
   gap: 4px;
+  color: var(--sm-fg-dim);
 }
 
 .sm-summary strong {
   font-size: 18px;
-  color: #0f172a;
+  color: var(--sm-fg);
 }
 
 .sm-stability {
   display: grid;
   gap: 12px;
   font-size: 13px;
-  color: #475569;
+  color: var(--sm-fg-dim);
 }
 
 .sm-stability-banner {
@@ -403,15 +442,15 @@
 }
 
 .sm-stability-banner.ok {
-  background: #ecfdf5;
-  border-color: #6ee7b7;
-  color: #047857;
+  background: rgba(52, 211, 153, 0.12);
+  border-color: rgba(52, 211, 153, 0.4);
+  color: #6ee7b7;
 }
 
 .sm-stability-banner.warn {
-  background: #fff7ed;
-  border-color: #fed7aa;
-  color: #c2410c;
+  background: rgba(251, 146, 60, 0.12);
+  border-color: rgba(251, 146, 60, 0.4);
+  color: #fdba74;
 }
 
 .sm-distribution {
@@ -424,6 +463,7 @@
   justify-content: center;
   gap: 16px;
   font-size: 12px;
+  color: var(--sm-fg-dim);
 }
 
 .sm-distribution-key {
@@ -461,11 +501,12 @@
   position: absolute;
   top: -28px;
   opacity: 0;
-  background: #0f172a;
-  color: #fff;
+  background: #20202a;
+  color: var(--sm-fg);
   font-size: 10px;
   padding: 4px 6px;
   border-radius: 6px;
+  border: 1px solid var(--sm-border-strong);
   pointer-events: none;
   transition: opacity 0.2s ease;
   white-space: nowrap;
@@ -490,7 +531,7 @@
 
 .sm-distribution-label {
   font-size: 10px;
-  color: #94a3b8;
+  color: var(--sm-fg-mute);
 }
 
 .sm-distribution-caption {
@@ -498,7 +539,7 @@
   font-size: 10px;
   text-transform: uppercase;
   letter-spacing: 0.1em;
-  color: #94a3b8;
+  color: var(--sm-fg-mute);
 }
 
 .sm-lab {
@@ -519,10 +560,10 @@
   align-items: center;
   justify-content: center;
   gap: 8px;
-  color: #94a3b8;
-  background: #f8fafc;
+  color: var(--sm-fg-mute);
+  background: var(--sm-raised);
   border-radius: 12px;
-  border: 1px dashed #cbd5f5;
+  border: 1px dashed var(--sm-border);
 }
 
 .sm-heatmap {
@@ -535,7 +576,7 @@
   margin: 0;
   font-size: 13px;
   text-align: center;
-  color: #334155;
+  color: var(--sm-fg);
 }
 
 .sm-heatmap-body {
@@ -554,7 +595,7 @@
 .sm-heatmap-axis span {
   transform: rotate(-90deg);
   font-size: 10px;
-  color: #64748b;
+  color: var(--sm-fg-dim);
   font-weight: 600;
   white-space: nowrap;
 }
@@ -562,8 +603,8 @@
 .sm-heatmap-grid {
   flex: 1;
   position: relative;
-  background: #fff;
-  border: 1px solid #e2e8f0;
+  background: var(--sm-bg);
+  border: 1px solid var(--sm-border);
   border-radius: 12px;
   overflow: hidden;
 }
@@ -574,7 +615,7 @@
 }
 
 .sm-heatmap-cell:hover {
-  filter: brightness(0.95);
+  filter: brightness(1.15);
 }
 
 .sm-heatmap-hover {
@@ -587,17 +628,17 @@
 }
 
 .sm-heatmap-tooltip {
-  background: rgba(15, 23, 42, 0.9);
-  color: #fff;
+  background: rgba(8, 8, 12, 0.92);
+  color: var(--sm-fg);
   padding: 10px 12px;
   border-radius: 12px;
   font-size: 11px;
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--sm-border-strong);
 }
 
 .sm-heatmap-tooltip-header {
   font-weight: 600;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.2);
+  border-bottom: 1px solid var(--sm-border-strong);
   padding-bottom: 6px;
   margin-bottom: 6px;
   text-align: center;
@@ -613,7 +654,7 @@
   text-align: center;
   font-size: 11px;
   font-weight: 600;
-  color: #64748b;
+  color: var(--sm-fg-dim);
 }
 
 .sm-heatmap-legend {
@@ -621,7 +662,7 @@
   align-items: center;
   justify-content: space-between;
   font-size: 10px;
-  color: #64748b;
+  color: var(--sm-fg-dim);
   gap: 8px;
 }
 
@@ -633,7 +674,7 @@
 }
 
 .sm-heatmap-legend-diverging .sm-heatmap-legend-bar {
-  background: linear-gradient(90deg, #3b82f6, #ffffff, #f472b6);
+  background: linear-gradient(90deg, #3b82f6, #e5e7eb, #f472b6);
 }
 
 @media (max-width: 900px) {
@@ -693,19 +734,19 @@
     height: 8px;
     -webkit-appearance: none;
     appearance: none;
-    background: #cbd5f5;
+    background: rgba(255, 255, 255, 0.15);
     border-radius: 4px;
   }
   .sm-controls input[type='range']::-webkit-slider-thumb {
     -webkit-appearance: none;
     width: 22px; height: 22px; border-radius: 50%;
-    background: #2563eb; cursor: pointer;
+    background: var(--sm-blue); cursor: pointer;
   }
   .sm-controls input[type='range']::-moz-range-thumb {
     width: 22px; height: 22px; border-radius: 50%;
-    background: #2563eb; border: none; cursor: pointer;
+    background: var(--sm-blue); border: none; cursor: pointer;
   }
 }
 
 /* Heatmap cell: keep hover-style highlight for taps too */
-.sm-heatmap-cell.pinned { filter: brightness(0.85); }
+.sm-heatmap-cell.pinned { filter: brightness(1.3); }

--- a/src/apps.ts
+++ b/src/apps.ts
@@ -1,0 +1,49 @@
+import type { AppDescriptor } from './components/AppShell';
+
+/** Catalog of animations, shared by the hash router (src/index.tsx) and the
+ *  menu screen (src/components/Menu.tsx). The order here is the order shown
+ *  both in the drawer's Apps tab and on the landing gallery. */
+export const apps: AppDescriptor[] = [
+  {
+    hash: '/complex-particles',
+    name: 'Complex Particles',
+    icon: '✦',
+    blurb: 'Visualise z → f(z) as a cloud of particles living in 4D, projected down to 3D.',
+  },
+  {
+    hash: '/plane-transform',
+    name: 'Plane Transform',
+    icon: '↦',
+    blurb: 'Watch a complex function f : ℂ → ℂ warp a colored grid of the plane.',
+  },
+  {
+    hash: '/fractals',
+    name: 'Fractals',
+    icon: '◯',
+    blurb: 'Explore the Mandelbrot, Julia, Burning Ship and Tricorn sets, rendered on the GPU.',
+  },
+  {
+    hash: '/correspondence',
+    name: 'Mandelbrot ↔ Julia',
+    icon: '⇄',
+    blurb: 'See how every point of the Mandelbrot set seeds its own Julia set.',
+  },
+  {
+    hash: '/mobius',
+    name: 'Möbius Walk',
+    icon: '∞',
+    blurb: 'Take an on-rails stroll through a corridor with a hidden half-twist.',
+  },
+  {
+    hash: '/stable-marriage',
+    name: 'Stable Marriage',
+    icon: '♥',
+    blurb: 'Step through the Gale–Shapley algorithm and probe the stability of its matchings.',
+  },
+  {
+    hash: '/agentic-sorting',
+    name: 'Agentic Sorting',
+    icon: '⇅',
+    blurb: 'Watch autonomous agents with rival strategies race to sort a population of values.',
+  },
+];

--- a/src/components/ActionFloater.css
+++ b/src/components/ActionFloater.css
@@ -4,7 +4,7 @@
 .af {
   position: absolute;
   bottom: 16px;
-  right: 16px;
+  left: 16px;
   z-index: 35;
   background: rgba(12, 12, 16, 0.72);
   backdrop-filter: blur(8px);

--- a/src/components/ActionFloater.css
+++ b/src/components/ActionFloater.css
@@ -1,0 +1,109 @@
+/* ActionFloater — draggable floating actions panel (default: bottom-right).
+   Collapsed: a play button with a drag grip on its left edge. */
+
+.af {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  z-index: 35;
+  background: rgba(12, 12, 16, 0.72);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 10px;
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+}
+.af-inactive { display: none; }
+
+.af-collapsed { padding: 3px; }
+.af-open { padding: 10px; width: 240px; max-width: calc(100vw - 32px); }
+
+/* Drag grip — present in both states. */
+.af-grip {
+  color: #6b6b73;
+  font-size: 13px;
+  line-height: 1;
+  cursor: grab;
+  touch-action: none;
+  user-select: none;
+  padding: 4px 2px;
+}
+.af-grip:active { cursor: grabbing; }
+
+/* Collapsed: grip on the left edge + play button. */
+.af-collapsed-row {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+}
+.af-grip-collapsed {
+  align-self: stretch;
+  display: flex;
+  align-items: center;
+  border-radius: 6px;
+}
+.af-grip-collapsed:hover { background: rgba(255, 255, 255, 0.06); }
+
+.af-play {
+  width: 34px;
+  height: 34px;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  color: var(--cp-accent, #ffd400);
+  font-size: 14px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.af-play:hover { background: rgba(255, 255, 255, 0.08); }
+
+/* Open: draggable header. */
+.af-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.af-title {
+  flex: 1;
+  font-size: 11px;
+  color: #9b9ba3;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.af-iconbtn {
+  background: transparent;
+  border: none;
+  color: #9b9ba3;
+  cursor: pointer;
+  font-size: 16px;
+  width: 24px;
+  height: 24px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+.af-iconbtn:hover { background: rgba(255, 255, 255, 0.08); color: #f0f0f3; }
+
+/* The actions render here (portaled from ShellActions). Reuse the drawer's
+   section-body spacing so buttons stack the same way. */
+.af-body {
+  max-height: 60vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+.af-body .cp-section-body {
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}

--- a/src/components/ActionFloater.tsx
+++ b/src/components/ActionFloater.tsx
@@ -1,0 +1,56 @@
+import React, { useState } from 'react';
+import { useFloaterDrag } from './useFloaterDrag';
+import './ActionFloater.css';
+
+export interface ActionFloaterProps {
+  /** Whether the active app has any actions to show. */
+  active: boolean;
+  /** Title shown in the open panel's header. */
+  title: string;
+  /** Portal target for the actions; AppShell renders ShellActions into it. */
+  bodyRef: React.RefObject<HTMLDivElement>;
+}
+
+/**
+ * A draggable, collapsible floating panel that surfaces an app's actions on
+ * screen (mirroring the drawer's Actions tab). Collapsed, it's a ▶ play button
+ * with a little drag grip on its left edge; expanded, it shows the actions with
+ * a draggable header. The body div is always mounted so the actions portal
+ * target persists across collapse — it's just hidden when collapsed.
+ */
+export default function ActionFloater({ active, title, bodyRef }: ActionFloaterProps) {
+  const [open, setOpen] = useState(false);
+  const { panelRef, posStyle, dragHandlers } = useFloaterDrag();
+
+  return (
+    <div
+      ref={panelRef}
+      style={posStyle}
+      className={`af ${open ? 'af-open' : 'af-collapsed'} ${active ? '' : 'af-inactive'}`}
+    >
+      {open ? (
+        <div className="af-header">
+          <span className="af-grip" title="Drag to move" {...dragHandlers}>⠿</span>
+          <span className="af-title">{title}</span>
+          <button
+            className="af-iconbtn"
+            onClick={() => setOpen(false)}
+            aria-label="Hide actions"
+          >×</button>
+        </div>
+      ) : (
+        <div className="af-collapsed-row">
+          <span className="af-grip af-grip-collapsed" title="Drag to move" {...dragHandlers}>⠿</span>
+          <button
+            className="af-play"
+            onClick={() => setOpen(true)}
+            aria-label="Show actions"
+            title="Actions"
+          >▶</button>
+        </div>
+      )}
+
+      <div className="af-body" ref={bodyRef} style={{ display: open ? 'block' : 'none' }} />
+    </div>
+  );
+}

--- a/src/components/AppShell.css
+++ b/src/components/AppShell.css
@@ -125,14 +125,16 @@
 }
 
 /* ---------- Drawer / scrim ---------- */
+/* Transparent rather than a dark overlay: tapping outside still closes the
+   drawer, but the animation stays fully visible so you can watch settings
+   changes take effect live. */
 .as-scrim {
   position: fixed;
   inset: 0;
-  background: rgba(0, 0, 0, 0.4);
+  background: transparent;
   z-index: 99;
   opacity: 0;
   pointer-events: none;
-  transition: opacity 200ms ease;
 }
 .as-scrim.as-open { opacity: 1; pointer-events: auto; }
 

--- a/src/components/AppShell.css
+++ b/src/components/AppShell.css
@@ -73,7 +73,10 @@
 .as-bar-btn-dim { opacity: 0.4; }
 
 .as-bar-title {
-  flex: 1;
+  /* Don't grow: take only the width the name/formula needs (shrinking with
+     ellipsis when cramped) so the controls stay clustered on the left rather
+     than the trailing buttons being pushed to the far edge. */
+  flex: 0 1 auto;
   display: flex;
   align-items: center;
   gap: 12px;
@@ -87,6 +90,9 @@
   color: var(--as-fg);
   text-align: left;
 }
+
+/* Eats the remaining bar width after the control cluster. */
+.as-bar-spacer { flex: 1 1 auto; min-width: 0; }
 .as-bar-title:hover { background: var(--as-hover); }
 .as-bar-title-name {
   font-weight: 600;
@@ -242,3 +248,119 @@
 /* ---------- Sections shared with old ControlPanel ---------- */
 .as-tab-body .cp-section { border-bottom: 1px solid var(--as-border); }
 .as-tab-body .cp-section:last-child { border-bottom: none; }
+
+/* ---------- Help / explainer popup ---------- */
+.as-help-scrim {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(2px);
+  -webkit-backdrop-filter: blur(2px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  /* Respect notches/home indicator when the popup is full-height on phones. */
+  padding-top: max(24px, env(safe-area-inset-top, 0));
+  padding-bottom: max(24px, env(safe-area-inset-bottom, 0));
+}
+
+.as-help-modal {
+  width: 100%;
+  max-width: 680px;
+  max-height: 100%;
+  background: var(--as-bg);
+  border: 1px solid var(--as-border);
+  border-radius: 12px;
+  box-shadow: var(--as-shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.as-help-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 10px 10px 18px;
+  border-bottom: 1px solid var(--as-border);
+  flex-shrink: 0;
+}
+.as-help-title {
+  flex: 1;
+  margin: 0;
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.as-help-body {
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  padding: 8px 22px 24px;
+}
+
+/* Markdown typography for the explainer body. */
+.as-help-body .markdown-body {
+  color: var(--as-fg-dim);
+  font-size: 14.5px;
+  line-height: 1.62;
+}
+.as-help-body .markdown-body h1 {
+  color: var(--as-fg);
+  font-size: 22px;
+  margin: 18px 0 8px;
+}
+.as-help-body .markdown-body h2 {
+  color: var(--as-fg);
+  font-size: 17px;
+  margin: 22px 0 8px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid var(--as-border);
+}
+.as-help-body .markdown-body h3 {
+  color: var(--as-fg);
+  font-size: 15px;
+  margin: 16px 0 6px;
+}
+.as-help-body .markdown-body p { margin: 8px 0; }
+.as-help-body .markdown-body a { color: var(--as-accent); }
+.as-help-body .markdown-body strong { color: var(--as-fg); }
+.as-help-body .markdown-body ul,
+.as-help-body .markdown-body ol { padding-left: 22px; margin: 8px 0; }
+.as-help-body .markdown-body li { margin: 4px 0; }
+.as-help-body .markdown-body code {
+  background: rgba(255, 255, 255, 0.08);
+  padding: 1px 5px;
+  border-radius: 4px;
+  font-size: 0.92em;
+  color: var(--as-fg);
+}
+.as-help-body .markdown-body table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 12px 0;
+  font-size: 13.5px;
+}
+.as-help-body .markdown-body th,
+.as-help-body .markdown-body td {
+  border: 1px solid var(--as-border);
+  padding: 7px 10px;
+  text-align: left;
+}
+.as-help-body .markdown-body th {
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--as-fg);
+  font-weight: 600;
+}
+.as-help-body .markdown-body blockquote {
+  margin: 10px 0;
+  padding: 2px 14px;
+  border-left: 3px solid var(--as-accent);
+  color: var(--as-fg-dim);
+}
+
+@media (max-width: 600px) {
+  .as-help-scrim { padding: 0; }
+  .as-help-modal { max-width: 100%; height: 100%; max-height: 100%; border-radius: 0; }
+}

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -9,6 +9,8 @@ export interface AppDescriptor {
   name: string;
   /** Optional emoji or single character used as a list-icon. */
   icon?: string;
+  /** One-line description shown on the menu screen's gallery cards. */
+  blurb?: string;
 }
 
 /** Apps register their function picker via useAppFunctions so the AppShell's
@@ -79,8 +81,9 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
-  const current = apps.find(a => a.hash === currentHash) ?? apps[0];
-  const titleName = header.title ?? current?.name ?? '';
+  const isHome = currentHash === '/';
+  const current = apps.find(a => a.hash === currentHash);
+  const titleName = header.title ?? (isHome ? 'animath' : current?.name) ?? '';
   const subtitle = header.subtitle;
   const hasFunctions = functions != null;
 
@@ -104,6 +107,14 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     <AppShellContext.Provider value={ctx}>
       <div className="as-shell">
         <header className="as-bar">
+          {currentHash !== '/' && (
+            <button
+              className="as-bar-btn"
+              aria-label="Menu screen"
+              title="Menu"
+              onClick={() => onNavigate('/')}
+            >⌂</button>
+          )}
           <button
             className="as-bar-btn"
             aria-label="Apps"

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,9 @@
-import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, Suspense } from 'react';
 import { createPortal } from 'react-dom';
 import './AppShell.css';
+
+// Lazily loaded so `marked` only enters the bundle when a help popup is opened.
+const Readme = React.lazy(() => import('./Readme'));
 
 export interface AppDescriptor {
   /** Hash route (no leading `#`, e.g. `/` or `/fractals`). */
@@ -42,6 +45,9 @@ export interface AppShellState {
   /** Function registration (or null when the active app has no function picker). */
   functions: AppFunctionsRegistration | null;
   setFunctions: (reg: AppFunctionsRegistration | null) => void;
+  /** Markdown explainer for the active app (the "?" help popup), or null. */
+  explainer: string | null;
+  setExplainer: (md: string | null) => void;
 }
 
 const AppShellContext = createContext<AppShellState | null>(null);
@@ -62,6 +68,8 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
   const [hasSettings, setHasSettings] = useState(false);
   const [hasActions, setHasActions] = useState(false);
   const [functions, setFunctions] = useState<AppFunctionsRegistration | null>(null);
+  const [explainer, setExplainer] = useState<string | null>(null);
+  const [helpOpen, setHelpOpen] = useState(false);
   const settingsTargetRef = useRef<HTMLDivElement | null>(null);
   const actionsTargetRef = useRef<HTMLDivElement | null>(null);
 
@@ -71,12 +79,18 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     setHasSettings(false);
     setHasActions(false);
     setFunctions(null);
+    setExplainer(null);
+    setHelpOpen(false);
     setTab('apps');
   }, [currentHash]);
 
-  // Escape closes drawer.
+  // Escape closes the help popup, then the drawer.
   useEffect(() => {
-    const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setOpen(false); };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Escape') return;
+      setHelpOpen(false);
+      setOpen(false);
+    };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
   }, []);
@@ -86,6 +100,7 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
   const titleName = header.title ?? (isHome ? 'animath' : current?.name) ?? '';
   const subtitle = header.subtitle;
   const hasFunctions = functions != null;
+  const hasExplainer = explainer != null;
 
   const ctx = useMemo<AppShellState>(() => ({
     title: header.title,
@@ -99,7 +114,9 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     setHeader,
     functions,
     setFunctions,
-  }), [header.title, header.subtitle, hasSettings, hasActions, functions]);
+    explainer,
+    setExplainer,
+  }), [header.title, header.subtitle, hasSettings, hasActions, functions, explainer]);
 
   const openWithTab = useCallback((t: Tab) => { setTab(t); setOpen(true); }, []);
 
@@ -147,6 +164,15 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
             title="Actions"
             onClick={() => openWithTab('actions')}
           >▶</button>
+          <button
+            className={`as-bar-btn ${hasExplainer ? '' : 'as-bar-btn-dim'}`}
+            aria-label="Explainer"
+            title="What am I looking at?"
+            onClick={() => { if (hasExplainer) setHelpOpen(true); }}
+          >?</button>
+          {/* Absorbs the leftover width so the controls cluster on the left
+              instead of the actions stretching to the far right. */}
+          <div className="as-bar-spacer" />
         </header>
 
         <div className="as-content">
@@ -209,6 +235,36 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
             {!hasActions && <div className="as-empty">No actions for this view.</div>}
           </div>
         </aside>
+
+        {helpOpen && explainer && (
+          <div
+            className="as-help-scrim"
+            onClick={() => setHelpOpen(false)}
+            role="presentation"
+          >
+            <div
+              className="as-help-modal"
+              role="dialog"
+              aria-modal="true"
+              aria-label={`${titleName} — explainer`}
+              onClick={(e) => e.stopPropagation()}
+            >
+              <div className="as-help-header">
+                <h2 className="as-help-title">{titleName}</h2>
+                <button
+                  className="as-bar-btn"
+                  aria-label="Close explainer"
+                  onClick={() => setHelpOpen(false)}
+                >×</button>
+              </div>
+              <div className="as-help-body">
+                <Suspense fallback={<div className="as-empty">Loading…</div>}>
+                  <Readme markdown={explainer} />
+                </Suspense>
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </AppShellContext.Provider>
   );
@@ -285,6 +341,19 @@ export function useAppFunctions(reg: AppFunctionsRegistration | null) {
     shell.setFunctions(reg ? { names: reg.names, current: reg.current, onChange: reg.onChange } : null);
     return () => shell.setFunctions(null);
   }, [shell, names, current, onChange]);
+}
+
+/** Register the active app's markdown explainer, shown by the top-bar "?"
+ *  button in a popup. Apps that don't call this leave the button dimmed.
+ *  Content lives in standalone `EXPLAINER.md` files imported with `?raw`, so
+ *  it can be edited without touching component code. */
+export function useAppExplainer(markdown: string | null) {
+  const shell = useContext(AppShellContext);
+  useEffect(() => {
+    if (!shell) return;
+    shell.setExplainer(markdown);
+    return () => shell.setExplainer(null);
+  }, [shell, markdown]);
 }
 
 /** Render children into the drawer's Settings tab. */

--- a/src/components/AppShell.tsx
+++ b/src/components/AppShell.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState, Suspense } from 'react';
 import { createPortal } from 'react-dom';
 import './AppShell.css';
+import ActionFloater from './ActionFloater';
 
 // Lazily loaded so `marked` only enters the bundle when a help popup is opened.
 const Readme = React.lazy(() => import('./Readme'));
@@ -36,6 +37,11 @@ export interface AppShellState {
   /** DOM nodes — portal targets — for the Settings and Actions drawer tabs. */
   settingsTargetRef: React.RefObject<HTMLDivElement | null>;
   actionsTargetRef: React.RefObject<HTMLDivElement | null>;
+  /** Portal target for the floating ActionFloater (a mirror of the actions). */
+  actionsFloaterRef: React.RefObject<HTMLDivElement | null>;
+  /** Lets an app suppress the generic floating action panel when it ships its
+   *  own (e.g. Correspondence's PlaybackFloater). */
+  setActionFloaterOff: (off: boolean) => void;
   /** Whether the registered app has populated each tab. */
   hasSettings: boolean;
   hasActions: boolean;
@@ -70,8 +76,10 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
   const [functions, setFunctions] = useState<AppFunctionsRegistration | null>(null);
   const [explainer, setExplainer] = useState<string | null>(null);
   const [helpOpen, setHelpOpen] = useState(false);
+  const [actionFloaterOff, setActionFloaterOff] = useState(false);
   const settingsTargetRef = useRef<HTMLDivElement | null>(null);
   const actionsTargetRef = useRef<HTMLDivElement | null>(null);
+  const actionsFloaterRef = useRef<HTMLDivElement | null>(null);
 
   // Reset header + tab flags when the active app changes.
   useEffect(() => {
@@ -81,6 +89,7 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     setFunctions(null);
     setExplainer(null);
     setHelpOpen(false);
+    setActionFloaterOff(false);
     setTab('apps');
   }, [currentHash]);
 
@@ -107,6 +116,8 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
     subtitle: header.subtitle,
     settingsTargetRef,
     actionsTargetRef,
+    actionsFloaterRef,
+    setActionFloaterOff,
     hasSettings,
     hasActions,
     setHasSettings,
@@ -177,6 +188,14 @@ export function AppShell({ apps, currentHash, onNavigate, children }: AppShellPr
 
         <div className="as-content">
           {children}
+          {/* Floating, draggable mirror of the app's actions. Always mounted so
+              its portal target persists; hidden when the app has no actions or
+              ships its own floater. */}
+          <ActionFloater
+            active={hasActions && !actionFloaterOff}
+            title={titleName}
+            bodyRef={actionsFloaterRef}
+          />
         </div>
 
         <div className={`as-scrim ${open ? 'as-open' : ''}`} onClick={() => setOpen(false)} />
@@ -371,17 +390,33 @@ export function ShellSettings({ children }: { children: React.ReactNode }) {
   return createPortal(<>{children}</>, shell.settingsTargetRef.current);
 }
 
-/** Render children into the drawer's Actions tab. */
+/** Render children into BOTH the drawer's Actions tab and the floating
+ *  ActionFloater, so the two stay in sync. The floater's body target is always
+ *  mounted, so by the time this child's effect runs both refs are populated. */
 export function ShellActions({ children }: { children: React.ReactNode }) {
   const shell = useShell();
   const [ready, setReady] = useState(false);
   useEffect(() => {
-    if (shell.actionsTargetRef.current) {
-      setReady(true);
-      shell.setHasActions(true);
-    }
+    setReady(true);
+    shell.setHasActions(true);
     return () => shell.setHasActions(false);
   }, [shell]);
-  if (!ready || !shell.actionsTargetRef.current) return null;
-  return createPortal(<>{children}</>, shell.actionsTargetRef.current);
+  if (!ready) return null;
+  return (
+    <>
+      {shell.actionsTargetRef.current && createPortal(<>{children}</>, shell.actionsTargetRef.current)}
+      {shell.actionsFloaterRef.current && createPortal(<>{children}</>, shell.actionsFloaterRef.current)}
+    </>
+  );
+}
+
+/** Suppress the generic floating action panel for apps that provide their own
+ *  (e.g. Correspondence's PlaybackFloater with its scrubber). */
+export function useActionFloaterOff() {
+  const shell = useContext(AppShellContext);
+  useEffect(() => {
+    if (!shell) return;
+    shell.setActionFloaterOff(true);
+    return () => shell.setActionFloaterOff(false);
+  }, [shell]);
 }

--- a/src/components/Menu.css
+++ b/src/components/Menu.css
@@ -1,0 +1,113 @@
+/* Menu — the landing gallery shown at the `/` route. Reuses the AppShell
+   design tokens (--as-*) so it stays visually consistent with the chrome. */
+
+.menu {
+  padding: clamp(24px, 6vw, 64px) clamp(16px, 5vw, 48px) 64px;
+  color: var(--as-fg);
+  background:
+    radial-gradient(1200px 600px at 50% -10%, rgba(255, 212, 0, 0.08), transparent 60%),
+    var(--as-bg);
+}
+
+/* ---------- Hero ---------- */
+.menu-hero {
+  max-width: 760px;
+  margin: 0 auto clamp(28px, 5vw, 48px);
+  text-align: center;
+}
+.menu-title {
+  margin: 0;
+  font-size: clamp(40px, 9vw, 76px);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  background: linear-gradient(120deg, var(--as-fg) 30%, var(--as-accent));
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+.menu-tagline {
+  margin: 16px auto 0;
+  max-width: 46ch;
+  color: var(--as-fg-dim);
+  font-size: clamp(14px, 2.2vw, 17px);
+  line-height: 1.5;
+}
+
+/* ---------- Card grid ---------- */
+.menu-grid {
+  max-width: 960px;
+  margin: 0 auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+
+.menu-card {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+  text-align: left;
+  padding: 20px;
+  border-radius: var(--as-radius);
+  border: 1px solid var(--as-border);
+  background: rgba(255, 255, 255, 0.03);
+  color: var(--as-fg);
+  cursor: pointer;
+  transition: transform 160ms ease, border-color 160ms ease,
+    background 160ms ease, box-shadow 160ms ease;
+}
+.menu-card:hover,
+.menu-card:focus-visible {
+  transform: translateY(-3px);
+  border-color: rgba(255, 212, 0, 0.5);
+  background: rgba(255, 255, 255, 0.06);
+  box-shadow: var(--as-shadow);
+  outline: none;
+}
+
+.menu-card-icon {
+  flex-shrink: 0;
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 24px;
+  border-radius: 10px;
+  background: rgba(255, 212, 0, 0.12);
+  color: var(--as-accent);
+}
+
+.menu-card-body {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.menu-card-name {
+  font-size: 17px;
+  font-weight: 700;
+}
+.menu-card-blurb {
+  font-size: 13px;
+  line-height: 1.45;
+  color: var(--as-fg-dim);
+}
+
+.menu-card-go {
+  flex-shrink: 0;
+  align-self: center;
+  font-size: 18px;
+  color: var(--as-fg-dim);
+  opacity: 0;
+  transform: translateX(-4px);
+  transition: opacity 160ms ease, transform 160ms ease, color 160ms ease;
+}
+.menu-card:hover .menu-card-go,
+.menu-card:focus-visible .menu-card-go {
+  opacity: 1;
+  transform: translateX(0);
+  color: var(--as-accent);
+}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,0 +1,39 @@
+import { apps } from '../apps';
+import './Menu.css';
+
+/** Landing screen: a gallery of every animation in the toolkit. Mounted at the
+ *  default `/` route. Cards navigate by setting the hash, which the router in
+ *  src/index.tsx listens to. The bar title ("animath") is supplied by AppShell
+ *  for the home route, so this view does not register its own header. */
+export default function Menu() {
+  const go = (hash: string) => { window.location.hash = '#' + hash; };
+
+  return (
+    <div className="as-content-scroll menu">
+      <header className="menu-hero">
+        <h1 className="menu-title">animath</h1>
+        <p className="menu-tagline">
+          A toolkit for mathematical animations &amp; generative art.
+          Pick something to explore.
+        </p>
+      </header>
+
+      <div className="menu-grid">
+        {apps.map(app => (
+          <button
+            key={app.hash}
+            className="menu-card"
+            onClick={() => go(app.hash)}
+          >
+            <span className="menu-card-icon" aria-hidden="true">{app.icon ?? '•'}</span>
+            <span className="menu-card-body">
+              <span className="menu-card-name">{app.name}</span>
+              {app.blurb && <span className="menu-card-blurb">{app.blurb}</span>}
+            </span>
+            <span className="menu-card-go" aria-hidden="true">→</span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Canvas3D from './Canvas3D';
 import Readme from './Readme';
 import { Section, Slider, Pills, Select, Checkbox } from './ControlPanel';
-import { ShellSettings, ShellActions, useAppHeader, useAppFunctions } from './AppShell';
+import { ShellSettings, ShellActions, useAppHeader, useAppFunctions, useAppExplainer } from './AppShell';
 import QuarterTurnFloater from '../controls/QuarterTurnFloater';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../config/defaults';
 import { useResponsive } from '../styles/responsive';
@@ -39,17 +39,20 @@ export interface ParticleViewerShellProps {
     onChangeIndex: (i: number) => void;
   };
   readme: string;
+  /** Markdown explainer for the top-bar "?" help popup. */
+  explainer?: string;
 }
 
 export default function ParticleViewerShell({
   state, controls, onMount,
-  functionName, functionFormula, functionPicker, variantExtras, functionList, readme,
+  functionName, functionFormula, functionPicker, variantExtras, functionList, readme, explainer,
 }: ParticleViewerShellProps) {
   const { isMobile, isTablet } = useResponsive();
   const compact = isMobile || isTablet;
   const gestures = useGestureRotation(state);
 
   useAppHeader(functionName, functionFormula);
+  useAppExplainer(explainer ?? null);
   useAppFunctions(functionList ? {
     names: functionList.names,
     current: functionList.names[functionList.currentIndex] ?? '',

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import Canvas3D from './Canvas3D';
 import Readme from './Readme';
 import { Section, Slider, Pills, Select, Checkbox } from './ControlPanel';
-import { ShellSettings, ShellActions, useAppHeader, useAppFunctions, useAppExplainer } from './AppShell';
+import { ShellSettings, ShellActions, useAppHeader, useAppFunctions, useAppExplainer, useActionFloaterOff } from './AppShell';
 import QuarterTurnFloater from '../controls/QuarterTurnFloater';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../config/defaults';
 import { useResponsive } from '../styles/responsive';
@@ -53,6 +53,9 @@ export default function ParticleViewerShell({
 
   useAppHeader(functionName, functionFormula);
   useAppExplainer(explainer ?? null);
+  // The QuarterTurnFloater already provides reset / drop-axis / 4D turns on
+  // screen, so suppress the generic ActionFloater here to avoid a duplicate.
+  useActionFloaterOff();
   useAppFunctions(functionList ? {
     names: functionList.names,
     current: functionList.names[functionList.currentIndex] ?? '',

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -132,9 +132,9 @@ export default function ParticleViewerShell({
           )}
         </Section>
 
-        <Section title="Colour" icon="◑">
+        <Section title="Color" icon="◑">
           <Pills
-            label="Colour by"
+            label="Color by"
             options={[
               { value: ColourBy.Domain, label: 'Domain' },
               { value: ColourBy.Range, label: 'Range' },

--- a/src/components/Readme.tsx
+++ b/src/components/Readme.tsx
@@ -3,13 +3,17 @@ import { marked } from 'marked';
 
 export interface ReadmeProps {
   markdown: string;
+  /** Extra class on the wrapper; the `markdown-body` class is always present
+   *  so callers (ControlPanel About sections, AppShell help popup) can style
+   *  the rendered markdown via CSS rather than fixed inline sizing. */
+  className?: string;
 }
 
-export default function Readme({ markdown }: ReadmeProps) {
+export default function Readme({ markdown, className }: ReadmeProps) {
   const html = useMemo(() => marked.parse(markdown), [markdown]);
   return (
     <div
-      style={{ maxWidth: 300, maxHeight: 200, overflow: 'auto' }}
+      className={`markdown-body${className ? ` ${className}` : ''}`}
       dangerouslySetInnerHTML={{ __html: html }}
     />
   );

--- a/src/components/useFloaterDrag.ts
+++ b/src/components/useFloaterDrag.ts
@@ -1,0 +1,54 @@
+import React, { useRef, useState } from 'react';
+
+/**
+ * Pointer-drag behavior shared by the floating panels (PlaybackFloater,
+ * ActionFloater). Attach `dragHandlers` to whatever element should act as the
+ * grip (a header bar, or a little handle on the collapsed icon), put `panelRef`
+ * on the panel root, and spread `posStyle` onto it. Until the panel is dragged
+ * it stays anchored by its CSS default corner; once moved it switches to
+ * absolute left/top, clamped to stay inside the positioned ancestor.
+ */
+export function useFloaterDrag() {
+  const panelRef = useRef<HTMLDivElement>(null);
+  const [pos, setPos] = useState<{ x: number; y: number } | null>(null);
+  const dragRef = useRef<{ startX: number; startY: number; baseX: number; baseY: number } | null>(null);
+
+  const clampToParent = (x: number, y: number) => {
+    const el = panelRef.current;
+    const parent = el?.offsetParent as HTMLElement | null;
+    if (!el || !parent) return { x, y };
+    const maxX = Math.max(0, parent.clientWidth - el.offsetWidth);
+    const maxY = Math.max(0, parent.clientHeight - el.offsetHeight);
+    return { x: Math.max(0, Math.min(maxX, x)), y: Math.max(0, Math.min(maxY, y)) };
+  };
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    const el = panelRef.current;
+    if (!el) return;
+    dragRef.current = { startX: e.clientX, startY: e.clientY, baseX: el.offsetLeft, baseY: el.offsetTop };
+    setPos({ x: el.offsetLeft, y: el.offsetTop });
+    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    e.preventDefault();
+  };
+  const onPointerMove = (e: React.PointerEvent) => {
+    const d = dragRef.current;
+    if (!d) return;
+    setPos(clampToParent(d.baseX + (e.clientX - d.startX), d.baseY + (e.clientY - d.startY)));
+  };
+  const onPointerUp = () => { dragRef.current = null; };
+
+  const posStyle: React.CSSProperties = pos
+    ? { left: pos.x, top: pos.y, right: 'auto', bottom: 'auto' }
+    : {};
+
+  return {
+    panelRef,
+    posStyle,
+    dragHandlers: {
+      onPointerDown,
+      onPointerMove,
+      onPointerUp,
+      onPointerCancel: onPointerUp,
+    },
+  };
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
-import { AppShell, AppDescriptor } from './components/AppShell';
+import Menu from './components/Menu';
+import { AppShell } from './components/AppShell';
+import { apps } from './apps';
 
 const FractalsGPU = React.lazy(() => import('./animations/FractalsGPU/FractalsGPU'));
 const Fractals2D = React.lazy(() => import('./animations/Fractals/Fractals2D'));
@@ -11,18 +13,9 @@ const MobiusWalk = React.lazy(() => import('./animations/MobiusWalk/MobiusWalk')
 const StableMarriage = React.lazy(() => import('./animations/StableMarriage/StableMarriage'));
 const AgenticSorting = React.lazy(() => import('./animations/AgenticSorting/AgenticSorting'));
 
-const apps: AppDescriptor[] = [
-  { hash: '/', name: 'Complex Particles', icon: '✦' },
-  { hash: '/plane-transform', name: 'Plane Transform', icon: '↦' },
-  { hash: '/fractals', name: 'Fractals', icon: '◯' },
-  { hash: '/correspondence', name: 'Mandelbrot ↔ Julia', icon: '⇄' },
-  { hash: '/mobius', name: 'Möbius Walk', icon: '∞' },
-  { hash: '/stable-marriage', name: 'Stable Marriage', icon: '♥' },
-  { hash: '/agentic-sorting', name: 'Agentic Sorting', icon: '⇅' },
-];
-
 const routes: Record<string, React.ComponentType> = {
-  '/': App,
+  '/': Menu,
+  '/complex-particles': App,
   '/plane-transform': PlaneTransform,
   '/fractals': FractalsGPU,
   '/fractals-cpu': Fractals2D,
@@ -45,7 +38,7 @@ function Router(): JSX.Element {
     return () => window.removeEventListener('hashchange', handleHashChange);
   }, []);
 
-  const Component = routes[hash] ?? App;
+  const Component = routes[hash] ?? Menu;
   const navigate = (h: string) => { window.location.hash = '#' + h; };
 
   return (

--- a/src/lib/colormaps.ts
+++ b/src/lib/colormaps.ts
@@ -1,0 +1,92 @@
+/**
+ * Shared GLSL for fractal palettes, injected into the FractalsGPU and
+ * Correspondence fragment shaders so both expose the same colormaps.
+ *
+ * `paletteColor(t, scheme)` takes an escape-band index `t` in 0..255 and a
+ * scheme id. Schemes 0..3 are the original hand-rolled palettes; 4..7 are the
+ * matplotlib perceptual colormaps, evaluated via the well-known 6th-order
+ * polynomial fits (Matt Zucker, https://www.shadertoy.com/view/WlfXRN), which
+ * are accurate to a few % and far cheaper than a lookup texture.
+ *
+ * Keep PALETTE_OPTIONS in sync with the scheme ids below.
+ */
+export const PALETTE_GLSL = /* glsl */ `
+  vec3 cmViridis(float x){
+    const vec3 c0=vec3(0.2777273272234177,0.005407344544966578,0.3340998053353061);
+    const vec3 c1=vec3(0.1050930431085774,1.404613529898575,1.384590162594685);
+    const vec3 c2=vec3(-0.3308618287255563,0.214847559468213,0.09509516302823659);
+    const vec3 c3=vec3(-4.634230498983486,-5.799100973351585,-19.33244095627987);
+    const vec3 c4=vec3(6.228269936347081,14.17993336680509,56.69055260068105);
+    const vec3 c5=vec3(4.776384997670288,-13.74514537774601,-65.35303263337234);
+    const vec3 c6=vec3(-5.435455855934631,4.645852612178535,26.3124352495832);
+    return c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6)))));
+  }
+  vec3 cmMagma(float x){
+    const vec3 c0=vec3(-0.002136485053939582,-0.000749655052795221,-0.005386127855323933);
+    const vec3 c1=vec3(0.2516605407371642,0.6775232436837668,2.494026599312351);
+    const vec3 c2=vec3(8.353717279216625,-3.577719514958484,0.3144679030132573);
+    const vec3 c3=vec3(-27.66873308576866,14.26473078096533,-13.64921318813922);
+    const vec3 c4=vec3(52.17613981234068,-27.94360607168351,12.94416944238394);
+    const vec3 c5=vec3(-50.76852536473588,29.04658282127291,4.23415299384598);
+    const vec3 c6=vec3(18.65570506591883,-11.48977351997711,-5.601961508734096);
+    return c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6)))));
+  }
+  vec3 cmInferno(float x){
+    const vec3 c0=vec3(0.0002189403691192265,0.001651004631001012,-0.01948089843709184);
+    const vec3 c1=vec3(0.1065134194856116,0.5639564367884091,3.932712388889277);
+    const vec3 c2=vec3(11.60249308247187,-3.972853965665698,-15.9423941062914);
+    const vec3 c3=vec3(-41.70399613139459,17.43639888205313,44.35414519872813);
+    const vec3 c4=vec3(77.162935699427,-33.40235894210092,-81.80730925738993);
+    const vec3 c5=vec3(-71.31942824499214,32.62606426397723,73.20951985803202);
+    const vec3 c6=vec3(25.13112622477341,-12.24266895238567,-23.07032500287172);
+    return c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6)))));
+  }
+  vec3 cmPlasma(float x){
+    const vec3 c0=vec3(0.05873234392399702,0.02333670892565664,0.5433401826748754);
+    const vec3 c1=vec3(2.176514634195958,0.2383834171260182,0.7522055045653658);
+    const vec3 c2=vec3(-2.689460476458034,-7.455851135738909,3.110799939717086);
+    const vec3 c3=vec3(6.130348345893603,42.3461881477227,-28.51885465332158);
+    const vec3 c4=vec3(-11.10743619062271,-82.66631109428045,60.13984767418263);
+    const vec3 c5=vec3(10.02306557647065,71.41361770095349,-54.07218655560067);
+    const vec3 c6=vec3(-3.658713842777788,-22.93153465461149,18.19190778539828);
+    return c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6)))));
+  }
+  vec3 paletteColor(float t, int scheme){
+    float x = clamp(t/255.0, 0.0, 1.0);
+    if(scheme==0){
+      return vec3(
+        sin(0.024*(t)+0.0)*0.5+0.5,
+        sin(0.024*(t)+2.0)*0.5+0.5,
+        sin(0.024*(t)+4.0)*0.5+0.5
+      );
+    }else if(scheme==1){
+      float r = min(255.0, t*3.0);
+      float g = clamp(t*3.0-255.0,0.0,255.0);
+      float b = max(0.0,t*3.0-510.0);
+      return vec3(r,g,b)/255.0;
+    }else if(scheme==2){
+      return vec3(0.0, t/2.0, t)/255.0;
+    }else if(scheme==4){
+      return clamp(cmViridis(x),0.0,1.0);
+    }else if(scheme==5){
+      return clamp(cmMagma(x),0.0,1.0);
+    }else if(scheme==6){
+      return clamp(cmInferno(x),0.0,1.0);
+    }else if(scheme==7){
+      return clamp(cmPlasma(x),0.0,1.0);
+    }
+    return vec3(x); // 3 = Grayscale (and fallback)
+  }
+`;
+
+/** Palette dropdown options, shared by both fractal viewers. */
+export const PALETTE_OPTIONS: { value: number; label: string }[] = [
+  { value: 0, label: 'Rainbow' },
+  { value: 1, label: 'Fire' },
+  { value: 2, label: 'Ocean' },
+  { value: 3, label: 'Grayscale' },
+  { value: 4, label: 'Viridis' },
+  { value: 5, label: 'Magma' },
+  { value: 6, label: 'Inferno' },
+  { value: 7, label: 'Plasma' },
+];


### PR DESCRIPTION
## Summary

The app previously dropped straight into Complex Particles at `/`. This adds a proper landing screen: a gallery of cards, one per animation, each with an icon, name, and one-line blurb, served at the default `/` route.

## Screenshots

| Desktop | Mobile |
|---|---|
| Responsive auto-fill card grid with a gradient "animath" hero | Reflows to a single column on phones |

Cards lift + glow on hover and expose a `→` affordance. The screen reuses AppShell's design tokens so it stays visually consistent with the chrome.

## Changes

- **`src/apps.ts`** (new) — shared app catalog used by both the router and the menu, with a new `blurb` field per app. `AppDescriptor` in `AppShell.tsx` extended to carry it.
- **`src/components/Menu.tsx` + `Menu.css`** (new) — the gallery itself; cards navigate via the hash router.
- **`src/index.tsx`** — `/` now renders `Menu`; Complex Particles moves to its own `/complex-particles` route; unknown hashes fall back to the menu.
- **`src/components/AppShell.tsx`** — shows an "animath" brand title on the home route and adds a ⌂ home button (hidden on the menu itself) so any view can return to the menu.

## Implementation note

The menu's title is set deterministically by `AppShell` rather than via `useAppHeader`, because `Menu` is eagerly imported and its header effect would otherwise race with AppShell's per-route reset effect (the lazy-loaded animations avoid this race by mounting in a later commit).

## Verification

- `npm run build` passes (`tsc && vite build`).
- Confirmed at runtime: cards launch each app, the ⌂ button returns to the menu (`#/` → title "animath"), and it is correctly hidden while on the menu.

https://claude.ai/code/session_01MnJwpU4ALrppC9KxJVc7xw

---
_Generated by [Claude Code](https://claude.ai/code/session_01MnJwpU4ALrppC9KxJVc7xw)_