### PR TITLE
PlaneTransform: add polar grid + log-polar plane views

### DIFF
--- a/src/animations/PlaneTransform/EXPLAINER.md
+++ b/src/animations/PlaneTransform/EXPLAINER.md
@@ -19,6 +19,21 @@ Hue is the **argument** of `z` (its angle around the origin); brightness and
 the tile pattern encode magnitude. Because the color rides along with each
 point, you can watch how `f` rotates, stretches, folds, or tears the plane.
 
+## Polar grid and the log-polar plane
+
+Two **View** toggles change how the plane is drawn:
+
+- **Grid: Polar** samples the input on concentric (log-spaced) circles and
+  radial spokes instead of a square mesh — so you watch circles `|z| = r` and
+  rays `arg z = θ` get bent into their image curves.
+- **Plane: Log-polar** *unrolls* the plane: each point is plotted at
+  `(arg, log|·|)` — angle across, log-radius up. Here multiplication by a
+  constant becomes a translation, `zⁿ` becomes a linear shear, and `ln` flattens
+  the strip into a square. The branch cut sits on the left/right edges.
+
+Combine them — *Polar grid + Log-polar plane* turns the input into a clean
+square lattice, which makes the shears and translations easy to read.
+
 ## Multi-valued functions and the branch index
 
 Some functions don't have a single answer. **√z**, **ln z**, and

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -13,6 +13,10 @@ import { usePersistentState, clearPersistedState } from '../../lib/usePersistent
 import { vertexShader, fragmentShader } from './shaders';
 import PlaneCurveFloater, { type StandardCurveName } from './PlaneCurveFloater';
 import { buildStandardCurve, type CurvePoint } from './standardCurves';
+import {
+  sampleInputPositions, clipFromMath, mathFromClip,
+  type GridMode, type PlaneMode,
+} from './polarViews';
 
 /** localStorage namespace for this viewer's saved settings. */
 const STORAGE_KEY = 'plane-transform';
