### PR TITLE
docs: refresh architecture docs + add "Building an app" guide + persist viewer settings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,46 +1,58 @@
 # AGENTS Instructions
 
-This repository contains `animath`, a modular browser-based toolkit for creating mathematical animations using TypeScript/React and WebGL (Three.js).
+This repository contains `animath`, a modular browser-based toolkit for
+mathematical animations and generative art, built with TypeScript, React 18,
+Three.js, and Vite. Each animation ("app") is a self-contained module that plugs
+into a shared **AppShell** (top bar + slide-out drawer) and is registered in a
+single catalog, `src/apps.ts`.
+
+## Orientation — read these first
+
+- **CLAUDE.md** — the detailed map of the codebase, the AppShell framework, the
+  routing model, conventions, and current technical debt.
+- **docs/BUILDING_AN_APP.md** — the step-by-step recipe for adding a new app that
+  conforms to the framework. **Follow it when creating a module.**
+- **README.md** — user-facing tour of the apps and interaction conventions.
+- **ARCHITECTURE.md** — historical design proposal; background only, not the
+  current layout.
 
 ## Development Quick Start
 
-1. Install dependencies and start the Vite dev server:
-   ```bash
-   npm run dev
-   ```
-   which serves the application at <http://localhost:5173>.
+```bash
+npm ci          # reproducible install (Node 20+, npm 10+)
+npm run dev     # Vite dev server at http://localhost:5173/animath/
+npm run build   # tsc && vite build → dist/   (the ONLY CI check)
+npm run preview # preview the production build
+```
 
-2. For a production build and simple preview:
-   ```bash
-   npm run build   # outputs files to dist/
-   npx serve dist  # preview
-   ```
+## Creating a new app (summary)
 
-Node 20+ and npm 10+ are recommended.
+The framework is hook-driven, not inheritance-driven. A new app:
 
-## Creating New Animations
+1. Lives in `src/animations/<Name>/` with its main `.tsx`, a `README.md` (the
+   in-app **About** text) and an `EXPLAINER.md` (the **?** popup), both imported
+   with Vite's `?raw` suffix.
+2. Is registered in **two** places: the `routes` map in `src/index.tsx`
+   (`React.lazy` import) and the `apps` array in `src/apps.ts` (catalog entry
+   that drives the drawer and the landing menu).
+3. Integrates with the shell via hooks/components from
+   `src/components/AppShell.tsx`: `useAppHeader`, `useAppExplainer`,
+   (optionally `useAppFunctions`), and `<ShellSettings>` / `<ShellActions>`.
+4. Builds its controls from the primitives in `src/components/ControlPanel.tsx`
+   (`Section`, `Slider`, `Pills`, `Select`, `Checkbox`) for a consistent look.
 
-The project is designed to allow small, self-contained React components for individual animations. A typical workflow is:
+For 3D work, wrap `src/components/Canvas3D.tsx`. For 4D particle viewers, build on
+`ParticleViewerShell` + the `src/lib/particles` engine — copy `ComplexParticles`,
+the canonical example. See `docs/BUILDING_AN_APP.md` for the full walkthrough.
 
-1. Create a new folder inside `src/animations/`.
-2. Implement a React component (e.g. `<MyCoolThing/>`) extending the `Canvas3D` wrapper.
-3. Add a route entry in `src/index.tsx` so the animation is accessible.
-4. Provide a `README.md` inside the animation folder explaining the maths.
-
-Shader code can be kept inline or loaded with `vite-plugin-glsl`.
-
-## Material Library Guidelines
-
-The project maintains a small library of reusable Three.js material presets
-(e.g. translucent sprites, reflective glass). When contributing new animations,
-consider whether a material preset could be added or improved. Place such
-materials in a dedicated folder (currently `src/materials/`) with clear
-documentation so other animations can reuse them.
+GLSL is kept inline as template strings under each app's `shaders/` directory.
 
 ## Contribution Checks
 
-Before opening a pull request, run `npm run build` to ensure the project compiles. There are currently no automated tests.
+Run `npm run build` before opening a pull request — it must pass. There are
+currently no automated tests, linter, or formatter.
 
 ---
 
 These instructions apply repository-wide.
+</content>

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,5 +1,15 @@
 # Animath Architecture & Consolidation Guide
 
+> **Historical note (kept for background).** This document was the *design
+> proposal* that motivated the consolidation work. The codebase was refactored in
+> its spirit — the duplicated complex viewers became the shared `src/lib/particles`
+> engine plus `ParticleViewerShell`, complex math moved to `lib/complexMath.ts`,
+> and textures to `lib/textures.ts` — but the concrete folder names below
+> (`core/`, `widgets/`, `ui/`) were **not** adopted. Shared code actually lives in
+> `src/components/` and `src/lib/`. For the current structure and the
+> hook-based AppShell framework, see **CLAUDE.md**; to build a new app, see
+> **docs/BUILDING_AN_APP.md**. Treat this file as background only.
+
 This document provides a detailed analysis of the repository structure, identifies the core primitives, and proposes a consolidated architecture for better maintainability and extensibility.
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,189 +2,299 @@
 
 ## Project Overview
 
-**animath** is a modular, browser-based toolkit for mathematical animations and generative art, built with TypeScript, React 18, Three.js, and Vite. It is deployed as a static site to GitHub Pages at `https://piyarsquare.github.io/animath/`.
+**animath** is a modular, browser-based toolkit for mathematical animations and
+generative art, built with TypeScript, React 18, Three.js, and Vite. It is
+deployed as a static site to GitHub Pages at `https://piyarsquare.github.io/animath/`.
+
+Every animation ("app") is a self-contained module that plugs into a shared
+**AppShell** — a persistent top bar + slide-out drawer that supplies navigation,
+settings, actions, a function picker, and a help/explainer popup. Apps declare
+themselves in a single registry (`src/apps.ts`) and register their UI through a
+small set of React hooks and portal components, so the chrome stays uniform
+across every view.
 
 ## Quick Reference
 
 ```bash
 npm ci              # install dependencies (use ci, not install, for reproducibility)
-npm run dev         # Vite dev server at http://localhost:5173
+npm run dev         # Vite dev server at http://localhost:5173/animath/
 npm run build       # TypeScript check + Vite production build → dist/
 npm run preview     # preview production build locally
 ```
 
-Node >= 20, npm >= 10 required.
+Node >= 20, npm >= 10 required. The only CI check is `npm run build` (which runs
+`tsc && vite build`). There are no automated tests, linter, or formatter.
+
+## New here? Read these first
+
+- **README.md** — user-facing tour of the apps, the shell, and interaction conventions.
+- **docs/BUILDING_AN_APP.md** — step-by-step guide (for humans *and* agents) to
+  adding a new app that conforms to the framework. **Read this before adding a module.**
+- **ARCHITECTURE.md** — a historical design/consolidation proposal. Useful for
+  background, but it describes a *proposed* structure that differs from what was
+  actually built; treat the layout below as the source of truth.
 
 ## Repository Layout
 
 ```
 animath/
 ├── index.html                  # SPA entry point with global CSS
-├── package.json                # dependencies: react, three, marked, lucide-react
+├── package.json                # deps: react, react-dom, three, marked, lucide-react
 ├── tsconfig.json               # strict TS, target esnext, path alias @/ → src/
 ├── vite.config.ts              # base: '/animath/', @/ alias
-├── AGENTS.md                   # instructions for other AI agents
+├── AGENTS.md                   # short instructions for other AI agents
 ├── CLAUDE.md                   # this file
+├── ARCHITECTURE.md             # historical consolidation proposal (background only)
 ├── PLAN.md                     # roadmap / plan notes
 ├── README.md                   # project documentation
-├── requirements.txt            # placeholder (no Python deps used)
-├── .github/workflows/deploy.yml  # GitHub Pages deploy (manual trigger)
-├── run/setup.sh                # placeholder setup script
-├── sh-test/project.test.cjs    # standalone projection function test (CJS)
+├── docs/
+│   ├── BUILDING_AN_APP.md      # how to add a new app to the framework
+│   └── PREVIEW_DEPLOYS.md      # per-PR preview deploy options
+├── .github/workflows/deploy.yml  # GitHub Pages deploy (push to main + manual)
 ├── public/textures/            # HDR environment map + placeholder
 └── src/
-    ├── index.tsx               # entry: hash-based router, all routes defined here
-    ├── App.tsx                 # default route — renders ComplexParticles
-    ├── animations/             # each animation is a self-contained module
-    │   ├── AgenticSorting/     # concurrent sorting simulation (CSS + lucide-react)
-    │   ├── ComplexMultibranch/ # multi-branch complex functions (Three.js particles)
-    │   ├── ComplexParticles/   # main complex function visualizer (Three.js particles)
-    │   ├── ComplexRoots/       # z^(p/q) root explorer (Three.js particles)
-    │   ├── Correspondence/     # Mandelbrot–Julia correspondence (split-pane GPU)
-    │   ├── Fractals/           # CPU-based 2D Mandelbrot/Julia (UNREACHABLE — no route)
-    │   ├── FractalsGPU/        # GPU-based fractal viewer (mapped to #/fractals)
-    │   ├── MobiusWalk/         # first-person Möbius corridor (Three.js)
-    │   └── StableMarriage/     # Gale–Shapley algorithm visualizer (CSS + lucide-react)
-    ├── components/             # shared React components
-    │   ├── Canvas3D.tsx        # Three.js scene/camera/renderer wrapper
-    │   ├── Readme.tsx          # markdown renderer (marked library)
-    │   └── ToggleMenu.tsx      # collapsible overlay menu
-    ├── config/defaults.ts      # shared constants and default values
+    ├── index.tsx               # entry: hash router + <AppShell>, lazy route map
+    ├── App.tsx                 # default Complex Particles route (lazy wrapper)
+    ├── apps.ts                 # THE app registry (drives router + landing menu)
+    │
+    ├── animations/             # one folder per app, each self-contained
+    │   ├── ComplexParticles/   # 4D complex-function particle viewer
+    │   │                       #   (absorbs the former Roots z^(p/q) and
+    │   │                       #    Multibranch sqrt/ln modes as variants)
+    │   ├── PlaneTransform/      # f as a transformation of the colored plane
+    │   ├── FractalsGPU/         # GPU Mandelbrot / Julia / Burning Ship / Tricorn
+    │   ├── Fractals/            # legacy CPU 2D fractals (routed at #/fractals-cpu)
+    │   ├── Correspondence/      # Mandelbrot ↔ Julia split-pane explorer
+    │   ├── MobiusWalk/          # first-person Möbius corridor walk
+    │   ├── StableMarriage/      # Gale–Shapley visualiser + heatmap lab (CSS/DOM)
+    │   └── AgenticSorting/      # concurrent agent-based sorting (CSS/DOM)
+    │
+    ├── components/             # shared shell + UI
+    │   ├── AppShell.tsx        # global chrome: top bar, drawer, tabs, hooks, portals
+    │   ├── AppShell.css
+    │   ├── ActionFloater.tsx   # draggable on-canvas mirror of an app's Actions
+    │   ├── ActionFloater.css
+    │   ├── useFloaterDrag.ts   # drag behaviour for floating panels
+    │   ├── Menu.tsx            # landing gallery shown at the `/` route
+    │   ├── Menu.css
+    │   ├── ParticleViewerShell.tsx  # turnkey shell for particle (4D) viewers
+    │   ├── ControlPanel.tsx    # form primitives: Section / Slider / Pills / Select / Checkbox
+    │   ├── ControlPanel.css
+    │   ├── Canvas3D.tsx        # Three.js scene + camera + renderer + resize wrapper
+    │   ├── Readme.tsx          # in-app markdown renderer (marked)
+    │   └── ToggleMenu.tsx      # legacy collapsible menu (still used by FractalsGPU)
+    │
     ├── controls/
-    │   └── QuarterTurnBar.tsx  # 4D rotation controls for particle views
-    ├── lib/                    # utility classes
-    │   ├── ParticleDisplay.ts  # particle grid helper (currently unused)
-    │   ├── R2Mapping.ts        # R²→R² mapping library (currently unused)
-    │   └── viewpoint.ts        # 4D projection and quaternion math
-    ├── materials/              # Three.js material presets (currently unused)
-    │   └── index.ts            # basic, wireframe, metallic, glass, toon, etc.
+    │   ├── QuarterTurnFloater.tsx  # floating 4D quarter-turn + drop-axis cluster
+    │   ├── QuarterTurnFloater.css
+    │   └── QuarterTurnBar.tsx      # older inline 4D rotation bar
+    │
+    ├── lib/
+    │   ├── particles/          # shared particle-viewer engine (see below)
+    │   │   ├── index.ts                # public re-exports
+    │   │   ├── types.ts                # ColorStyle, ColourBy, shapeNames, viewTypes, …
+    │   │   ├── useParticleState.ts     # all viewer state + setters
+    │   │   ├── useViewControls.ts      # orientation/turn/projection/drop-axis controls
+    │   │   ├── useUniformSync.ts       # React state → shader uniforms
+    │   │   ├── useGestureRotation.ts   # camera-orbit + pan + zoom pointer handlers
+    │   │   ├── createParticleGeometry.ts  # grid + adaptive density sampling
+    │   │   ├── createAxes.ts           # 4D axis lines
+    │   │   └── createAnimationLoop.ts  # rAF loop (quaternion compose, axis update)
+    │   ├── useViewportGestures.ts      # pan + pinch-zoom + tap for 2D (fractal) viewers
+    │   ├── viewpoint.ts                # 4D → 3D projection helpers + ProjectionMode
+    │   ├── complexMath.ts              # complex arithmetic + function name/formula tables
+    │   ├── colormaps.ts                # GLSL palette source + palette options (fractals)
+    │   ├── textures.ts                 # particle texture factory (checker/stone/metal/HDR)
+    │   ├── ParticleDisplay.ts          # (legacy, unused)
+    │   └── R2Mapping.ts                # (legacy, unused)
+    │
     ├── math/
-    │   ├── constants.ts        # plane names and quarter-turn constant
+    │   ├── constants.ts        # plane names ('XY','XU',…) and QUARTER constant
     │   └── quat4.ts            # 4D quaternion rotation builder
-    ├── styles/
-    │   └── responsive.ts       # responsive utilities, breakpoints, useResponsive hook
-    ├── types/
-    │   └── uniforms.d.ts       # TypeScript declarations for shader uniforms
+    │
+    ├── config/defaults.ts      # shared slider ranges + initial values
+    ├── styles/responsive.ts    # breakpoints + useResponsive hook
+    ├── materials/index.ts      # Three.js material presets (legacy, unused)
+    ├── types/uniforms.d.ts     # shader uniform type declarations
     └── unported_examples/      # excluded from build (tsconfig exclude)
-        └── fractint-simulator.tsx
 ```
 
 ## Routing
 
-The app uses a **hand-rolled hash router** in `src/index.tsx`:
+The app uses a **hand-rolled hash router** in `src/index.tsx`. Every route is
+`React.lazy`-imported (code-split) and rendered inside a single persistent
+`<AppShell>`. The route table is keyed by hash; the visible app catalog comes
+from `src/apps.ts`.
 
-| Hash Route          | Component          | Description                          |
-|--------------------|--------------------|--------------------------------------|
-| `#/` (default)     | `App → ComplexParticles` | Complex function particle visualizer |
-| `#/fractals`       | `FractalsGPU`      | GPU-accelerated Mandelbrot/Julia     |
-| `#/correspondence` | `Correspondence`   | Mandelbrot–Julia correspondence      |
-| `#/roots`          | `ComplexRoots`     | z^(p/q) root explorer                |
-| `#/multibranch`    | `ComplexMultibranch` | Multi-branch complex functions      |
-| `#/mobius`         | `MobiusWalk`       | Möbius corridor walk                 |
-| `#/stable-marriage`| `StableMarriage`   | Gale–Shapley algorithm               |
-| `#/agentic-sorting`| `AgenticSorting`   | Concurrent sorting simulation        |
+| Hash Route            | Component        | Description                                |
+|----------------------|------------------|--------------------------------------------|
+| `#/` (default)       | `Menu`           | Landing gallery of all apps                 |
+| `#/complex-particles`| `App → ComplexParticles` | 4D complex-function particle viewer |
+| `#/plane-transform`  | `PlaneTransform` | f as a transformation of the plane          |
+| `#/fractals`         | `FractalsGPU`    | GPU Mandelbrot / Julia / Burning Ship / Tricorn |
+| `#/fractals-cpu`     | `Fractals2D`     | Legacy CPU 2D fractals                      |
+| `#/correspondence`   | `Correspondence` | Mandelbrot ↔ Julia split view               |
+| `#/mobius`           | `MobiusWalk`     | Möbius corridor walk                        |
+| `#/stable-marriage`  | `StableMarriage` | Gale–Shapley algorithm + heatmap lab        |
+| `#/agentic-sorting`  | `AgenticSorting` | Concurrent agent-based sorting              |
 