@@ -49,6 +53,8 @@ export default function PlaneTransform() {
   const [density, setDensity] = usePersistentState(`${STORAGE_KEY}:density`, 240);          // points per side
   const [pointSize, setPointSize] = usePersistentState(`${STORAGE_KEY}:pointSize`, 2.5);
   const [viewExtent, setViewExtent] = usePersistentState(`${STORAGE_KEY}:viewExtent`, 3);   // half-side of visible square
+  const [gridMode, setGridMode] = usePersistentState<GridMode>(`${STORAGE_KEY}:gridMode`, 'cartesian');
+  const [planeMode, setPlaneMode] = usePersistentState<PlaneMode>(`${STORAGE_KEY}:planeMode`, 'cartesian');
   const [colourMode, setColourMode] = usePersistentState<ColourMode>(`${STORAGE_KEY}:colourMode`, 0);
   const [saturation, setSaturation] = usePersistentState(`${STORAGE_KEY}:saturation`, 0.85);
   const [intensity, setIntensity] = usePersistentState(`${STORAGE_KEY}:intensity`, 1.0);
@@ -99,21 +105,13 @@ export default function PlaneTransform() {
   // viewExtent for the input pane and apply f then divide for the output pane.
   useEffect(() => {
     const n = density * density;
-    const inputPos = new Float32Array(n * 2);
+    const inputPos = sampleInputPositions(gridMode, density, viewExtent);
     const seeds    = new Float32Array(n * 4);
-    let k = 0;
-    for (let i = 0; i < density; i++) {
-      for (let j = 0; j < density; j++) {
-        const x = (i / (density - 1) - 0.5) * 2 * viewExtent;
-        const y = (j / (density - 1) - 0.5) * 2 * viewExtent;
-        inputPos[2 * k]     = x;
-        inputPos[2 * k + 1] = y;
-        seeds[4 * k]     = Math.random();
-        seeds[4 * k + 1] = Math.random();
-        seeds[4 * k + 2] = Math.random();
-        seeds[4 * k + 3] = Math.random();
-        k++;
-      }
+    for (let k = 0; k < n; k++) {
+      seeds[4 * k]     = Math.random();
+      seeds[4 * k + 1] = Math.random();
+      seeds[4 * k + 2] = Math.random();
+      seeds[4 * k + 3] = Math.random();
     }
     const geom = new THREE.BufferGeometry();
     geom.setAttribute('inputPos', new THREE.BufferAttribute(inputPos, 2));
@@ -125,7 +123,7 @@ export default function PlaneTransform() {
     if (outputPane.current.points) outputPane.current.points.geometry = geom;
 
     return () => geom.dispose();
-  }, [density, viewExtent]);
+  }, [density, viewExtent, gridMode]);
 
   // Mount and tear down both renderers.
   useEffect(() => {
@@ -144,6 +142,7 @@ export default function PlaneTransform() {
         uniforms: {
           viewExtent:    { value: viewExtent },
           transform:     { value: transform },
+          planeMode:     { value: planeMode === 'logpolar' ? 1 : 0 },
           functionType:  { value: functionIndex },
           exponentP:     { value: expP },
           exponentQ:     { value: expQ === 0 ? 1 : expQ },
@@ -205,6 +204,7 @@ export default function PlaneTransform() {
     for (const pane of [inputPane.current, outputPane.current]) {
       const m = pane.material; if (!m) continue;
       m.uniforms.viewExtent.value   = viewExtent;
+      m.uniforms.planeMode.value    = planeMode === 'logpolar' ? 1 : 0;
       m.uniforms.functionType.value = functionIndex;
       m.uniforms.exponentP.value    = expP;
       m.uniforms.exponentQ.value    = expQ === 0 ? 1 : expQ;
@@ -214,7 +214,7 @@ export default function PlaneTransform() {
       m.uniforms.saturation.value   = saturation;
       m.uniforms.intensity.value    = intensity;
     }
-  }, [viewExtent, functionIndex, expP, expQ, branchIndex, pointSize, colourMode, saturation, intensity]);
+  }, [viewExtent, planeMode, functionIndex, expP, expQ, branchIndex, pointSize, colourMode, saturation, intensity]);
 
   // Map a curve through the active complex function to get the output polyline.
   const outputCurve = useMemo<CurvePoint[]>(() => {
@@ -269,6 +269,7 @@ export default function PlaneTransform() {
         <InputPane
           mountRef={inputMountRef}
           viewExtent={viewExtent}
+          planeMode={planeMode}
           drawMode={drawMode}
           curve={curve}
           onAppendCurve={(pt, fresh) => {
@@ -281,6 +282,7 @@ export default function PlaneTransform() {
         <OutputPane
           mountRef={outputMountRef}
           viewExtent={viewExtent}
+          planeMode={planeMode}
           curve={outputCurve}
           onWheelZoom={(factor) => setViewExtent(v => Math.min(20, Math.max(0.2, v * factor)))}
         >
@@ -344,6 +346,24 @@ export default function PlaneTransform() {
         </Section>
 
         <Section title="View" icon="◑">
+          <Pills<GridMode>
+            label="Grid"
+            options={[
+              { value: 'cartesian', label: 'Cartesian' },
+              { value: 'polar', label: 'Polar' },
+            ]}
+            value={gridMode}
+            onChange={setGridMode}
+          />
+          <Pills<PlaneMode>
+            label="Plane"
+            options={[
+              { value: 'cartesian', label: 'Cartesian' },
+              { value: 'logpolar', label: 'Log-polar' },
+            ]}
+            value={planeMode}
+            onChange={setPlaneMode}
+          />
           <Slider label="Extent (±)" value={viewExtent}
             min={0.5} max={10} step={0.5}
             onChange={setViewExtent} format={v => v.toFixed(1)} />
@@ -410,28 +430,31 @@ function useInscribedSquare(ref: React.RefObject<HTMLDivElement>) {
 interface PaneCommon {
   mountRef: React.RefObject<HTMLDivElement>;
   viewExtent: number;
+  planeMode: PlaneMode;
   curve: CurvePoint[];
   onWheelZoom: (factor: number) => void;
   children?: React.ReactNode;
 }
 
-function CurveSvg({ box, viewExtent, points }: {
+function CurveSvg({ box, viewExtent, planeMode, points }: {
   box: { w: number; h: number; size: number; offX: number; offY: number };
   viewExtent: number;
+  planeMode: PlaneMode;
   points: CurvePoint[];
 }) {
   if (box.size === 0 || points.length === 0) return null;
   const cx = box.offX + box.size / 2;
   const cy = box.offY + box.size / 2;
-  const sx = box.size / (2 * viewExtent);
-  // Clip wildly-large points (e.g. 1/z near origin) so the path stays inside
-  // the SVG; matches the shader's `length(pos) > 1e3` cap.
-  const MAX = 1e3;
+  const half = box.size / 2;
+  // Map each math point through the same transform the shader uses (Cartesian
+  // or log-polar), then place it within the inscribed square. Clamp the NDC so
+  // a stray point at infinity can't blow the path out to a huge bounding box.
   const d = points.map(([x, y], i) => {
-    const cx0 = Math.max(-MAX, Math.min(MAX, x));
-    const cy0 = Math.max(-MAX, Math.min(MAX, y));
-    const px = cx + cx0 * sx;
-    const py = cy - cy0 * sx;
+    let [nx, ny] = clipFromMath(x, y, planeMode, viewExtent);
+    nx = Math.max(-1e4, Math.min(1e4, nx));
+    ny = Math.max(-1e4, Math.min(1e4, ny));
+    const px = cx + nx * half;
+    const py = cy - ny * half;
     return `${i === 0 ? 'M' : 'L'} ${px.toFixed(2)} ${py.toFixed(2)}`;
   }).join(' ');
   return (
@@ -446,7 +469,7 @@ function CurveSvg({ box, viewExtent, points }: {
 }
 
 function InputPane({
-  mountRef, viewExtent, drawMode, curve, onAppendCurve, onWheelZoom, children,
+  mountRef, viewExtent, planeMode, drawMode, curve, onAppendCurve, onWheelZoom, children,
 }: PaneCommon & {
   drawMode: boolean;
   onAppendCurve: (pt: CurvePoint, fresh: boolean) => void;
@@ -459,10 +482,14 @@ function InputPane({
   const toMath = (clientX: number, clientY: number): CurvePoint | null => {
     const el = mountRef.current; if (!el || box.size === 0) return null;
     const r = el.getBoundingClientRect();
-    const sx = box.size / (2 * viewExtent);
-    const cx = r.left + box.offX + box.size / 2;
-    const cy = r.top  + box.offY + box.size / 2;
-    return [(clientX - cx) / sx, -(clientY - cy) / sx];
+    const half = box.size / 2;
+    const cx = r.left + box.offX + half;
+    const cy = r.top  + box.offY + half;
+    // Pixel → NDC → math, inverting whichever plane layout is active so a
+    // freehand stroke in the (possibly unrolled) input pane maps to real z.
+    const nx = (clientX - cx) / half;
+    const ny = -(clientY - cy) / half;
+    return mathFromClip(nx, ny, planeMode, viewExtent);
   };
 
   const onPointerDown = (e: React.PointerEvent) => {
@@ -533,13 +560,13 @@ function InputPane({
       onWheel={onWheel}
     >
       {children}
-      <CurveSvg box={box} viewExtent={viewExtent} points={curve} />
+      <CurveSvg box={box} viewExtent={viewExtent} planeMode={planeMode} points={curve} />
     </div>
   );
 }
 
 function OutputPane({
-  mountRef, viewExtent, curve, onWheelZoom, children,
+  mountRef, viewExtent, planeMode, curve, onWheelZoom, children,
 }: PaneCommon) {
   const box = useInscribedSquare(mountRef);
   const pointersRef = useRef(new Map<number, { x: number; y: number }>());
@@ -585,7 +612,7 @@ function OutputPane({
       onWheel={onWheel}
     >
       {children}
-      <CurveSvg box={box} viewExtent={viewExtent} points={curve} />
+      <CurveSvg box={box} viewExtent={viewExtent} planeMode={planeMode} points={curve} />
     </div>
   );
 }

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -42,6 +42,9 @@ interface PaneRefs {
  * canvas, stacked top-bottom on a tall one. Same point cloud renders into
  * both panes — the second pane's vertex shader runs the selected function so
  * each colored point ends up at its f(z) location.
+ *
+ * The View section offers a polar sampling grid (rings + rays) and a log-polar
+ * plane layout (plot at (arg, log|·|)) — see polarViews.ts.
  */
 export default function PlaneTransform() {
   const [functionIndex, setFunctionIndex] = usePersistentState(

--- a/src/animations/PlaneTransform/polarViews.ts
+++ b/src/animations/PlaneTransform/polarViews.ts
@@ -1,0 +1,101 @@
+// Polar / log-polar helpers for the Plane Transform viewer.
+//
+// These are deliberately small, dependency-free pure functions: this is an
+// experiment living inside PlaneTransform, but if it proves useful the sampler
+// and the layout transforms below can be lifted into `lib/particles` wholesale
+// and shared with the 3D ComplexParticles viewer.
+//
+// IMPORTANT: `clipFromMath` mirrors the log-polar branch in
+// `shaders/index.ts` (the vertex shader). If you change the math in one,
+// change it in the other so the GPU points and the SVG curve overlay agree.
+
+export type GridMode  = 'cartesian' | 'polar';
+export type PlaneMode = 'cartesian' | 'logpolar';
+
+const PI = Math.PI;
+/** Floor on the magnitude before taking log, matching the shader's `max(r,…)`. */
+const MIN_R = 1e-4;
+/** Cartesian clamp for giant points (1/z near 0), matching the shader. */
+const GIANT = 1e3;
+
+/** Vertical span (in log-radius) that fills the visible pane in log-polar mode.
+ *  Floored at 1 so the view never collapses or inverts for viewExtent ≤ 1. */
+export function logSpan(viewExtent: number): number {
+  return Math.max(Math.log(viewExtent), 1);
+}
+
+/**
+ * Sample the input domain into a flat [x0,y0, x1,y1, …] array of `density²`
+ * points (math coordinates), either on a Cartesian mesh or a polar grid of
+ * log-spaced rings × evenly-spaced rays.
+ */
+export function sampleInputPositions(
+  gridMode: GridMode, density: number, viewExtent: number,
+): Float32Array {
+  const n = density * density;
+  const out = new Float32Array(n * 2);
+  let k = 0;
+
+  if (gridMode === 'polar') {
+    const rMin = viewExtent * 1e-3;
+    const ratio = viewExtent / rMin;
+    for (let i = 0; i < density; i++) {
+      // Log-spaced radius so rings read evenly and match the brightness banding.
+      const t = density > 1 ? i / (density - 1) : 0;
+      const r = rMin * Math.pow(ratio, t);
+      for (let j = 0; j < density; j++) {
+        const theta = (j / density) * 2 * PI;   // exclusive end avoids a doubled ray
+        out[2 * k]     = r * Math.cos(theta);
+        out[2 * k + 1] = r * Math.sin(theta);
+        k++;
+      }
+    }
+    return out;
+  }
+
+  // Cartesian mesh over [-viewExtent, +viewExtent]².
+  for (let i = 0; i < density; i++) {
+    for (let j = 0; j < density; j++) {
+      out[2 * k]     = (i / (density - 1) - 0.5) * 2 * viewExtent;
+      out[2 * k + 1] = (j / (density - 1) - 0.5) * 2 * viewExtent;
+      k++;
+    }
+  }
+  return out;
+}
+
+/**
+ * Math point → normalized device coords (NDC, the [-1,1]² square the renderer
+ * draws into). The SVG overlay reuses this so curves line up with the GPU
+ * points. Mirrors the vertex shader.
+ */
+export function clipFromMath(
+  x: number, y: number, planeMode: PlaneMode, viewExtent: number,
+): [number, number] {
+  if (planeMode === 'logpolar') {
+    const r = Math.hypot(x, y);
+    const ny = Math.log(Math.max(r, MIN_R)) / logSpan(viewExtent);
+    const nx = Math.atan2(y, x) / PI;
+    return [nx, ny];
+  }
+  // Cartesian: clamp giants the same way the shader does, then scale.
+  let cx = x, cy = y;
+  const L = Math.hypot(x, y);
+  if (L > GIANT) { cx = (x / L) * GIANT; cy = (y / L) * GIANT; }
+  return [cx / viewExtent, cy / viewExtent];
+}
+
+/**
+ * Inverse of `clipFromMath`: NDC → math point. Used by freehand drawing so a
+ * stroke in the (unrolled) input pane maps back to the right z values.
+ */
+export function mathFromClip(
+  nx: number, ny: number, planeMode: PlaneMode, viewExtent: number,
+): [number, number] {
+  if (planeMode === 'logpolar') {
+    const theta = nx * PI;
+    const r = Math.exp(ny * logSpan(viewExtent));
+    return [r * Math.cos(theta), r * Math.sin(theta)];
+  }
+  return [nx * viewExtent, ny * viewExtent];
+}

--- a/src/animations/PlaneTransform/shaders/index.ts
+++ b/src/animations/PlaneTransform/shaders/index.ts
@@ -8,6 +8,7 @@ attribute vec4 seed;
 
 uniform float viewExtent;
 uniform int   transform;
+uniform int   planeMode;   // 0 = Cartesian plot, 1 = log-polar (unrolled) plot
 uniform int   functionType;
 uniform int   exponentP;
 uniform int   exponentQ;
@@ -15,6 +16,8 @@ uniform int   branchIndex;
 uniform float pointSize;
 
 varying vec2 vSourcePos;
+
+const float VS_PI = 3.14159265359;
 
 // ---------- Complex helpers (matched to ComplexParticles' shader) ----------
 vec2 complexSqrt    (vec2 z){float r=length(z);float t=atan(z.y,z.x);float sr=sqrt(r);return vec2(sr*cos(t*0.5),sr*sin(t*0.5));}
@@ -92,10 +95,21 @@ vec2 applyComplex(vec2 z, int t){
 void main(){
   vSourcePos = inputPos;
   vec2 pos = transform == 1 ? applyComplex(inputPos, functionType) : inputPos;
-  // Clip giants so we don't lose all colour to one stray point at infinity.
-  if(length(pos) > 1e3) pos = normalize(pos)*1e3;
-  // Map to clip space using viewExtent (= half-side of the visible square).
-  gl_Position = vec4(pos / viewExtent, 0.0, 1.0);
+
+  vec2 ndc;
+  if(planeMode == 1){
+    // Log-polar "unrolled" plot: x = arg/π across, y = log|·| up.
+    // Mirrors clipFromMath() in polarViews.ts — keep the two in sync.
+    float r = length(pos);
+    float logSpan = max(log(viewExtent), 1.0);
+    ndc = vec2(atan(pos.y, pos.x) / VS_PI, log(max(r, 1e-4)) / logSpan);
+  } else {
+    // Cartesian plot. Clip giants so one stray point at infinity doesn't
+    // wash out the colour, then scale by viewExtent (= half visible side).
+    if(length(pos) > 1e3) pos = normalize(pos)*1e3;
+    ndc = pos / viewExtent;
+  }
+  gl_Position = vec4(ndc, 0.0, 1.0);
   gl_PointSize = pointSize;
 }
 `;


### PR DESCRIPTION
Adds two independent **View** toggles to the planar complex-function viewer (`PlaneTransform`), as an experiment scoped to that app only.

## What's new

- **Grid: Cartesian / Polar** — sample the input on log-spaced concentric rings + radial spokes instead of a square mesh, so circles `|z| = r` and rays `arg z = θ` are visibly bent into their image curves.
- **Plane: Cartesian / Log-polar** — plot points at `(arg, log|·|)`, unrolling the plane into a strip (angle across, log-radius up). Multiplication by a constant becomes a translation, `zⁿ` a linear shear, and `ln` flattens the strip into a square; the branch cut sits on the strip edges.

They compose: *Polar grid + Log-polar plane* turns the input into a clean square lattice, making the shears/translations easy to read.

## Structure (built to factor out later)

The reusable pieces live in a small, dependency-free `PlaneTransform/polarViews.ts`:
- `sampleInputPositions(gridMode, density, viewExtent)` — the domain sampler.
- `clipFromMath` / `mathFromClip` — forward/inverse layout transforms.

The GLSL vertex shader mirrors `clipFromMath` (paired by a comment); the SVG curve overlay and freehand drawing route through the same transforms, so standard curves, their images, and pen strokes stay aligned in every mode. `EXPLAINER.md` gained a short section.

If this proves useful, `polarViews.ts` can be lifted into `lib/particles` — the **polar grid** sampler is the part that would carry over to the 3D `ComplexParticles` viewer (the log-polar *layout* is 2D-pane-specific).

## Scope

No shared files touched — no `lib/particles`, `apps.ts`, or routing changes, so it stays conflict-free with other app branches.

## Validation

`npm run build` (tsc + vite) passes.

https://claude.ai/code/session_01MDn37UjnLYUQG3k8Jmp2SX

---
_Generated by [Claude Code](https://claude.ai/code/session_01MDn37UjnLYUQG3k8Jmp2SX)_