-All routes are eagerly imported (no code splitting). Unknown hashes fall back to `App`.
+Unknown hashes fall back to `Menu`. **`src/apps.ts` is the single source of
+truth** for the user-visible catalog (order, name, icon, blurb) — it drives both
+the drawer's Apps tab and the landing-page cards. When you add an app you update
+*both* the `routes` map in `index.tsx` and the `apps` array in `apps.ts`.
+
+## The AppShell framework
+
+`src/components/AppShell.tsx` renders the global chrome and exposes everything an
+app needs to integrate. The top bar shows (left to right):
+
+- **⌂ Home** — back to the landing menu (hidden on `/`).
+- **☰ Apps** — opens the drawer's Apps tab.
+- **ƒ Function** — opens the Function tab (dimmed if the app registered no functions).
+- **Title / formula** — app name plus an optional monospace subtitle (e.g. a formula);
+  clicking it opens Settings.
+- **⚙ Settings** — opens the Settings tab (dimmed if empty).
+- **▶ Actions** — opens the Actions tab (dimmed if empty).
+- **? Explainer** — opens the "What am I looking at?" popup (dimmed if none).
+
+The drawer has four tabs: **Apps**, **Function**, **Settings**, **Actions**. The
+Settings and Actions tab bodies are **portal targets**: apps render their controls
+into them via `<ShellSettings>` / `<ShellActions>`. When the active app changes
+(`currentHash`), the shell resets all of this registered state.
+
+### Integration API (import from `components/AppShell`)
+
+| Export | Purpose |
+|--------|---------|
+| `useAppHeader(title, subtitle?)` | Set the bar title + optional formula subtitle. |
+| `useAppFunctions(reg \| null)` | Register a function list `{ names, current, onChange }` so the ƒ button + Function tab can switch functions without opening Settings. |
+| `useAppExplainer(markdown \| null)` | Register markdown for the **?** help popup (typically `import x from './EXPLAINER.md?raw'`). |
+| `<ShellSettings>{…}</ShellSettings>` | Portal children into the Settings tab. |
+| `<ShellActions>{…}</ShellActions>` | Portal children into **both** the Actions tab and the floating `ActionFloater` (kept in sync). |
+| `useActionFloaterOff()` | Suppress the generic `ActionFloater` (for apps shipping their own floater, e.g. Correspondence's playback scrubber). |
+| `AppDescriptor` | Type of an `apps.ts` entry (`hash`, `name`, `icon?`, `blurb?`). |
+
+### Control primitives (import from `components/ControlPanel`)
+
+`Section` (collapsible group with icon), `Slider`, `Pills` (segmented buttons),
+`Select` (dropdown), `Checkbox`. These are the standard building blocks for the
+Settings/Actions panels and are styled by `ControlPanel.css`. Use them instead of
+hand-rolling inputs so every app looks consistent.
 
 ## Architecture Patterns
 
-### Animation modules
-Each animation lives in `src/animations/<Name>/` and typically contains:
-- A main `.tsx` component (the entire animation + UI)
-- An optional `README.md` (imported as raw text via `?raw`)
-- Optional `shaders/` directory for GLSL code
-- Optional `.css` files for non-Three.js animations
+### Anatomy of an app
 
-### Three.js animations
-The 3D animations (ComplexParticles, ComplexRoots, ComplexMultibranch, FractalsGPU, Correspondence, MobiusWalk) follow this pattern:
-1. Use `Canvas3D` component which provides scene, camera, renderer
-2. Setup geometry + material in a `useCallback` `onMount`
-3. Run `requestAnimationFrame` loops inside `onMount`
-4. Sync React state → shader uniforms via individual `useEffect` hooks
+Each app lives in `src/animations/<Name>/` and typically contains:
 
-### CSS-based animations
-StableMarriage and AgenticSorting use regular DOM/CSS rendering with lucide-react icons.
+- A main `.tsx` component (the whole animation + its controls).
+- `README.md` — longer write-up rendered in the **About** section (`import md from './README.md?raw'`).
+- `EXPLAINER.md` — short "what am I looking at" text for the **?** popup (`?raw`).
+- Optional `shaders/` directory (GLSL kept as inline template strings).
+- Optional `.css` for CSS/DOM apps, plus any helper `.ts` modules.
 
-## Known Issues and Technical Debt
+Inside the component, an app: (1) holds its own state with `useState`/`useRef`;
+(2) calls `useAppHeader` (and `useAppExplainer`, optionally `useAppFunctions`);
+(3) renders its scene (Three.js via `Canvas3D`, or DOM/CSS); (4) renders controls
+inside `<ShellSettings>` / `<ShellActions>` using the `ControlPanel` primitives.
 
-### Critical
-1. **HDR texture path broken on production** — `ComplexParticles.tsx:398` and `ComplexRoots.tsx:303` load `/textures/royal_esplanade_1k.hdr` but the Vite `base` is `/animath/`, so the correct path should be relative or use the base URL.
-2. **MobiusWalk twist toggle broken** — `onMount` callback captures initial `twist` value and never updates when the toggle is clicked (the geometry is not rebuilt).
-3. **Fractals2D component has no route** — `src/animations/Fractals/Fractals2D.tsx` exists but is unreachable.
+### Three.js / particle (4D) viewers
 
-### Severe code duplication
-4. **ComplexParticles, ComplexRoots, and ComplexMultibranch are ~95% identical** — each is 800–1100 lines duplicating: texture factories, complex math (CPU-side), 30+ state hooks, animation loops, axis rendering, projection logic, and UI controls. These should be refactored into a shared base.
-5. **Complex math is implemented 4 times** — in GLSL shaders, CPU-side in ComplexParticles, CPU-side in ComplexRoots, and in `R2Mapping.ts`.
+The complex viewers are powered by the **`src/lib/particles` engine** plus the
+turnkey `ParticleViewerShell` component, which together provide the standard
+**Function / Camera / Color / Particles / Motion / Detail / About** sections, the
+`QuarterTurnFloater`, gesture handling, and the rAF loop out of the box. The flow
+is: `useParticleState` (state) → `useViewControls` (orientation/projection
+controls) → build geometry/axes in `Canvas3D`'s `onMount` → `useUniformSync`
+pushes React state into shader uniforms → `startAnimationLoop` runs the rAF loop.
+**ComplexParticles is the canonical, simplest consumer** — copy it when building a
+new particle viewer.
 
-### Mobile / responsive issues
-6. **No touch support on FractalsGPU** — shows "pinch to zoom" label but no touch handlers exist.
-7. **Correspondence path drawing broken on mobile** — only mouse events, no touch events.
-8. **MobiusWalk has no mobile controls** at all.
-9. **QuarterTurnBar hidden on mobile** for all particle views — no way to do 4D rotations on phones.
-10. **Fractals2D has zero responsive design** (moot since it's unreachable, but worth noting).
+### 2D / fractal viewers
 
-### Build / tooling
-11. **No linter, formatter, or test runner** configured — no eslint, prettier, or `npm test`.
-12. **No code splitting** — all 8 modules eagerly loaded, producing an 805KB JS bundle.
-13. **Unused utilities** — `ParticleDisplay.ts`, `R2Mapping.ts`, and `materials/index.ts` are never imported.
-14. **Deploy workflow has duplicate `configure-pages` step**.
-15. **`requirements.txt`** and **`run/setup.sh`** are empty placeholders.
+FractalsGPU and Correspondence render a full-screen shader quad through an
+orthographic camera and navigate with `useViewportGestures` (drag-pan,
+pinch/wheel-zoom, tap). Palettes come from `lib/colormaps.ts`.
 
-### Code quality
-16. **XSS risk** — `Readme.tsx` uses `dangerouslySetInnerHTML` with `marked` output.
-17. **Mixed import styles** — some files use `@/` path alias, others use relative `../../` paths.
-18. **No cleanup of animation frames** in several components — potential memory leaks.
+### CSS/DOM apps
 
-## Development Workflow
+StableMarriage and AgenticSorting render plain DOM with `lucide-react` icons and
+their own CSS. They still integrate via `useAppHeader` / `useAppExplainer` and may
+use `<ShellSettings>` / `<ShellActions>`.
 
-### Adding a new animation
-1. Create `src/animations/MyAnimation/MyAnimation.tsx`
-2. Add route in `src/index.tsx`: import the component and add to the `routes` map
-3. For Three.js animations: use the `Canvas3D` component and follow existing patterns
-4. For CSS/DOM animations: follow StableMarriage/AgenticSorting patterns
-5. Include a `README.md` in the folder if desired (import with `?raw`)
+## Interaction conventions
 
-### Build verification
-```bash
-npm run build       # must pass — this is the only CI check
-```
-There are no automated tests. The only validation is `tsc && vite build`.
+Particle viewers split **looking** (gestures) from **navigating** (buttons):
 
-### Deployment
-The GitHub Pages deploy is triggered manually via the `Deploy demo` workflow in the Actions tab. It runs `npm ci && npm run build` and uploads `dist/` to Pages.
+- **1-finger / mouse drag** orbits the camera (never the 4D rotation).
+- **2-finger drag** (or `Shift`+drag) pans the look-at target.
+- **2-finger pinch / wheel** zooms.
+- **QuarterTurnFloater** (bottom-left of the canvas): tap a plane for a 90°
+  animated turn, **hold** for continuous rotation; includes reset + drop-axis.
+
+Fractal viewers: drag to pan, pinch/wheel to zoom, and **Trace mode** (Actions
+drawer) spawns an iteration orbit from a tapped point.
+
+### Projection modes (Complex Particles)
+
+A 4D point `(x, y, u, v)` maps to 3D via: **Perspective** (divide by `3 + v`),
+**Stereo** (stereographic from the +v pole), **Hopf** (Hopf fibration), or
+**Drop X / Y / U / V** (discard the named axis). Mode switches interpolate on the GPU.
 
 ## Code Conventions
 
-- **TypeScript strict mode** is enabled
-- **Path alias**: `@/` maps to `src/` (configured in both `tsconfig.json` and `vite.config.ts`)
-- **Shaders**: GLSL is kept as inline template strings in TypeScript files under `shaders/` directories
-- **Styling**: mix of inline React styles, CSS files, and responsive utility functions from `styles/responsive.ts`
-- **Components**: functional React components with hooks (no class components)
-- **State management**: local `useState`/`useRef` only (no global state/context)
-- **Markdown**: each animation can have a `README.md` loaded via Vite's `?raw` import
+- **TypeScript strict mode**; functional components with hooks only.
+- **Path alias** `@/` → `src/` (in both `tsconfig.json` and `vite.config.ts`).
+  Note: many files still use relative `../../` imports — both work; match the file
+  you're editing.
+- **State** is local `useState`/`useRef` only (no global store/context except the
+  AppShell context, which you consume via the provided hooks).
+- **Shaders**: GLSL as inline template strings under per-app `shaders/`.
+- **Markdown**: `README.md` (About) and `EXPLAINER.md` (?) imported via `?raw`.
+- **Base-aware asset paths**: load public assets with `import.meta.env.BASE_URL`
+  (the Vite `base` is `/animath/`) — see `lib/textures.ts`.
 
-## Recommended Improvements (Priority Order)
+## Known Issues and Technical Debt
 
-### P0 — Fix what's broken
-- Fix HDR texture paths for production (`base`-aware URLs)
-- Fix MobiusWalk twist toggle (rebuild geometry on state change)
-- Wire up or remove Fractals2D
+Much of the old debt has been paid down: the three near-identical complex viewers
+were consolidated into the `lib/particles` engine + `ParticleViewerShell` (Roots
+and Multibranch are now modes of ComplexParticles); complex math lives in
+`lib/complexMath.ts`; texture factories in `lib/textures.ts`; code splitting is in
+place via `React.lazy`; the HDR texture path is now `base`-aware; touch/gesture
+support exists across the 3D, 2D, and DOM apps; and the former orphan `Fractals2D`
+is reachable at `#/fractals-cpu`.
 
-### P1 — Reduce duplication
-- Extract shared particle visualization base from ComplexParticles/ComplexRoots/ComplexMultibranch
-- Consolidate complex math functions into a single shared module
-- Consolidate texture factory functions
+Remaining items:
 
-### P2 — Mobile experience
-- Add touch event handlers to FractalsGPU and Correspondence
-- Add mobile controls to MobiusWalk
-- Make QuarterTurnBar available on mobile (perhaps as a compact drawer)
+1. **No linter / formatter / test runner** — no eslint, prettier, or `npm test`.
+   The only validation is `npm run build`.
+2. **Deploy workflow has a duplicate `configure-pages` step** (`.github/workflows/deploy.yml`).
+3. **Orphaned utilities** — `lib/ParticleDisplay.ts`, `lib/R2Mapping.ts`, and
+   `materials/index.ts` are never imported.
+4. **Placeholder files** — `requirements.txt` and `run/setup.sh` are empty stubs.
+5. **XSS surface** — `Readme.tsx` uses `dangerouslySetInnerHTML` with `marked`
+   output (content is first-party only, but unsanitised).
+6. **`ARCHITECTURE.md` is aspirational** — it proposes a `core/widgets/ui` layout
+   that was not adopted; the actual shared code lives in `components/` and `lib/`.
 
-### P3 — Build and DX
-- Add code splitting with `React.lazy()` and `Suspense`
-- Add ESLint + Prettier configuration
-- Add a real test framework (Vitest)
-- Add `npm test` and `npm run lint` scripts
-- Remove or use orphaned utilities (ParticleDisplay, R2Mapping, materials)
-- Remove placeholder files (requirements.txt, run/setup.sh) or give them real content
-- Sanitize markdown output in Readme.tsx (DOMPurify or equivalent)
+## Development Workflow
+
+### Adding a new app
+
+Follow **docs/BUILDING_AN_APP.md**. In short:
+
+1. Create `src/animations/MyApp/MyApp.tsx` (+ `README.md`, `EXPLAINER.md`).
+2. Register the route in `src/index.tsx` (`React.lazy` import + `routes` entry).
+3. Register the catalog entry in `src/apps.ts` (`hash`, `name`, `icon`, `blurb`).
+4. Call `useAppHeader(...)` (and `useAppExplainer`, optionally `useAppFunctions`);
+   render controls in `<ShellSettings>` / `<ShellActions>` with `ControlPanel`
+   primitives. For 4D particle viewers, build on `ParticleViewerShell` +
+   `lib/particles` (copy ComplexParticles).
+5. `npm run build` must pass.
+
+### Deployment
+
+Pushing to `main` triggers the **Deploy demo** GitHub Pages workflow
+(`npm ci && npm run build`, uploads `dist/`); it also accepts manual dispatch.
+For per-PR preview URLs, see `docs/PREVIEW_DEPLOYS.md`.
+</content>

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -303,7 +303,20 @@ Follow **docs/BUILDING_AN_APP.md**. In short:
    render controls in `<ShellSettings>` / `<ShellActions>` with `ControlPanel`
    primitives. For 4D particle viewers, build on `ParticleViewerShell` +
    `lib/particles` (copy ComplexParticles).
-5. `npm run build` must pass.
+5. Document *your* app: add its row to the **Routing** table above and a line to
+   the repository-layout tree (and to `README.md`). Append — don't reorder.
+6. `npm run build` must pass.
+
+> **Parallel branches.** Several app branches are often in flight at once
+> (frequently in separate agent threads). The framework keeps that conflict-free
+> because each app is a self-contained folder; the only shared files a new app
+> edits — `index.tsx`, `apps.ts`, `CLAUDE.md`, `README.md` — are all **append-only**.
+> Add new entries at the **end** of each list/table, never reorder existing ones,
+> and touch only your own app's lines. Before opening/finalizing a PR,
+> `git fetch && git merge origin/main`, resolve any shared-file overlap by
+> *keeping every app's entries*, and re-run `npm run build`. Merge order doesn't
+> matter — the re-sync is cheap because the edits are additive. See
+> **docs/BUILDING_AN_APP.md §8** for the full workflow.
 
 ### Deployment
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -188,10 +188,16 @@ hand-rolling inputs so every app looks consistent.
 Each app lives in `src/animations/<Name>/` and typically contains:
 
 - A main `.tsx` component (the whole animation + its controls).
-- `README.md` — longer write-up rendered in the **About** section (`import md from './README.md?raw'`).
-- `EXPLAINER.md` — short "what am I looking at" text for the **?** popup (`?raw`).
+- `EXPLAINER.md` — short "what am I looking at" text for the **?** popup (`?raw`);
+  shipped by nearly every app.
+- `README.md` — *optional* longer write-up for the **About** section
+  (`import md from './README.md?raw'`). `ParticleViewerShell` viewers render it
+  automatically; custom apps render it if they choose, and some (e.g. the Trinary
+  System) ship none.
+- Optional helper `.ts` modules — pull simulation/algorithm logic and data out of
+  the component (e.g. `physics.ts` + `presets.ts`, or `corridorGeometry.ts`).
 - Optional `shaders/` directory (GLSL kept as inline template strings).
-- Optional `.css` for CSS/DOM apps, plus any helper `.ts` modules.
+- Optional `.css` for CSS/DOM apps.
 
 Inside the component, an app: (1) holds its own state with `useState`/`useRef`;
 (2) calls `useAppHeader` (and `useAppExplainer`, optionally `useAppFunctions`);

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,13 @@ A 4D point `(x, y, u, v)` maps to 3D via: **Perspective** (divide by `3 + v`),
   you're editing.
 - **State** is local `useState`/`useRef` only (no global store/context except the
   AppShell context, which you consume via the provided hooks).
+- **Persisted settings**: `usePersistentState(key, initial)` (`lib/usePersistentState.ts`)
+  is a drop-in `useState` that mirrors to `localStorage` (namespaced
+  `animath:<version>:<app>:<field>`), so a user's controls survive a reload. Pass
+  `key = null` to opt out. The particle viewers persist through
+  `useParticleState({ storageKey })`; `clearPersistedState(namespace)` powers the
+  "Reset settings to defaults" action. Persist *settings*, not transient view
+  state (camera orbit/pan) or derived values.
 - **Shaders**: GLSL as inline template strings under per-app `shaders/`.
 - **Markdown**: `README.md` (About) and `EXPLAINER.md` (?) imported via `?raw`.
 - **Base-aware asset paths**: load public assets with `import.meta.env.BASE_URL`

--- a/README.md
+++ b/README.md
@@ -6,14 +6,16 @@
   <a href="https://piyarsquare.github.io/animath/">Live demo</a>
 </p>
 
-## Apps
+The landing page (`#/`) is a gallery of every app; the cards below are also
+reachable directly by hash route.
 
-1. **[Complex Particles](https://piyarsquare.github.io/animath/#/)** – 3D representation of four-dimensional complex functions. Includes the former *Complex Roots* (`z^(p/q)`) and *Complex Multibranch* (multi-sheeted maps for `sqrt`, `ln`, etc.) as built-in modes.
-2. **[Fractals](https://piyarsquare.github.io/animath/#/fractals)** – GPU-accelerated Mandelbrot / Julia / Burning Ship / Tricorn viewer with optional orbit-tracing mode.
-3. **[Correspondence](https://piyarsquare.github.io/animath/#/correspondence)** – side-by-side Mandelbrot–Julia explorer; pick or draw paths through `c`.
-4. **[Möbius Walk](https://piyarsquare.github.io/animath/#/mobius)** – first-person stroll through a twisted corridor.
-5. **[Stable Marriage](https://piyarsquare.github.io/animath/#/stable-marriage)** – step through the Gale–Shapley algorithm with bias and consensus controls.
-6. **[Agentic Sorting](https://piyarsquare.github.io/animath/#/agentic-sorting)** – concurrent sorting simulation where autonomous agents with distinct strategies produce emergent order.
+1. **[Complex Particles](https://piyarsquare.github.io/animath/#/complex-particles)** – 3D representation of four-dimensional complex functions. Includes the former *Complex Roots* (`z^(p/q)`) and *Complex Multibranch* (multi-sheeted maps for `sqrt`, `ln`, etc.) as built-in modes.
+2. **[Plane Transform](https://piyarsquare.github.io/animath/#/plane-transform)** – watch a complex function `f : ℂ → ℂ` warp a coloured grid of the plane, input pane beside output pane.
+3. **[Fractals](https://piyarsquare.github.io/animath/#/fractals)** – GPU-accelerated Mandelbrot / Julia / Burning Ship / Tricorn viewer with optional orbit-tracing mode.
+4. **[Correspondence](https://piyarsquare.github.io/animath/#/correspondence)** – side-by-side Mandelbrot–Julia explorer; pick or draw paths through `c`.
+5. **[Möbius Walk](https://piyarsquare.github.io/animath/#/mobius)** – first-person stroll through a twisted corridor.
+6. **[Stable Marriage](https://piyarsquare.github.io/animath/#/stable-marriage)** – step through the Gale–Shapley algorithm with bias and consensus controls.
+7. **[Agentic Sorting](https://piyarsquare.github.io/animath/#/agentic-sorting)** – concurrent sorting simulation where autonomous agents with distinct strategies produce emergent order.
 
 ---
 
@@ -37,17 +39,28 @@ Goals:
 
 ## 2 The app shell
 
-Every route is wrapped in a persistent `AppShell` that provides:
+The default route (`#/`) is a **landing menu** — a gallery of cards, one per
+app. Every other route is wrapped in a persistent `AppShell` that provides a top
+bar with these buttons (left to right):
 
-* A top bar showing the current app's name and (where relevant) a formula.
-* Three menu buttons: **Apps** (☰), **Settings** (⚙), and **Actions** (▶).
-  Each opens a side drawer to that tab directly.
-* iOS safe-area padding so the bottom of the screen stays visible behind
-  Safari's URL bar and the home indicator.
+* **⌂ Home** — back to the landing menu (hidden on the menu itself).
+* **☰ Apps** — opens the drawer's Apps tab to switch animations.
+* **ƒ Function** — switch the active function/variant where an app offers one
+  (dimmed otherwise).
+* **Title** — the current app's name plus an optional monospace formula;
+  clicking it jumps to the Settings tab.
+* **⚙ Settings** — the app's parameter controls.
+* **▶ Actions** — one-shot actions (reset, modes, …); these are mirrored into a
+  draggable on-canvas floater.
+* **? Explainer** — a "what am I looking at?" popup with a short write-up.
 
-The Complex Particles viewer also adds a small floating **quarter-turn**
-cluster in the bottom-left corner of the canvas for direct 4D plane
-rotations (tap for 90°, hold for continuous rotation).
+Buttons for tabs an app doesn't populate are dimmed. The shell also adds iOS
+safe-area padding so the bottom of the screen stays visible behind Safari's URL
+bar and the home indicator.
+
+The Complex Particles viewer adds a small floating **quarter-turn** cluster in
+the bottom-left corner of the canvas for direct 4D plane rotations (tap for 90°,
+hold for continuous rotation).
 
 ---
 
@@ -84,20 +97,24 @@ merging to `main`), see [docs/PREVIEW_DEPLOYS.md](./docs/PREVIEW_DEPLOYS.md).
 
 ```
 src/
-├── index.tsx               # entry: hash-based router + AppShell
-├── App.tsx                 # default route (Complex Particles)
+├── index.tsx               # entry: hash-based router + AppShell, lazy route map
+├── App.tsx                 # default Complex Particles route (lazy wrapper)
+├── apps.ts                 # app registry: drives the router AND the landing menu
 │
-├── animations/             # one folder per app, each with its own README
+├── animations/             # one folder per app, each with README + EXPLAINER
 │   ├── ComplexParticles/   # 4D complex-function viewer (Particles + Roots + Multibranch)
+│   ├── PlaneTransform/     # f as a transformation of the coloured plane
 │   ├── FractalsGPU/        # GPU Mandelbrot / Julia / Burning Ship / Tricorn
 │   ├── Correspondence/     # Mandelbrot ↔ Julia split view
-│   ├── Fractals/           # legacy CPU fractal renderer (unreachable, kept for reference)
+│   ├── Fractals/           # legacy CPU fractal renderer (routed at #/fractals-cpu)
 │   ├── MobiusWalk/         # first-person corridor walk
 │   ├── StableMarriage/     # Gale–Shapley visualiser + heatmap lab
 │   └── AgenticSorting/     # concurrent agent-based sorting
 │
-├── components/             # shared UI
-│   ├── AppShell.tsx        # global chrome: top bar + drawer + tabs
+├── components/             # shared shell + UI
+│   ├── AppShell.tsx        # global chrome: top bar + drawer + tabs + integration hooks
+│   ├── ActionFloater.tsx   # draggable on-canvas mirror of the Actions tab
+│   ├── Menu.tsx            # landing gallery rendered at the `/` route
 │   ├── ParticleViewerShell # wraps Canvas3D + standard 7 sections for the particle viewers
 │   ├── ControlPanel.tsx    # form primitives (Section / Slider / Pills / Select / Checkbox)
 │   ├── Canvas3D.tsx        # Three.js scene + camera + resize wrapper
@@ -115,12 +132,13 @@ src/
 │   │   ├── useParticleState.ts
 │   │   ├── useUniformSync.ts
 │   │   ├── useViewControls.ts
-│   │   ├── useGestureRotation.ts   # camera-orbit + zoom gestures
-│   │   └── types.ts                # ProjectionMode, ColorStyle, shapeNames, …
+│   │   ├── useGestureRotation.ts   # camera-orbit + pan + zoom gestures
+│   │   └── types.ts                # ColorStyle, ColourBy, shapeNames, viewTypes, …
 │   ├── useViewportGestures.ts      # pan + pinch-zoom + tap for 2D viewers
-│   ├── viewpoint.ts                # 4D → 3D projection helpers
-│   ├── complexMath.ts              # complex arithmetic + function names
-│   └── textures.ts                 # particle texture factory
+│   ├── viewpoint.ts                # 4D → 3D projection helpers + ProjectionMode
+│   ├── complexMath.ts              # complex arithmetic + function names/formulas
+│   ├── colormaps.ts                # GLSL palettes for the fractal viewers
+│   └── textures.ts                 # particle texture factory (incl. base-aware HDR)
 │
 ├── math/
 │   ├── constants.ts        # plane names, QUARTER constant
@@ -131,30 +149,41 @@ src/
 └── types/uniforms.d.ts     # shader uniform type declarations
 ```
 
-For architectural notes and the consolidation history that produced the
-current shape, see [ARCHITECTURE.md](./ARCHITECTURE.md).
+For a hands-on walkthrough of adding a module, see
+[docs/BUILDING_AN_APP.md](./docs/BUILDING_AN_APP.md). For background on the
+consolidation that produced the current shape, see
+[ARCHITECTURE.md](./ARCHITECTURE.md) (a historical design proposal — the layout
+above is the source of truth).
 
 ---
 
 ## 5 Adding a new animation
 
-1. Create `src/animations/MyAnimation/MyAnimation.tsx` and (optionally) a
-   `README.md` next to it loaded via `import md from './README.md?raw'`.
-2. Add a route entry in `src/index.tsx`:
+The full, copy-pasteable walkthrough lives in
+[docs/BUILDING_AN_APP.md](./docs/BUILDING_AN_APP.md). The short version:
+
+1. Create `src/animations/MyAnimation/MyAnimation.tsx`, plus a `README.md`
+   (the in-app **About** section) and `EXPLAINER.md` (the **?** popup), both
+   loaded via `import md from './README.md?raw'`.
+2. Register the lazy route in `src/index.tsx`:
    ```ts
    const MyAnimation = React.lazy(() => import('./animations/MyAnimation/MyAnimation'));
-   const apps: AppDescriptor[] = [
-     // …existing entries…
-     { hash: '/my-animation', name: 'My Animation', icon: '◆' },
-   ];
    const routes = {
      // …existing routes…
      '/my-animation': MyAnimation,
    };
    ```
-3. Inside the component, call `useAppHeader('My Animation', 'optional formula')`
-   to populate the top bar, and render `<ShellSettings>` / `<ShellActions>`
-   for controls.
+3. Register the catalogue entry in `src/apps.ts` (this drives both the drawer's
+   Apps tab and the landing menu):
+   ```ts
+   export const apps: AppDescriptor[] = [
+     // …existing entries…
+     { hash: '/my-animation', name: 'My Animation', icon: '◆', blurb: 'One-line teaser.' },
+   ];
+   ```
+4. Inside the component, call `useAppHeader('My Animation', 'optional formula')`
+   and `useAppExplainer(explainerText)`, then render `<ShellSettings>` /
+   `<ShellActions>` for controls (built from the `ControlPanel` primitives).
 
 Three.js animations can wrap `Canvas3D`. For particle-style 4D viewers,
 `ParticleViewerShell` plus the `src/lib/particles` hooks gives you the

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -275,6 +275,15 @@ re-implementing.
 - **Mobile first.** Use `useResponsive()` from `src/styles/responsive.ts` for
   breakpoints, and `touchAction: 'none'` on gesture surfaces. The shell already
   reserves iOS safe-area insets.
+- **Persisting settings (optional).** To make a control survive a reload, swap
+  its `useState` for `usePersistentState(key, initial)` from
+  `src/lib/usePersistentState.ts` — a drop-in that mirrors to `localStorage`
+  under a namespaced key (e.g. `` `${'my-app'}:speed` ``). Persist *settings*
+  (sliders, toggles, selects), not transient view state (camera orbit/pan) or
+  derived values. Add a "Reset settings to defaults" button that calls
+  `clearPersistedState('my-app')` then `window.location.reload()`. Particle
+  viewers get this for free via `useParticleState({ storageKey })` +
+  `ParticleViewerShell`'s `settingsStorageKey` prop — see `ComplexParticles`.
 - **Imports.** `@/` maps to `src/`; relative `../../` also works. Match the file
   you're editing.
 

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -34,18 +34,30 @@ differs.
 ```
 src/animations/MyApp/
 ├── MyApp.tsx        # the component (default export)
-├── README.md        # longer write-up → in-app "About" section
-├── EXPLAINER.md     # short "what am I looking at?" → the ? popup
+├── EXPLAINER.md     # short "what am I looking at?" → the ? popup  (recommended for every app)
+├── README.md        # optional: longer write-up → in-app "About" section
+├── physics.ts       # optional: pull simulation / algorithm logic out of the component
+├── presets.ts       # optional: data tables, configurations, named presets
 ├── shaders/         # optional: GLSL as inline template strings (index.ts)
 └── myApp.css        # optional: for CSS/DOM apps
 ```
 
-- `README.md` and `EXPLAINER.md` are imported as raw text — they never touch
-  component code and can be edited freely:
+- `EXPLAINER.md` is the one doc nearly every app ships — it powers the **?**
+  popup and is registered with `useAppExplainer`. `README.md` is **optional**:
+  it backs the in-app **About** section, which the `ParticleViewerShell` viewers
+  render automatically and other apps render if they choose. A custom canvas app
+  can skip `README.md` entirely (the Trinary System module ships only an
+  `EXPLAINER.md`).
+- Both are imported as raw text — they never touch component code and can be
+  edited freely:
   ```ts
-  import readmeText from './README.md?raw';
   import explainerText from './EXPLAINER.md?raw';
+  import readmeText from './README.md?raw';   // only if you have one
   ```
+- Pull non-trivial simulation/algorithm logic into sibling `.ts` modules
+  (`physics.ts`, `presets.ts`, geometry helpers, …) so the `.tsx` stays focused
+  on state + rendering + controls. See `TrinaryStars/` (physics + presets) and
+  `MobiusWalk/` (corridorGeometry + objects) for the pattern.
 - Keep the component's **default export** the app itself; the router imports it
   lazily.
 
@@ -104,7 +116,7 @@ import {
 
 | API | What it does |
 |-----|--------------|
-| `useAppHeader(title, subtitle?)` | Sets the top-bar title and an optional monospace subtitle (e.g. a formula). |
+| `useAppHeader(title, subtitle?)` | Sets the top-bar title and an optional monospace subtitle — a formula, a current preset name, whatever labels the active state. |
 | `useAppExplainer(markdown \| null)` | Supplies the **?** popup content. Pass your imported `explainerText`. |
 | `useAppFunctions({ names, current, onChange } \| null)` | Registers a flat function list so the **ƒ** button + Function tab can switch it without opening Settings. Omit if your app has no "function". |
 | `<ShellSettings>…</ShellSettings>` | Portals its children into the drawer's **Settings** tab. |
@@ -191,8 +203,11 @@ return <Canvas3D onMount={onMount} />;
 > **Critical gotcha:** `onMount` runs once and closes over whatever state it
 > captured. If a control needs to change the scene, either read the latest value
 > through a `ref` updated by `useEffect`, or include it in the `useCallback`
-> deps so `Canvas3D` re-mounts. (This is exactly the bug that broke the old
-> MobiusWalk twist toggle.)
+> deps so `Canvas3D` re-mounts. `TrinaryStars` is the model: a stable
+> `useCallback` `onMount`, a `refs.current` object the loop reads each frame for
+> live slider values, and a returned cleanup that `cancelAnimationFrame`s and
+> disposes textures. (Capturing stale state here is exactly the bug that broke
+> the old MobiusWalk twist toggle.)
 
 ### 4D particle viewer — `ParticleViewerShell` + `lib/particles`
 
@@ -276,7 +291,8 @@ Manual checklist before opening a PR:
 
 - [ ] App appears on the landing menu and in the drawer's Apps tab.
 - [ ] Top-bar title (and formula, if any) shows via `useAppHeader`.
-- [ ] **?** button opens your `EXPLAINER.md`; **About** shows your `README.md`.
+- [ ] **?** button opens your `EXPLAINER.md` (and the **About** section shows
+      your `README.md`, if you ship one).
 - [ ] Settings/Actions render and the dimmed buttons light up appropriately.
 - [ ] Works on a narrow viewport; gestures don't fight page scroll.
 - [ ] No console errors; rAF loops and listeners are cleaned up on navigation away.
@@ -289,8 +305,9 @@ Manual checklist before opening a PR:
 | File | Why |
 |------|-----|
 | `src/animations/MyApp/MyApp.tsx` | the component |
-| `src/animations/MyApp/README.md` | About text (`?raw`) |
-| `src/animations/MyApp/EXPLAINER.md` | ? popup text (`?raw`) |
+| `src/animations/MyApp/EXPLAINER.md` | ? popup text (`?raw`) — recommended |
+| `src/animations/MyApp/README.md` | About text (`?raw`) — optional |
+| `src/animations/MyApp/*.ts` | optional logic/data helpers (physics, presets, geometry) |
 | `src/index.tsx` | lazy route registration |
 | `src/apps.ts` | catalog entry (drawer + menu) |
 | `src/components/AppShell.tsx` | integration hooks/components (import only) |

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -1,0 +1,301 @@
+# Building a new animath app
+
+A practical guide — for humans **and** AI agents — to adding an animation that
+fits the animath framework. Follow it and your module will get the shared
+navigation, settings drawer, actions floater, function picker, help popup, mobile
+gestures, and code-splitting for free.
+
+If you only read one thing: **an app is a self-contained React component in
+`src/animations/<Name>/`, registered in `src/index.tsx` (route) and `src/apps.ts`
+(catalog), that talks to the shell through hooks — there is no base class to
+extend.** When in doubt, copy the closest existing app.
+
+> Background reading: `CLAUDE.md` (codebase map + framework reference) and
+> `README.md` (user-facing tour). `ARCHITECTURE.md` is historical only.
+
+---
+
+## 1. Pick an archetype
+
+| Archetype | Use when… | Copy from | Built on |
+|-----------|-----------|-----------|----------|
+| **Particle / 4D viewer** | you map ℂ→ℂ (or any 4D field) to a projected point cloud | `ComplexParticles` | `ParticleViewerShell` + `src/lib/particles` |
+| **2D shader viewer** | you render a full-screen fragment shader you pan/zoom around | `FractalsGPU`, `Correspondence` | `Canvas3D`/raw renderer + `useViewportGestures` |
+| **Custom 3D scene** | a bespoke Three.js scene (camera path, geometry) | `MobiusWalk` | `Canvas3D` |
+| **CSS / DOM app** | an algorithm visualiser, no WebGL | `StableMarriage`, `AgenticSorting` | plain React + CSS + `lucide-react` |
+
+All four integrate with the shell the same way (Section 4). Only the *rendering*
+differs.
+
+---
+
+## 2. Create the folder
+
+```
+src/animations/MyApp/
+├── MyApp.tsx        # the component (default export)
+├── README.md        # longer write-up → in-app "About" section
+├── EXPLAINER.md     # short "what am I looking at?" → the ? popup
+├── shaders/         # optional: GLSL as inline template strings (index.ts)
+└── myApp.css        # optional: for CSS/DOM apps
+```
+
+- `README.md` and `EXPLAINER.md` are imported as raw text — they never touch
+  component code and can be edited freely:
+  ```ts
+  import readmeText from './README.md?raw';
+  import explainerText from './EXPLAINER.md?raw';
+  ```
+- Keep the component's **default export** the app itself; the router imports it
+  lazily.
+
+---
+
+## 3. Register the app (two files)
+
+### 3a. Route — `src/index.tsx`
+
+Add a `React.lazy` import and a `routes` entry. The route is code-split, so the
+app's JS only loads when its hash is visited.
+
+```ts
+const MyApp = React.lazy(() => import('./animations/MyApp/MyApp'));
+
+const routes: Record<string, React.ComponentType> = {
+  // …existing routes…
+  '/my-app': MyApp,
+};
+```
+
+### 3b. Catalog — `src/apps.ts`
+
+Add an `AppDescriptor`. This **single array drives both** the drawer's Apps tab
+and the landing-page gallery, in the order listed.
+
+```ts
+export const apps: AppDescriptor[] = [
+  // …existing entries…
+  {
+    hash: '/my-app',                       // must match the routes key
+    name: 'My App',                        // shown in bar, drawer, menu card
+    icon: '◆',                             // single char / emoji
+    blurb: 'One-line teaser for the menu card.',
+  },
+];
+```
+
+> Both edits are required. The `routes` map decides *what renders*; `apps.ts`
+> decides *what the user can discover*. Forgetting `apps.ts` makes the app
+> reachable only by typing the hash.
+
+---
+
+## 4. Integrate with the AppShell
+
+Import from `src/components/AppShell.tsx`. None of these are mandatory, but the
+header is what makes your app look "wired in".
+
+```tsx
+import {
+  useAppHeader, useAppExplainer, useAppFunctions,
+  ShellSettings, ShellActions, useActionFloaterOff,
+} from '../../components/AppShell';
+```
+
+| API | What it does |
+|-----|--------------|
+| `useAppHeader(title, subtitle?)` | Sets the top-bar title and an optional monospace subtitle (e.g. a formula). |
+| `useAppExplainer(markdown \| null)` | Supplies the **?** popup content. Pass your imported `explainerText`. |
+| `useAppFunctions({ names, current, onChange } \| null)` | Registers a flat function list so the **ƒ** button + Function tab can switch it without opening Settings. Omit if your app has no "function". |
+| `<ShellSettings>…</ShellSettings>` | Portals its children into the drawer's **Settings** tab. |
+| `<ShellActions>…</ShellActions>` | Portals into **both** the **Actions** tab and the draggable on-canvas `ActionFloater`. |
+| `useActionFloaterOff()` | Suppresses the generic floater (use if you ship your own, like Correspondence's scrubber). |
+
+Build the controls from the primitives in `src/components/ControlPanel.tsx` so
+every app shares one look:
+
+```tsx
+import { Section, Slider, Pills, Select, Checkbox } from '../../components/ControlPanel';
+
+<ShellSettings>
+  <Section title="Shape" icon="✦" defaultOpen>
+    <Slider label="Size" value={size} min={1} max={20} step={0.5}
+            onChange={setSize} format={v => v.toFixed(1)} />
+    <Pills label="Mode"
+           options={[{ value: 'a', label: 'A' }, { value: 'b', label: 'B' }]}
+           value={mode} onChange={setMode} />
+    <Checkbox label="Wireframe" checked={wire} onChange={setWire} />
+  </Section>
+</ShellSettings>
+```
+
+`Section` is a collapsible group; `Slider`, `Pills` (segmented buttons),
+`Select` (dropdown) and `Checkbox` are the inputs. Prefer them over raw
+`<input>` elements.
+
+---
+
+## 5. Render your scene
+
+### CSS / DOM app
+
+Nothing special — render your markup and (optionally) register settings/actions.
+
+```tsx
+export default function MyApp() {
+  const [speed, setSpeed] = useState(1);
+  useAppHeader('My App');
+  useAppExplainer(explainerText);
+  return (
+    <div className="as-content-scroll myapp">
+      {/* …your visualiser… */}
+      <ShellSettings>
+        <Section title="Controls" icon="⚙" defaultOpen>
+          <Slider label="Speed" value={speed} min={0} max={5} step={0.1}
+                  onChange={setSpeed} format={v => `${v.toFixed(1)}×`} />
+        </Section>
+      </ShellSettings>
+    </div>
+  );
+}
+```
+
+Use the `as-content-scroll` class on a root wrapper if your content should scroll
+within the shell (see `Menu.tsx`).
+
+### Custom Three.js scene — `Canvas3D`
+
+`Canvas3D` owns the scene/camera/renderer lifecycle and resize handling. You get
+a one-time `onMount({ scene, camera, renderer })` callback.
+
+```tsx
+import Canvas3D, { type CanvasContext } from '../../components/Canvas3D';
+
+const onMount = useCallback((ctx: CanvasContext) => {
+  const { scene, camera, renderer } = ctx;
+  // build geometry, materials, lights…
+  let raf = 0;
+  const tick = () => {
+    // update…
+    renderer.render(scene, camera);
+    raf = requestAnimationFrame(tick);
+  };
+  tick();
+  // NOTE: Canvas3D disposes the renderer on unmount, but YOU own your rAF loop.
+  // Cancel it (see gotchas) to avoid leaks.
+}, [/* deps */]);
+
+return <Canvas3D onMount={onMount} />;
+```
+
+> **Critical gotcha:** `onMount` runs once and closes over whatever state it
+> captured. If a control needs to change the scene, either read the latest value
+> through a `ref` updated by `useEffect`, or include it in the `useCallback`
+> deps so `Canvas3D` re-mounts. (This is exactly the bug that broke the old
+> MobiusWalk twist toggle.)
+
+### 4D particle viewer — `ParticleViewerShell` + `lib/particles`
+
+This is the highest-leverage path: you get the standard **Function / Camera /
+Color / Particles / Motion / Detail / About** sections, the `QuarterTurnFloater`,
+camera-orbit/pan/zoom gestures, the rAF loop and uniform syncing for free.
+
+**Copy `src/animations/ComplexParticles/ComplexParticles.tsx`** — it is the
+smallest, canonical consumer. The shape is:
+
+```tsx
+import ParticleViewerShell from '../../components/ParticleViewerShell';
+import {
+  useParticleState, useViewControls, useUniformSync,
+  createParticleGeometry, createAxes, startAnimationLoop,
+} from '../../lib/particles';
+
+export default function MyParticles() {
+  const state = useParticleState();              // all sliders/toggles + setters
+  const controls = useViewControls(state);       // orientation / projection / drop-axis
+
+  const onMount = useCallback((ctx) => {
+    // build geometry + axes, wire useUniformSync, startAnimationLoop(...)
+  }, [/* … */]);
+
+  return (
+    <ParticleViewerShell
+      state={state}
+      controls={controls}
+      onMount={onMount}
+      functionName={fnName}
+      functionFormula={fnFormula}
+      functionPicker={/* a <Select>/<Pills> of your functions */}
+      functionList={{ names, currentIndex, onChangeIndex }}  // drives the ƒ button
+      readme={readmeText}
+      explainer={explainerText}
+    />
+  );
+}
+```
+
+The function tables and complex arithmetic live in `src/lib/complexMath.ts`;
+texture options in `src/lib/textures.ts`; projection math + `ProjectionMode` in
+`src/lib/viewpoint.ts`; shared enums (`ColorStyle`, `ColourBy`, `shapeNames`,
+`viewTypes`, …) in `src/lib/particles/types.ts`. Reuse them rather than
+re-implementing.
+
+---
+
+## 6. Conventions & gotchas
+
+- **Strict TypeScript.** `npm run build` runs `tsc`; it must pass with no errors.
+- **State is local.** Use `useState`/`useRef`. The only shared "context" is the
+  AppShell, and you touch it solely through the hooks above.
+- **Base-aware asset paths.** The Vite `base` is `/animath/`. Load anything from
+  `public/` with `import.meta.env.BASE_URL`, e.g.
+  `` `${import.meta.env.BASE_URL}textures/foo.hdr` `` — never a leading `/`.
+  (See `lib/textures.ts`.)
+- **Shaders** are inline GLSL template strings under the app's `shaders/`
+  directory (see `ComplexParticles/shaders/index.ts`). No `.glsl` fetches at
+  runtime.
+- **Clean up.** Cancel `requestAnimationFrame` loops, `removeEventListener`, and
+  disconnect observers on unmount. Several older apps leak frames — don't copy
+  that.
+- **Mobile first.** Use `useResponsive()` from `src/styles/responsive.ts` for
+  breakpoints, and `touchAction: 'none'` on gesture surfaces. The shell already
+  reserves iOS safe-area insets.
+- **Imports.** `@/` maps to `src/`; relative `../../` also works. Match the file
+  you're editing.
+
+---
+
+## 7. Verify
+
+```bash
+npm run dev      # open http://localhost:5173/animath/#/my-app
+npm run build    # MUST pass — tsc + vite build, the only CI gate
+```
+
+Manual checklist before opening a PR:
+
+- [ ] App appears on the landing menu and in the drawer's Apps tab.
+- [ ] Top-bar title (and formula, if any) shows via `useAppHeader`.
+- [ ] **?** button opens your `EXPLAINER.md`; **About** shows your `README.md`.
+- [ ] Settings/Actions render and the dimmed buttons light up appropriately.
+- [ ] Works on a narrow viewport; gestures don't fight page scroll.
+- [ ] No console errors; rAF loops and listeners are cleaned up on navigation away.
+- [ ] `npm run build` is green.
+
+---
+
+## 8. Quick reference — files you'll touch
+
+| File | Why |
+|------|-----|
+| `src/animations/MyApp/MyApp.tsx` | the component |
+| `src/animations/MyApp/README.md` | About text (`?raw`) |
+| `src/animations/MyApp/EXPLAINER.md` | ? popup text (`?raw`) |
+| `src/index.tsx` | lazy route registration |
+| `src/apps.ts` | catalog entry (drawer + menu) |
+| `src/components/AppShell.tsx` | integration hooks/components (import only) |
+| `src/components/ControlPanel.tsx` | form primitives (import only) |
+| `src/components/Canvas3D.tsx` | Three.js wrapper (import only) |
+| `src/components/ParticleViewerShell.tsx` | turnkey 4D viewer (import only) |
+| `src/lib/particles/` | particle engine (import only) |
+</content>

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -196,7 +196,9 @@ within the shell (see `Menu.tsx`).
 ### Custom Three.js scene — `Canvas3D`
 
 `Canvas3D` owns the scene/camera/renderer lifecycle and resize handling. You get
-a one-time `onMount({ scene, camera, renderer })` callback.
+a one-time `onMount({ scene, camera, renderer })` callback. **Return a cleanup
+function** and `Canvas3D` calls it on unmount/remount (just before it disposes
+the renderer) — cancel your render loop and dispose geometries/textures there.
 
 ```tsx
 import Canvas3D, { type CanvasContext } from '../../components/Canvas3D';
@@ -211,8 +213,12 @@ const onMount = useCallback((ctx: CanvasContext) => {
     raf = requestAnimationFrame(tick);
   };
   tick();
-  // NOTE: Canvas3D disposes the renderer on unmount, but YOU own your rAF loop.
-  // Cancel it (see gotchas) to avoid leaks.
+  // Canvas3D disposes the renderer, but YOU own the rAF loop and your own
+  // geometries/textures. Return a cleanup so they don't leak on remount:
+  return () => {
+    cancelAnimationFrame(raf);
+    // geometry.dispose(); material.dispose(); texture.dispose(); …
+  };
 }, [/* deps */]);
 
 return <Canvas3D onMount={onMount} />;
@@ -221,11 +227,12 @@ return <Canvas3D onMount={onMount} />;
 > **Critical gotcha:** `onMount` runs once and closes over whatever state it
 > captured. If a control needs to change the scene, either read the latest value
 > through a `ref` updated by `useEffect`, or include it in the `useCallback`
-> deps so `Canvas3D` re-mounts. `TrinaryStars` is the model: a stable
-> `useCallback` `onMount`, a `refs.current` object the loop reads each frame for
-> live slider values, and a returned cleanup that `cancelAnimationFrame`s and
-> disposes textures. (Capturing stale state here is exactly the bug that broke
-> the old MobiusWalk twist toggle.)
+> deps so `Canvas3D` re-mounts. The model is a stable `useCallback` `onMount`, a
+> `refs.current` object the loop reads each frame for live slider values, and the
+> returned cleanup above. (Capturing stale state here is exactly the bug that
+> broke the old MobiusWalk twist toggle.) If you'd rather not return a cleanup,
+> the alternative is to stash the rAF id / disposables in a `ref` and cancel them
+> from a separate `useEffect` teardown — but the returned cleanup is simpler.
 
 ### 4D particle viewer — `ParticleViewerShell` + `lib/particles`
 

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -100,6 +100,24 @@ export const apps: AppDescriptor[] = [
 > decides *what the user can discover*. Forgetting `apps.ts` makes the app
 > reachable only by typing the hash.
 
+**Append, don't reorder.** Add your `routes` entry and `AppDescriptor` at the
+**end** of their respective lists, and your `lazy` import next to the others.
+These two files are the shared coordination points every new app touches, so
+keeping edits additive (new lines at the bottom) is what lets several app
+branches merge without conflicts — see [§8](#8-working-on-several-apps-at-once).
+Don't re-sort or reformat the existing entries.
+
+### 3c. Docs — your app's own paragraph
+
+Your PR also **owns the documentation for your app** — don't rely on a separate
+docs pass to backfill it. As additive edits (same append rule):
+
+- **`CLAUDE.md`** — add one row to the **Routing** table and one line to the
+  repository-layout tree under `src/animations/`.
+- **`README.md`** — add your app to the app list and the repo tree.
+
+Keep it to *your* app's lines only; leave everyone else's untouched.
+
 ---
 
 ## 4. Integrate with the AppShell
@@ -305,11 +323,63 @@ Manual checklist before opening a PR:
 - [ ] Settings/Actions render and the dimmed buttons light up appropriately.
 - [ ] Works on a narrow viewport; gestures don't fight page scroll.
 - [ ] No console errors; rAF loops and listeners are cleaned up on navigation away.
+- [ ] Docs updated for your app (`CLAUDE.md` route table + tree, `README.md`) — [§3c](#3c-docs--your-apps-own-paragraph).
+- [ ] Latest `main` merged in and `npm run build` re-run — [§8](#8-working-on-several-apps-at-once).
 - [ ] `npm run build` is green.
 
 ---
 
-## 8. Quick reference — files you'll touch
+## 8. Working on several apps at once
+
+Multiple app branches (often in separate agent threads) can be in flight at the
+same time. The framework is built to make that safe: **each app is a
+self-contained folder, so the bulk of every branch never overlaps.** The only
+files two app branches both touch are the shared coordination points:
+
+- `src/index.tsx` (route map) and `src/apps.ts` (catalog)
+- `CLAUDE.md` and `README.md` (the route table + repo tree)
+
+All four are edited **additively** (§3a–3c). Git auto-merges additive edits in
+different regions, so independent app branches normally merge with **no
+conflicts, in any order**. Two rules keep it that way:
+
+1. **Append, never reorder.** New entries go at the bottom of each list/table.
+   Don't re-sort, rename, or reformat existing lines — that's what turns a clean
+   auto-merge into a conflict.
+2. **Own only your app's lines.** Touch the shared files solely to add *your*
+   app. Leave other apps' rows, routes, and catalog entries alone.
+
+### Merge / PR workflow for a new app
+
+Because `main` moves under you while you work, **re-sync before you open (or
+finalize) the PR** so your branch reflects the latest set of apps:
+
+```bash
+git fetch origin
+git merge origin/main          # or: git rebase origin/main
+# resolve any conflicts — for the shared files it's almost always
+# "keep both": your new entry AND theirs. Never delete another app's lines.
+npm run build                  # MUST pass again after the merge
+```
+
+Then push and open the PR. Concretely:
+
+1. Build your app on its own branch; register it and write its docs (§3).
+2. `git fetch && git merge origin/main`; resolve the shared-file edits by
+   keeping every app's entries (yours + any that landed while you worked).
+3. `npm run build` — green — then verify the app still loads (§7).
+4. Push and open the PR. If another app's PR merges before yours, repeat step 2;
+   the re-sync is cheap precisely because the edits are additive.
+
+> **Why this matters here:** the docs-refresh PR that introduced this guide is
+> expected to land first and establish the structure above. App branches in
+> flight should pull `main` afterward, then add their own route-table row, tree
+> line, and catalog entry as part of their PR — so the docs stay correct as each
+> app merges, with no central catch-up pass.
+
+---
+
+## 9. Quick reference — files you'll touch
 
 | File | Why |
 |------|-----|
@@ -317,8 +387,10 @@ Manual checklist before opening a PR:
 | `src/animations/MyApp/EXPLAINER.md` | ? popup text (`?raw`) — recommended |
 | `src/animations/MyApp/README.md` | About text (`?raw`) — optional |
 | `src/animations/MyApp/*.ts` | optional logic/data helpers (physics, presets, geometry) |
-| `src/index.tsx` | lazy route registration |
-| `src/apps.ts` | catalog entry (drawer + menu) |
+| `src/index.tsx` | lazy route registration (append) |
+| `src/apps.ts` | catalog entry — drawer + menu (append) |
+| `CLAUDE.md` | route-table row + repo-tree line for your app (append) |
+| `README.md` | app list + repo-tree entry for your app (append) |
 | `src/components/AppShell.tsx` | integration hooks/components (import only) |
 | `src/components/ControlPanel.tsx` | form primitives (import only) |
 | `src/components/Canvas3D.tsx` | Three.js wrapper (import only) |

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import ParticleViewerShell from '../../components/ParticleViewerShell';
 import { Select } from '../../components/ControlPanel';
@@ -12,7 +12,11 @@ import {
   createParticleGeometry, rebuildGeometryBuffers, redistributeAdaptive,
   createAxes, startAnimationLoop, shapeNames,
 } from '../../lib/particles';
+import { usePersistentState } from '../../lib/usePersistentState';
 import type { ViewPoint } from '../../lib/particles';
+
+/** localStorage namespace for this viewer's saved settings. */
+const STORAGE_KEY = 'complex-particles';
 import {
   applyComplex, complexPowRational,
   functionNames, functionFormulas, POW_PQ_INDEX,
@@ -41,19 +45,20 @@ export default function ComplexParticles({
   onViewPointChange,
   viewPoint,
 }: ComplexParticlesProps) {
-  const state = useParticleState({ count, viewPoint, onViewPointChange });
+  const state = useParticleState({ count, viewPoint, onViewPointChange, storageKey: STORAGE_KEY });
   const controls = useViewControls(state);
   useUniformSync(state);
 
-  const [functionIndex, setFunctionIndex] = useState(() => {
+  const defaultFunctionIndex = (() => {
     const idx = functionNames.indexOf(selectedFunction);
     return idx >= 0 ? idx : 0;
-  });
-  const [expP, setExpP] = useState(p);
-  const [expQ, setExpQ] = useState(q);
-  const [branchCount, setBranchCount] = useState(branches);
-  const [branchIndices, setBranchIndices] = useState<number[]>([0, 1, 2]);
-  const [branchStyle, setBranchStyle] = useState<BranchStyle>('color');
+  })();
+  const [functionIndex, setFunctionIndex] = usePersistentState(`${STORAGE_KEY}:functionIndex`, defaultFunctionIndex);
+  const [expP, setExpP] = usePersistentState(`${STORAGE_KEY}:expP`, p);
+  const [expQ, setExpQ] = usePersistentState(`${STORAGE_KEY}:expQ`, q);
+  const [branchCount, setBranchCount] = usePersistentState(`${STORAGE_KEY}:branchCount`, branches);
+  const [branchIndices, setBranchIndices] = usePersistentState<number[]>(`${STORAGE_KEY}:branchIndices`, [0, 1, 2]);
+  const [branchStyle, setBranchStyle] = usePersistentState<BranchStyle>(`${STORAGE_KEY}:branchStyle`, 'color');
 
   const sceneRef = useRef<THREE.Scene>();
   const pointsRef = useRef<THREE.Points[]>([]);
@@ -318,6 +323,7 @@ export default function ComplexParticles({
       }}
       readme={readmeText}
       explainer={explainerText}
+      settingsStorageKey={STORAGE_KEY}
     />
   );
 }

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -9,9 +9,13 @@ import {
   functionNames, functionFormulas, POW_PQ_INDEX,
   applyComplexBranch, complexPowRational,
 } from '../../lib/complexMath';
+import { usePersistentState, clearPersistedState } from '../../lib/usePersistentState';
 import { vertexShader, fragmentShader } from './shaders';
 import PlaneCurveFloater, { type StandardCurveName } from './PlaneCurveFloater';
 import { buildStandardCurve, type CurvePoint } from './standardCurves';
+
+/** localStorage namespace for this viewer's saved settings. */
+const STORAGE_KEY = 'plane-transform';
 
 type ColourMode = 0 | 1 | 2;
 const COLOUR_MODE_LABELS: Record<ColourMode, string> = {
@@ -36,18 +40,19 @@ interface PaneRefs {
  * each colored point ends up at its f(z) location.
  */
 export default function PlaneTransform() {
-  const [functionIndex, setFunctionIndex] = useState(() =>
-    Math.max(0, functionNames.indexOf('sin')),
+  const [functionIndex, setFunctionIndex] = usePersistentState(
+    `${STORAGE_KEY}:functionIndex`, Math.max(0, functionNames.indexOf('sin')),
   );
-  const [expP, setExpP] = useState(1);
-  const [expQ, setExpQ] = useState(2);
-  const [branchIndex, setBranchIndex] = useState(0);
-  const [density, setDensity] = useState(240);          // points per side
-  const [pointSize, setPointSize] = useState(2.5);
-  const [viewExtent, setViewExtent] = useState(3);      // half-side of visible square
-  const [colourMode, setColourMode] = useState<ColourMode>(0);
-  const [saturation, setSaturation] = useState(0.85);
-  const [intensity, setIntensity] = useState(1.0);
+  const [expP, setExpP] = usePersistentState(`${STORAGE_KEY}:expP`, 1);
+  const [expQ, setExpQ] = usePersistentState(`${STORAGE_KEY}:expQ`, 2);
+  const [branchIndex, setBranchIndex] = usePersistentState(`${STORAGE_KEY}:branchIndex`, 0);
+  const [density, setDensity] = usePersistentState(`${STORAGE_KEY}:density`, 240);          // points per side
+  const [pointSize, setPointSize] = usePersistentState(`${STORAGE_KEY}:pointSize`, 2.5);
+  const [viewExtent, setViewExtent] = usePersistentState(`${STORAGE_KEY}:viewExtent`, 3);   // half-side of visible square
+  const [colourMode, setColourMode] = usePersistentState<ColourMode>(`${STORAGE_KEY}:colourMode`, 0);
+  const [saturation, setSaturation] = usePersistentState(`${STORAGE_KEY}:saturation`, 0.85);
+  const [intensity, setIntensity] = usePersistentState(`${STORAGE_KEY}:intensity`, 1.0);
+  // Drawn curve + draw toggle are transient per-session state, not persisted.
   const [curve, setCurve] = useState<CurvePoint[]>([]);
   const [drawMode, setDrawMode] = useState(false);
 
@@ -353,6 +358,22 @@ export default function PlaneTransform() {
         <Section title="About" icon="ⓘ">
           <Readme markdown={readmeText} />
         </Section>
+
+        <button
+          style={{
+            margin: '4px 0', padding: '12px 16px', borderRadius: 6,
+            border: '1px solid var(--cp-border)',
+            background: 'rgba(255,255,255,0.06)', color: 'var(--cp-fg)',
+            cursor: 'pointer', fontSize: 14, fontWeight: 600,
+          }}
+          onClick={() => {
+            clearPersistedState(STORAGE_KEY);
+            window.location.reload();
+          }}
+          title="Forget saved settings and restore the defaults"
+        >
+          Reset settings to defaults
+        </button>
       </ShellSettings>
     </>
   );

--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -9,7 +9,13 @@ export interface CanvasContext {
 }
 
 export interface Canvas3DProps {
-  onMount: (ctx: CanvasContext) => void;
+  /**
+   * Called once after the scene/camera/renderer are created. May optionally
+   * return a cleanup function (e.g. to `cancelAnimationFrame` your render loop
+   * and dispose geometries/textures); Canvas3D invokes it on unmount/remount,
+   * just before disposing the renderer.
+   */
+  onMount: (ctx: CanvasContext) => void | (() => void);
 }
 
 export default function Canvas3D({ onMount }: Canvas3DProps) {
@@ -41,8 +47,8 @@ export default function Canvas3D({ onMount }: Canvas3DProps) {
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2)); // Limit DPR for performance
     mount.appendChild(renderer.domElement);
     
-    onMount({ scene, camera, renderer });
-    
+    const cleanup = onMount({ scene, camera, renderer });
+
     const handleResize = () => {
       if (!mount) return;
       const w = mount.clientWidth;
@@ -62,6 +68,9 @@ export default function Canvas3D({ onMount }: Canvas3DProps) {
     window.addEventListener('resize', handleResize);
     
     return () => {
+      // Run the app's own teardown (cancel rAF, dispose geometries/textures)
+      // before we tear down the renderer it was drawing into.
+      if (typeof cleanup === 'function') cleanup();
       resizeObserver.disconnect();
       window.removeEventListener('resize', handleResize);
       renderer.dispose();

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -7,6 +7,7 @@ import QuarterTurnFloater from '../controls/QuarterTurnFloater';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../config/defaults';
 import { useResponsive } from '../styles/responsive';
 import { planes } from '../math/constants';
+import { clearPersistedState } from '../lib/usePersistentState';
 import {
   ColorStyle, ColourBy, AXIS_COLORS,
   shapeNames, textureNames, viewTypes, motionModes, dropModes,
@@ -41,11 +42,15 @@ export interface ParticleViewerShellProps {
   readme: string;
   /** Markdown explainer for the top-bar "?" help popup. */
   explainer?: string;
+  /** localStorage namespace whose saved settings the "Reset settings" action
+   *  clears. Omit on ephemeral viewers to hide the button. */
+  settingsStorageKey?: string;
 }
 
 export default function ParticleViewerShell({
   state, controls, onMount,
   functionName, functionFormula, functionPicker, variantExtras, functionList, readme, explainer,
+  settingsStorageKey,
 }: ParticleViewerShellProps) {
   const { isMobile, isTablet } = useResponsive();
   const compact = isMobile || isTablet;
@@ -227,6 +232,25 @@ export default function ParticleViewerShell({
           >
             Reset orientation
           </button>
+
+          {settingsStorageKey && (
+            <button
+              style={{
+                marginTop: 8,
+                padding: '12px 16px', borderRadius: 6,
+                border: '1px solid var(--cp-border)',
+                background: 'rgba(255,255,255,0.06)', color: 'var(--cp-fg)',
+                cursor: 'pointer', fontSize: 14, fontWeight: 600,
+              }}
+              onClick={() => {
+                clearPersistedState(settingsStorageKey);
+                window.location.reload();
+              }}
+              title="Forget saved settings and restore the defaults"
+            >
+              Reset settings to defaults
+            </button>
+          )}
 
           <div className="cp-row-label" style={{ marginTop: 8, marginBottom: 4 }}>Drop axis</div>
           <Pills

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -26,7 +26,7 @@ export interface ParticleViewerShellProps {
     scene: import('three').Scene;
     camera: import('three').PerspectiveCamera;
     renderer: import('three').WebGLRenderer;
-  }) => void;
+  }) => void | (() => void);
   functionName: string;
   functionFormula: string;
   functionPicker: React.ReactNode;

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -2,12 +2,17 @@ import { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { ProjectionMode } from '../viewpoint';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
+import { usePersistentState } from '../usePersistentState';
 import { ViewPoint, ColorStyle, ColourBy, Axis, motionModes, dropModes } from './types';
 
 export interface UseParticleStateOptions {
   count?: number;
   viewPoint?: ViewPoint;
   onViewPointChange?: (vp: ViewPoint) => void;
+  /** When set, the viewer's serializable settings persist to localStorage under
+   *  this namespace (e.g. 'complex-particles') and are restored on reload.
+   *  Omit to keep the viewer ephemeral. */
+  storageKey?: string;
 }
 
 export function useParticleState(options: UseParticleStateOptions = {}) {
@@ -15,48 +20,59 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     count = COMPLEX_PARTICLES_DEFAULTS.defaultParticleCount,
     viewPoint,
     onViewPointChange,
+    storageKey,
   } = options;
 
-  // ---- Rendering state ----
-  const [saturation, setSaturation] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.saturation);
-  const [particleCount, setParticleCount] = useState(count);
-  const [cameraZ, setCameraZ] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.cameraZ);
-  // Camera orbit: spherical coords around the origin. 1-finger drag updates
-  // these without touching the 4D quaternion rotation.
+  // Build a per-field persistence key, or null to fall back to ephemeral state.
+  const pk = (name: string) => (storageKey ? `${storageKey}:${name}` : null);
+
+  // ---- Rendering state (persisted) ----
+  const [saturation, setSaturation] = usePersistentState(pk('saturation'), COMPLEX_PARTICLES_DEFAULTS.initial.saturation);
+  const [particleCount, setParticleCount] = usePersistentState(pk('particleCount'), count);
+  const [cameraZ, setCameraZ] = usePersistentState(pk('cameraZ'), COMPLEX_PARTICLES_DEFAULTS.initial.cameraZ);
+  // Camera orbit + pan are transient "looking" state, not settings — they reset
+  // each session (and the Reset orientation button clears them), so they are
+  // intentionally NOT persisted.
   const [azimuth, setAzimuth] = useState(0);
   const [elevation, setElevation] = useState(0);
-  // Pan offset: shifts the look-at target away from the origin. 2-finger drag
-  // (or Shift+drag on desktop) updates these. Position and look-at both
-  // translate by this vector, so the visible scene appears to follow the
-  // finger (Maps convention).
   const [panX, setPanX] = useState(0);
   const [panY, setPanY] = useState(0);
   const [panZ, setPanZ] = useState(0);
-  const [size, setSize] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.size);
-  const [opacity, setOpacity] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.opacity);
-  const [intensity, setIntensity] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.intensity);
-  const [shimmer, setShimmer] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.shimmer);
-  const [hueShift, setHueShift] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.hueShift);
-  const [jitter, setJitter] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.jitter);
-  const [axisWidth, setAxisWidth] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.axisWidth);
+  const [size, setSize] = usePersistentState(pk('size'), COMPLEX_PARTICLES_DEFAULTS.initial.size);
+  const [opacity, setOpacity] = usePersistentState(pk('opacity'), COMPLEX_PARTICLES_DEFAULTS.initial.opacity);
+  const [intensity, setIntensity] = usePersistentState(pk('intensity'), COMPLEX_PARTICLES_DEFAULTS.initial.intensity);
+  const [shimmer, setShimmer] = usePersistentState(pk('shimmer'), COMPLEX_PARTICLES_DEFAULTS.initial.shimmer);
+  const [hueShift, setHueShift] = usePersistentState(pk('hueShift'), COMPLEX_PARTICLES_DEFAULTS.initial.hueShift);
+  const [jitter, setJitter] = usePersistentState(pk('jitter'), COMPLEX_PARTICLES_DEFAULTS.initial.jitter);
+  const [axisWidth, setAxisWidth] = usePersistentState(pk('axisWidth'), COMPLEX_PARTICLES_DEFAULTS.initial.axisWidth);
   /** Half-side of the sampled grid in input-space units. */
-  const [gridExtent, setGridExtent] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.gridExtent);
+  const [gridExtent, setGridExtent] = usePersistentState(pk('gridExtent'), COMPLEX_PARTICLES_DEFAULTS.initial.gridExtent);
   /** When true, sample more densely where |f'(z)| is large. */
-  const [adaptive, setAdaptive] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.adaptive);
+  const [adaptive, setAdaptive] = usePersistentState(pk('adaptive'), COMPLEX_PARTICLES_DEFAULTS.initial.adaptive);
   /** Exponent biasing strength for adaptive sampling. */
-  const [adaptiveAlpha, setAdaptiveAlpha] = useState(COMPLEX_PARTICLES_DEFAULTS.initial.adaptiveAlpha);
-  const [objectMode, setObjectMode] = useState(false);
-  const [shapeIndex, setShapeIndex] = useState(1);
-  const [textureIndex, setTextureIndex] = useState(0);
+  const [adaptiveAlpha, setAdaptiveAlpha] = usePersistentState(pk('adaptiveAlpha'), COMPLEX_PARTICLES_DEFAULTS.initial.adaptiveAlpha);
+  const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
+  const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
+  const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
   const [realView, setRealView] = useState(false);
-  const [colourStyle, setColourStyle] = useState<ColorStyle>(ColorStyle.HSV);
-  const [colourBy, setColourBy] = useState<ColourBy>(ColourBy.Domain);
+  const [colourStyle, setColourStyle] = usePersistentState<ColorStyle>(pk('colourStyle'), ColorStyle.HSV);
+  const [colourBy, setColourBy] = usePersistentState<ColourBy>(pk('colourBy'), ColourBy.Domain);
 
   // ---- View / projection state ----
-  const [viewType, setViewType] = useState<ProjectionMode>(ProjectionMode.Perspective);
-  const [viewMotion, setViewMotion] = useState<(typeof motionModes)[number]>('Quaternion');
-  const [dropAxis, setDropAxis] = useState<(typeof dropModes)[number]>('None');
-  const [proj, setProj] = useState(ProjectionMode.Perspective);
+  const [viewType, setViewType] = usePersistentState<ProjectionMode>(pk('viewType'), ProjectionMode.Perspective);
+  const [viewMotion, setViewMotion] = usePersistentState<(typeof motionModes)[number]>(pk('viewMotion'), 'Quaternion');
+  const [dropAxis, setDropAxis] = usePersistentState<(typeof dropModes)[number]>(pk('dropAxis'), 'None');
+  // `proj` is the projection actually applied to the shader (vs. `viewType`, the
+  // user's pick). Seed it from the restored viewType + dropAxis so a reloaded
+  // Stereo/Hopf/Drop view renders correctly from the first frame instead of
+  // snapping back to Perspective.
+  const [proj, setProj] = useState(
+    dropAxis === 'DropX' ? ProjectionMode.DropX
+      : dropAxis === 'DropY' ? ProjectionMode.DropY
+      : dropAxis === 'DropU' ? ProjectionMode.DropU
+      : dropAxis === 'DropV' ? ProjectionMode.DropV
+      : viewType,
+  );
   const [orientationMatrix, setOrientationMatrix] = useState<number[][]>([
     [0, 0, 0, 0],
     [0, 0, 0, 0],

--- a/src/lib/usePersistentState.ts
+++ b/src/lib/usePersistentState.ts
@@ -1,0 +1,72 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Lightweight settings persistence backed by localStorage.
+ *
+ * `usePersistentState` is a drop-in replacement for `useState` that mirrors its
+ * value to localStorage, so a user's choices survive a reload (and switching
+ * apps and back). Pass `key = null` to disable persistence — the hook is still
+ * called unconditionally, so React's hook order stays stable whether or not an
+ * app opts in.
+ *
+ * Keys are namespaced under `animath:<version>:` so we can invalidate every
+ * stored setting at once by bumping VERSION (e.g. after an incompatible change
+ * to what a value means). Every storage access is wrapped in try/catch because
+ * private-mode browsers throw on access, and writes are debounced so dragging a
+ * slider doesn't hammer storage on every animation frame.
+ */
+
+/** Bump when stored values change meaning incompatibly; old keys are ignored. */
+const VERSION = 'v1';
+const PREFIX = `animath:${VERSION}:`;
+
+function load<T>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(PREFIX + key);
+    if (raw == null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function usePersistentState<T>(key: string | null, initial: T) {
+  const [value, setValue] = useState<T>(() => (key ? load(key, initial) : initial));
+  const timer = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (!key || typeof window === 'undefined') return;
+    clearTimeout(timer.current);
+    timer.current = setTimeout(() => {
+      try {
+        window.localStorage.setItem(PREFIX + key, JSON.stringify(value));
+      } catch {
+        /* quota exceeded / private mode — silently skip */
+      }
+    }, 150);
+    return () => clearTimeout(timer.current);
+  }, [key, value]);
+
+  return [value, setValue] as const;
+}
+
+/**
+ * Remove every persisted key under a namespace (e.g. 'complex-particles'), so a
+ * "Reset to defaults" can wipe one app's saved settings. Callers typically clear
+ * then reload so the components re-initialise from their defaults.
+ */
+export function clearPersistedState(namespace: string): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const full = `${PREFIX}${namespace}:`;
+    const doomed: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i);
+      if (k && k.startsWith(full)) doomed.push(k);
+    }
+    doomed.forEach(k => window.localStorage.removeItem(k));
+  } catch {
+    /* ignore */
+  }
+}


### PR DESCRIPTION
## Summary

Two related things: (1) bring the repo docs in line with the new AppShell architecture and add a build guide, and (2) add **settings persistence** so a user's controls survive a reload.

## Part 1 — Documentation

The recent PRs (#154–#173) introduced a new architecture — a persistent **AppShell**, a `src/apps.ts` registry, a landing **Menu**, the `lib/particles` engine + `ParticleViewerShell`, per-app `EXPLAINER.md` popups, code-splitting, and the **Plane Transform** module. The docs hadn't caught up.

- **CLAUDE.md** — full rewrite: current layout, hash-route table, the AppShell integration API (hooks + portal components), `ControlPanel` primitives, the `lib/particles` engine, and a refreshed tech-debt list.
- **README.md** — added Plane Transform + the landing menu, the full top-bar button set, corrected routes and repository tree, linked the new guide.
- **AGENTS.md** — rewritten around the hook-driven framework.
- **ARCHITECTURE.md** — headed with a note marking it a *historical design proposal*.
- **docs/BUILDING_AN_APP.md** (new) — step-by-step guide for people and agents: pick an archetype, register the route + catalog, integrate via the shell hooks, render (DOM / `Canvas3D` / `ParticleViewerShell`), conventions, gotchas, checklist.

Cross-checked against the two open PRs — #174 (Möbius fix) and #175 (Trinary System, a new module) — to make sure the guide matches how modules are actually built. The Trinary module surfaced two conventions now captured: `README.md` (About) is optional while `EXPLAINER.md` (the `?` popup) is the always-present doc, and non-trivial logic/data is split into sibling `.ts` modules.

## Part 2 — Settings persistence (new feature)

Until now every control reset to defaults on reload, because state was in-memory only. This adds opt-in persistence:

- **`src/lib/usePersistentState.ts`** (new) — a drop-in `useState` that mirrors to `localStorage` under a namespaced `animath:<version>:<app>:<field>` key. Debounced writes; every storage access wrapped in `try/catch` (private-mode safe); `key = null` opts out so hook order stays stable; `clearPersistedState(namespace)` for resets; a `VERSION` prefix to invalidate old data on incompatible changes.
- **`useParticleState`** gains a `storageKey` option → **Complex Particles** now remembers colour/size/projection/etc. **Plane Transform** persists its settings too.
- Projection is seeded from the restored `viewType` + `dropAxis`, so a reloaded Stereo/Hopf/Drop view renders correctly from the first frame instead of snapping to Perspective.
- Transient view state (camera orbit/pan) and derived values are intentionally **not** persisted.
- Added a **"Reset settings to defaults"** action (clear namespace + reload) to the particle viewers and Plane Transform.

Scope per the design discussion: localStorage, auto remember-last, particle viewers first (the shared `useParticleState` covers Complex Particles; Plane Transform wired directly). The same `usePersistentState` hook makes extending to the other apps a small follow-up.

## Verification

`npm run build` (tsc + vite) passes cleanly. Does not touch `apps.ts`/`index.tsx` route wiring, so it won't conflict with the in-flight module PRs (#174, #175).

https://claude.ai/code/session_01HrL5NXVKEX8hmA15Bsya6U