### PR TITLE
Add translucent-sheet render mode to Complex Particles

### DIFF
--- a/docs/sessions/handoff/complex-sheet-ar9zA/2026-06-08-S01-surface-render-modes.md
+++ b/docs/sessions/handoff/complex-sheet-ar9zA/2026-06-08-S01-surface-render-modes.md
@@ -1,0 +1,118 @@
+---
+kind: handoff
+session: 2026-06-08-S01
+date: 2026-06-08
+title: Surface render modes (Sheet · Tiles · Net) + colormaps & sampling
+branch: claude/complex-sheet-ar9zA
+slug: complex-sheet-ar9zA
+status: completed
+build: passed
+followup: low
+pr: null
+app: ComplexParticles
+---
+
+# Surface render modes (Sheet · Tiles · Net) + colormaps & sampling
+
+> [!NOTE]
+> All work is on **`origin/complex-sheet`** (tip `81af245`). It is **not merged to
+> `main` and not deployed** to GitHub Pages — view it by running the branch
+> locally (`npm run dev`). The companion progress report has the full timeline.
+
+## Summary
+
+Grew `ComplexParticles` from a points viewer into a multi-mode complex-function
+surface viewer, all inside the existing `lib/particles` engine +
+`ParticleViewerShell` (no new route / `apps.ts` entry). There are now four render
+modes — **Points**, **Sheet** (translucent fill + rectangular wireframe, with
+adaptive dissolve-to-points), **Tiles** (oriented surfels that tear apart where
+the map stretches), and **Net** (a polar fibre net of circles/rays as fat
+ribbons). Colour gained a 14-entry **colormap** system (perceptual + cyclic +
+diverging, log-scaled, repeatable, driven by a chosen Quantity/Brightness),
+**external directional lighting** (inside-vs-outside), and **reciprocal
+(log-radial) sampling** that applies to every mode. The settings panel was then
+decluttered to show only mode-relevant controls. `npm run build` passes.
+
+## What changed
+
+Each feature is its own commit (history is intentionally fine-grained because the
+container kept reverting the local checkout — see Context):
+
+| Commit | Feature |
+|---|---|
+| `6e99207` / `3b71adb` | Sheet **adaptive density** (dissolve to points where stretched) + edge-fade; max resolution 200→500 |
+| `70d7d6d` | **Tiles** render mode (oriented surfels, `Tile size` cap) |
+| `77d3afc` | **Sequential colormaps** for magnitude (reuse `lib/colormaps.ts`) |
+| `92d9df3` | **External light** (directional + cool/dim back-face = inside/outside) on Sheet/Tiles |
+| `902fabb` | **Net** render mode (polar fibre net: circles + rays) |
+| `f132697` | Net **independent Circles/Rays toggles** (rays default off), Circles max 250 |
+| `3031f4c` | Colormaps **log-scaled** + **Repeat (log bands)** |
+| `a8d588f` | **Reciprocal (log-radial) sampling** for all modes (`domainWarp`) |
+| `6027c29` | Net **Width + Resolution** (screen-space ribbons; was 1px LineSegments) |
+| `1ee72b3` | **+6 colormaps**: Turbo, Cubehelix, Hot, Copper, Cool, Cool–warm |
+| `939525c` | **Declutter** settings panel (mode/colormap-aware control visibility) |
+| `81af245` | Colormaps **honour Quantity + Brightness** selectors (fix declutter over-hide) |
+
+## Key files
+
+<!-- Links pinned to commit 81af245. -->
+
+| File | Role |
+|---|---|
+| [`lib/particles/createSheetGeometry.ts`](https://github.com/piyarsquare/animath/blob/81af245/src/lib/particles/createSheetGeometry.ts) | Sheet fill/wire, `createTileGeometry`, `createNetGeometry` (net = screen-space ribbon quads via `aOther`/`aSide`) |
+| [`lib/particles/types.ts`](https://github.com/piyarsquare/animath/blob/81af245/src/lib/particles/types.ts) | `renderModes` (Points/Sheet/Tiles/Net), `colormapNames` (14) |
+| [`lib/particles/useParticleState.ts`](https://github.com/piyarsquare/animath/blob/81af245/src/lib/particles/useParticleState.ts) | All persisted state for the new controls |
+| [`lib/particles/useUniformSync.ts`](https://github.com/piyarsquare/animath/blob/81af245/src/lib/particles/useUniformSync.ts) | Syncs new uniforms to every material |
+| [`lib/colormaps.ts`](https://github.com/piyarsquare/animath/blob/81af245/src/lib/colormaps.ts) | Shared palette GLSL + `PALETTE_OPTIONS` (also used by fractal viewers) |
+| [`ComplexParticles/shaders/index.ts`](https://github.com/piyarsquare/animath/blob/81af245/src/animations/ComplexParticles/shaders/index.ts) | `vsCommon`: `domainWarp` (reciprocal), `surfacePos`, colormap branch; point/sheet/tile/net shaders + `applyExternalLight` |
+| [`ComplexParticles/ComplexParticles.tsx`](https://github.com/piyarsquare/animath/blob/81af245/src/animations/ComplexParticles/ComplexParticles.tsx) | Per-branch materials/meshes for all 5 object types; geometry/visibility/uniform effects |
+| [`components/ParticleViewerShell.tsx`](https://github.com/piyarsquare/animath/blob/81af245/src/components/ParticleViewerShell.tsx) | Color / Surface / Domain control sections (mode-aware) |
+
+## Open / not done
+
+- **Merge + deploy.** Branch is not merged to `main`; nothing is live yet. Before a
+  PR: `git fetch && git merge origin/main`, keep every app's append-only entries,
+  re-run `npm run build`. The user has not yet asked for a PR.
+- **Docs.** README/EXPLAINER cover Sheet but **not** Tiles/Net/colormaps/lighting/
+  reciprocal sampling. Worth a pass before merge.
+- **Polish (all optional, low value):** context-aware colormap default (magnitude
+  for sequential maps vs phase for HSV); dedicated sheet opacity; independent
+  reciprocal-sampling depth (currently tied to domain extent); optional screen-space
+  (rather than world) cap for Tiles; start Net rays off-origin so they don't bundle
+  at the Torus core when enabled.
+
+## Context
+
+- **Container instability (important).** This cloud container repeatedly reset the
+  **local** working tree to an old commit (`6fd2683`) mid-session while
+  `origin/complex-sheet` stayed current. Always start a turn with
+  `git fetch origin complex-sheet && git reset --hard origin/complex-sheet`, and
+  commit + push after each change. Treat origin as the source of truth.
+- **Branch naming.** Designated branch is `claude/complex-sheet-ar9zA` (hence the
+  slug), but the actual remote branch carrying the work is **`complex-sheet`**.
+- **Verification.** Done headlessly via SwiftShader screenshots, seeding the
+  viewer's `localStorage` (`animath:v1:complex-particles:<field>`) to set modes —
+  there is no test runner; `npm run build` is the only CI check.
+- **Net math note.** Circles (constant |z|) relate to Hopf fibres — for f=z a
+  domain circle *is* a Hopf fibre; for zⁿ it's a (1,n) torus knot. Rays converge at
+  the Torus centre because they all share z=0.
+
+## Self-reflection
+
+1. **Another session?** Polish + docs: context-aware colormap default, dedicated
+   sheet opacity, independent reciprocal depth, and writing up the new modes in
+   README/EXPLAINER. Then a merge-to-main PR.
+2. **Change about what I produced?** The declutter over-hid the Quantity/Brightness
+   colour selectors and needed a follow-up fix; a clearer "which control belongs to
+   which mode" model up front would have avoided the round-trip.
+3. **Not asked that's important?** Whether to merge/deploy — none of this is live
+   yet, so users (and the Pages site) don't see it until a PR lands.
+4. **What did we both overlook?** Net rays still pass through the exact origin, so
+   they bundle at the Torus core; an inner-radius start would tidy that.
+5. **Difficult?** The container reverting the local checkout — mitigated by
+   per-turn `reset --hard origin` and frequent pushes.
+6. **Easier?** A harness helper to drive in-app controls (beyond seeding
+   `localStorage`) would speed visual iteration.
+7. **Follow-up value:** <span class="badge badge-ok">LOW</span> — all features
+   build, are pushed, and were verified; what remains is optional polish, docs, and
+   the merge decision.

--- a/docs/sessions/progress/complex-sheet-ar9zA/2026-06-08-S01-translucent-sheet-surface.md
+++ b/docs/sessions/progress/complex-sheet-ar9zA/2026-06-08-S01-translucent-sheet-surface.md
@@ -31,6 +31,35 @@ color/sampling/projection controls — the engine this new sheet view would buil
 
 <!-- Newest entry first. One ### per state transition. -->
 
+### 🟡 milestone · 16:45 — Quad sheet reworked + verified
+**Why:** implemented the user's model; build green and visually confirmed.
+
+Fill is now a **non-indexed per-quad** mesh whose new `sheetFillVertexShader`
+averages `calcColour` over each cell's four corners (`cellBase` attribute +
+`uCellSize` uniform) → one flat colour per rectangle. Wireframe is a
+**`THREE.LineSegments`** over a dedicated line geometry (`createSheetWireGeometry`,
+row/column edges only). Verified headless on `z²` in DropV: clean rectangular
+cells, wire exactly on the fill, flat tiles (the origin's muted tiles correctly
+flag the zero, where averaging the wrapping phase desaturates). Points unregressed.
+
+### 🟣 decision · 16:30 — Quad faces + rectangular wireframe + flat averaged color
+**Why:** user feedback. Two issues: (1) the wireframe shows triangle diagonals
+(I triangulated each cell), and (2) the sheet everts under Perspective.
+
+Diagnosed the eversion: the **4D Perspective** projection divides by `(3 + Im f)`;
+for `z²`/`eᶻ`, `Im f` crosses `−3`, so the surface shoots to infinity and folds
+back. The mesh is correct — in a linear **Drop-axis** projection the same sheet is
+clean and the wire sits exactly on the cells (verified headless). User chose to
+**keep the 4D graph** (same object as the particles) and live with the eversion
+(use Drop-axis/Stereo to avoid it), but wants:
+- **Rectangular faces** (no triangle diagonals) — switch the wireframe from a
+  triangulated `wireframe:true` mesh to a `LineSegments` of just the row/column
+  grid edges.
+- **Flat per-rectangle color = average of the 4 corner colors** — switch the fill
+  to a non-indexed per-quad mesh; each vertex carries its quad's `cellBase`, and
+  the fill vertex shader averages `calcColour` over the 4 corners (`cellBase` +
+  `uCellSize`) so each rectangle is one flat color.
+
 ### 🟡 milestone · 15:55 — Sheet render mode shipped, build green
 **Why:** feature complete and verified headlessly.
 

--- a/docs/sessions/progress/complex-sheet-ar9zA/2026-06-08-S01-translucent-sheet-surface.md
+++ b/docs/sessions/progress/complex-sheet-ar9zA/2026-06-08-S01-translucent-sheet-surface.md
@@ -1,0 +1,142 @@
+---
+kind: progress
+session: 2026-06-08-S01
+date: 2026-06-08
+title: Translucent sheet surface viewer
+branch: claude/complex-sheet-ar9zA
+slug: complex-sheet-ar9zA
+status: completed
+build: passed
+followup: null
+pr: null
+app: ComplexSheet (proposed)
+---
+
+# Translucent sheet surface viewer
+
+## Session purpose
+
+Explore a variation of the particle plot where a regular grid of vertices defines
+a wireframe surface, and the 2D surface of the complex function is visualized as a
+single translucent sheet (rather than discrete particles).
+
+## Previous session
+
+First tracked session on this branch. The most relevant prior work is
+[particle-viewer ideas triage + quick wins](../../handoff/particle-viewer-ideas-priority-UDZRe/2026-06-05-S01-ideas-triage-quick-wins.md)
+(completed, build passed): consolidated the `lib/particles` engine and added
+color/sampling/projection controls — the engine this new sheet view would build on.
+
+## Working notes
+
+<!-- Newest entry first. One ### per state transition. -->
+
+### 🟡 milestone · 15:55 — Sheet render mode shipped, build green
+**Why:** feature complete and verified headlessly.
+
+Added a **Surface** render mode to ComplexParticles: **Points** (unchanged) or
+**Sheet** — a single translucent triangle surface over a regular grid, with
+toggleable filled + wireframe layers, a resolution slider, and a faceted-shading
+slider. Verified by headless render (SwiftShader) across z² and eᶻ in both
+filled+wire and wire-only; Points mode confirmed unregressed. `npm run build`
+passes.
+
+> [!CAUTION]
+> **Gotcha (fixed)** A double-sided translucent sheet under the points' default
+> **AdditiveBlending** blows out to solid white (overdraw sums past 1). The sheet
+> materials therefore force **NormalBlending** with `depthWrite: false` (true
+> alpha compositing), and are tagged `userData.sheet` so the `objectMode`
+> (light-background) effect leaves their blending alone. Faceted shading from
+> `dFdx/dFdy(viewPos)` supplies the depth cues additive glow can't.
+
+> [!NOTE]
+> Sheet mode samples its **own** Cartesian grid (its `sheetResolution`), ignoring
+> the Sampling pattern and particle count — a continuous surface needs grid
+> topology. The big stretching near singularities / fast-growing `f` is inherent
+> to the projection (same as Points); zoom out with **Distance**.
+
+### 🔵 finding · 15:30 — branchIndex relied on positional index
+**Why:** adding 3 materials per branch broke the old assumption.
+
+The Riemann-sheet `branchIndex` effect set `materialsRef[i] = branchMin + i`,
+assuming one material per branch. With points + sheet-fill + sheet-wire per
+branch that mapping is wrong, so each material is now tagged
+`userData.branch` and the effect reads that instead of its list position.
+
+### 🟢 code · 15:20 — Implementing Sheet render mode
+**Why:** finished reading the engine; the seams are clear, starting the build.
+
+Design (maximal reuse of the existing engine):
+- **Sheet geometry** = a new regular `res×res` indexed triangle grid
+  (`lib/particles/createSheetGeometry.ts`), independent of `particleCount` /
+  `samplePattern` (a sheet needs grid topology). Its own `sheetResolution`.
+- **Shaders** — refactor `ComplexParticles/shaders/index.ts` to share the GLSL
+  function library (`vsPreamble` + `vsLib`) between the existing points vertex
+  shader and a new `sheetVertexShader` (adds a `vViewPos` varying, drops
+  `gl_PointSize`). New `sheetFragmentShader`: translucent fill with faceted
+  shading from screen-space derivatives, plus a `uWire` flag for the wireframe
+  overlay.
+- **Materials** — sheet fill + wire materials carry the *same* uniform set as the
+  points material (so `useUniformSync` / the animation loop / `useViewControls`
+  drive them unchanged), tagged with `userData.branch` so `branchIndex` no longer
+  relies on positional index.
+- **Controls** — a new "Surface" section in `ParticleViewerShell`: Render
+  (Points/Sheet) Pills, then Filled/Wireframe checkboxes, Resolution + Shading
+  sliders.
+
+> [!NOTE]
+> Delivered inside ComplexParticles — **no new route / apps.ts entry**, so no
+> shared-file churn beyond the engine it builds on.
+
+### 🟣 decision · 15:05 — Deliver as a new render mode inside ComplexParticles
+**Why:** user chose "new render mode in ComplexParticles" over a separate app, and
+"both translucent fill + wireframe, toggleable" for the surface style.
+
+Plan: add a render-mode toggle (Points / Sheet) to the existing viewer. In Sheet
+mode, build an indexed triangle mesh from the existing regular grid, render it with
+a translucent double-sided material and a toggleable wireframe overlay, reusing the
+existing projection + per-vertex color shaders. Now exploring the `lib/particles`
+engine to find the cleanest seams.
+
+### 🟡 milestone · 15:02 — Session initialized
+**Why:** start-session skill — orient before any implementation.
+
+New branch `claude/complex-sheet-ar9zA`. Focus: a translucent-sheet surface
+variant of the particle viewer (regular grid → wireframe → translucent sheet,
+instead of point particles). The `lib/particles` engine + `ParticleViewerShell`
+(canonical consumer: `ComplexParticles`) is the foundation to study. Awaiting
+direction before writing code.
+
+## Key files
+
+| File | Role |
+| --- | --- |
+| `lib/particles/createSheetGeometry.ts` | **New.** Regular `res×res` indexed triangle grid (+ rebuild); zero `seed` so jitter never tears the sheet. |
+| `lib/particles/types.ts` | `renderModes = ['Points','Sheet']` + `RenderMode`. |
+| `lib/particles/useParticleState.ts` | New persisted state: `renderMode`, `sheetFill`, `sheetWire`, `sheetResolution`, `sheetShade`. |
+| `lib/particles/useUniformSync.ts` | `objectMode` blending now skips `userData.sheet` materials. |
+| `ComplexParticles/shaders/index.ts` | Refactored to share `vsCommon` (the GLSL library) between the points and the new `sheetVertexShader` / `sheetFragmentShader` (faceted shading + `uWire`). |
+| `ComplexParticles/ComplexParticles.tsx` | `makeUniforms` factory; points + sheet-fill + sheet-wire materials per branch; sheet geometry + visibility + shade + branch-tag effects. |
+| `components/ParticleViewerShell.tsx` | New **Surface** section (Render pills + Filled/Wireframe/Resolution/Shading). |
+| `ComplexParticles/{README,EXPLAINER}.md` | Documented the Surface / Sheet mode. |
+
+## Self-reflection
+
+1. **Another session?** Tune the sheet's default look (it inherits the points'
+   `cameraZ` / `opacity`; a Sheet-specific default distance + opacity would frame
+   it better out of the box), and consider seeding `seed` from a low-discrepancy
+   sequence so optional jitter wrinkles the surface coherently instead of just
+   translating it.
+2. **Change about what I produced?** The sheet shares the points' `opacity`
+   slider; a dedicated sheet opacity would avoid coupling the two modes' looks.
+3. **Not asked but important?** Whether multi-sheet (Riemann branch) *surfaces*
+   should stack translucently — they do now, which can be busy; a per-sheet hue
+   offset might help. Left as-is.
+4. **Overlooked together?** The additive-blending blow-out wasn't obvious until I
+   rendered it; the headless harness caught it immediately.
+5. **Difficult?** Judging a translucent WebGL surface without a display — solved
+   by the SwiftShader screenshot harness (seeding `localStorage` to flip the mode).
+6. **Easier?** A built-in way to drive app controls in the screenshot harness
+   (beyond seeding `localStorage`) would speed up visual iteration.
+7. **Follow-up value:** LOW — feature is complete, builds, and is verified; what
+   remains is optional aesthetic tuning.

--- a/docs/sessions/progress/complex-sheet-ar9zA/2026-06-08-S01-translucent-sheet-surface.md
+++ b/docs/sessions/progress/complex-sheet-ar9zA/2026-06-08-S01-translucent-sheet-surface.md
@@ -2,23 +2,27 @@
 kind: progress
 session: 2026-06-08-S01
 date: 2026-06-08
-title: Translucent sheet surface viewer
+title: Surface render modes (Sheet · Tiles · Net) + colormaps & sampling
 branch: claude/complex-sheet-ar9zA
 slug: complex-sheet-ar9zA
 status: completed
 build: passed
-followup: null
+followup: low
 pr: null
-app: ComplexSheet (proposed)
+app: ComplexParticles
 ---
 
-# Translucent sheet surface viewer
+# Surface render modes (Sheet · Tiles · Net) + colormaps & sampling
 
 ## Session purpose
 
 Explore a variation of the particle plot where a regular grid of vertices defines
-a wireframe surface, and the 2D surface of the complex function is visualized as a
-single translucent sheet (rather than discrete particles).
+a surface instead of discrete particles. This grew over the session into a full
+set of **render modes** (Points / Sheet / Tiles / Net), a richer **colormap**
+system, **external lighting**, **reciprocal (log-radial) sampling**, and a
+**decluttered settings panel** — all delivered inside `ComplexParticles` /
+`ParticleViewerShell` + the `lib/particles` engine (no new route or `apps.ts`
+entry).
 
 ## Previous session
 
@@ -30,6 +34,128 @@ color/sampling/projection controls — the engine this new sheet view would buil
 ## Working notes
 
 <!-- Newest entry first. One ### per state transition. -->
+
+### 🔵 finding · throughout — Container kept reverting the local checkout
+**Why:** worth flagging for the next agent on this cloud branch.
+
+Several times mid-session the ephemeral container reset the **local** working tree
+to an old commit (`6fd2683`) while origin still held the latest. Pushed work was
+never lost. Mitigation that worked: `git fetch origin complex-sheet && git reset
+--hard origin/complex-sheet` at the start of each turn, and **commit + push after
+every feature** (which is why the history is many small commits). Treat
+`origin/complex-sheet` as the source of truth.
+
+### 🟡 milestone · S01 — Colormaps honor Quantity + Brightness (81af245)
+**Why:** the declutter had hidden the Quantity/Brightness selectors and the shader
+hardwired colormaps to magnitude; user wanted to map any quantity.
+
+Sequential colormaps now read the **Quantity** selector (phase / magnitude /
+real / imag) for the colormap axis and the **Brightness** selector (Uniform flat,
+magnitude-scaled, …) for value. `Repeat` tiles along whichever axis (log for
+magnitude). Renamed the selector label **Hue → Quantity**. Verified headless
+(Viridis by phase vs magnitude differ as expected).
+
+> [!CAUTION]
+> **Gotcha** Default `colourQuantity` is **Phase** (the classic HSV default), so a
+> freshly-picked colormap maps *phase*, not magnitude. For the radial |f| ramp set
+> Quantity → Magnitude (+ Brightness → Uniform for a pure map). A context-aware
+> default (phase for HSV, magnitude for colormaps) is an open option.
+
+### 🟡 milestone · S01 — Settings panel declutter (939525c)
+**Why:** user: "menus have gotten too rich; easier to see things."
+
+Mode/colormap-aware control visibility: HSV-only controls (Hue/Brightness/Style/
+Hue-shift) hidden unless Phase wheel; point-only controls (Size/Shape/Texture)
+hidden unless Points mode; the dense 4×4 orientation matrix moved from the
+default-open Camera section into the collapsed Detail section. (Quantity/Brightness
+visibility was then corrected in 81af245 — see above.)
+
+### 🟡 milestone · S01 — Six more colormaps (1ee72b3)
+**Why:** "more colormap choices please."
+
+Added Turbo (Anton Mikhailov polynomial), Cubehelix (Dave Green), Hot, Copper,
+Cool, and a diverging Cool–warm to the shared `lib/colormaps.ts` palette library —
+so the fractal viewers gain them too (`PALETTE_OPTIONS` kept in sync).
+
+### 🟡 milestone · S01 — Net width + resolution = screen-space ribbons (6027c29)
+**Why:** GPU line width on `LineSegments` is ignored by browsers; user wanted a
+controllable thread width + smoothness.
+
+Rebuilt the net as **screen-space ribbons**: each segment is a camera-facing quad
+expanded perpendicular in pixels by the net vertex shader (`aOther` + `aSide`
+attributes, `uResolution` + `uLineWidth` uniforms; width tracks the live
+drawing-buffer size on resize). Net is now a `THREE.Mesh`. Added **Width** and
+**Resolution** sliders. Verified headless (1.5px vs 7px, no twist).
+
+### 🟡 milestone · S01 — Reciprocal (log-radial) sampling, all modes (a8d588f)
+**Why:** "sample as deeply inside the unit circle as outside; apply to every mode."
+
+A `domainWarp()` inside the shared `surfacePos` + colour path remaps the domain
+radius uniform in log|z| (unit circle at the middle: r→0 ↦ 1/R, r=R ↦ R), so it's
+inherited by points, sheet, tiles, and net. Adaptive/stretch metrics warp
+consistently. Toggle in the **Domain** section; depth is tied to the domain extent
+(inner reach = 1/R). Verified headless (net circles bunch toward the origin).
+
+### 🟡 milestone · S01 — Log-scaled + repeating colormaps (3031f4c)
+**Why:** "log-scale the magnitude; include repeating colormaps."
+
+Sequential colormaps map magnitude on a log scale; a **Repeat (log bands)** slider
+tiles the colormap that many cycles per e-fold using a mirrored (seamless) wave →
+contour-like magnitude bands.
+
+### 🟡 milestone · S01 — Net: independent circles/rays toggles + more circles (f132697)
+**Why:** user wanted to turn rays off; rays cluttered the Torus centre.
+
+Replaced the 3-way Fibers pills with independent **Circles** / **Rays** checkboxes
+(rays default **off**); raised Circles max to 250.
+
+> [!NOTE]
+> **Why rays converge at the Torus centre** Every ray includes z=0 as its inner
+> endpoint, so all rays share one point; the Torus map sends |z|/|f|→latitude, so
+> that shared point lands on the torus core and the rays bundle into it. Turning
+> rays off (or starting them off-origin) removes the bundle. The circles are the
+> Hopf-fibre-related family the user cares about (for f=z they *are* Hopf fibres;
+> for zⁿ they're (1,n) torus knots).
+
+### 🟡 milestone · S01 — Net render mode (polar fibre net) (902fabb)
+**Why:** "make a net between the points; structured to see fibre structures."
+
+New **Net** render mode: concentric circles (constant |z|) and rays (constant
+arg z) placed on the surface and domain-coloured, exposing the function's fibre
+structure. Verified headless on z² (the two orthogonal curve families) and 1/z in
+Hopf.
+
+### 🟡 milestone · S01 — External light: inside vs outside (92d9df3)
+**Why:** user asked for lighting to distinguish "inside" from "outside".
+
+Shared `applyExternalLight()` in the sheet + tile fragment shaders: a directional
+light shades whichever side faces the camera, and back faces get a cooler/dimmer
+tint so inside reads distinctly. Toggle + strength on Sheet and Tiles.
+
+### 🟡 milestone · S01 — Sequential colormaps for magnitude (77d3afc)
+**Why:** "colormaps besides rainbow, suitable for magnitude."
+
+Added a **Colormap** selector reusing the fractal viewers' GLSL palette library
+(Phase wheel + Viridis/Magma/Inferno/Plasma/Grayscale/Fire/Ocean), initially
+mapping magnitude.
+
+### 🟡 milestone · S01 — Tiles render mode (oriented surfels) (70d7d6d)
+**Why:** user vision — a fabric of tiles that tears into points where stretched.
+
+New **Tiles** mode: one oriented quad per grid sample, expanded along the local
+deformed grid directions (central differences of `surfacePos`) and capped at a
+**Tile size** (world units) — dense regions form a solid fabric, stretched regions
+detach into a field of separated tiles. Verified headless across tile sizes.
+
+### 🟡 milestone · S01 — Adaptive sheet density + resolution → 500 (6e99207, 3b71adb)
+**Why:** sheet should read as solid where dense and fall back to points where the
+function stretches it; finer meshes wanted.
+
+Adaptive mode: where a cell's deformed 3D size exceeds a **Density** threshold the
+fill/wire dissolves and the underlying point cloud shows through (per-cell
+`cellStretch` metric; `renderOrder` pins points behind fill behind wire). Also
+added an edge-fade to zero (no hard domain boundary) and raised max sheet
+resolution 200 → 500.
 
 ### 🟡 milestone · 16:45 — Quad sheet reworked + verified
 **Why:** implemented the user's model; build green and visually confirmed.
@@ -140,32 +266,39 @@ direction before writing code.
 
 | File | Role |
 | --- | --- |
-| `lib/particles/createSheetGeometry.ts` | **New.** Regular `res×res` indexed triangle grid (+ rebuild); zero `seed` so jitter never tears the sheet. |
-| `lib/particles/types.ts` | `renderModes = ['Points','Sheet']` + `RenderMode`. |
-| `lib/particles/useParticleState.ts` | New persisted state: `renderMode`, `sheetFill`, `sheetWire`, `sheetResolution`, `sheetShade`. |
-| `lib/particles/useUniformSync.ts` | `objectMode` blending now skips `userData.sheet` materials. |
-| `ComplexParticles/shaders/index.ts` | Refactored to share `vsCommon` (the GLSL library) between the points and the new `sheetVertexShader` / `sheetFragmentShader` (faceted shading + `uWire`). |
-| `ComplexParticles/ComplexParticles.tsx` | `makeUniforms` factory; points + sheet-fill + sheet-wire materials per branch; sheet geometry + visibility + shade + branch-tag effects. |
-| `components/ParticleViewerShell.tsx` | New **Surface** section (Render pills + Filled/Wireframe/Resolution/Shading). |
-| `ComplexParticles/{README,EXPLAINER}.md` | Documented the Surface / Sheet mode. |
+| `lib/particles/createSheetGeometry.ts` | Sheet fill + wire, **`createTileGeometry`** (oriented surfels), **`createNetGeometry`** (polar net as screen-space ribbon quads: `aOther`/`aSide`). All rebuildable. |
+| `lib/particles/types.ts` | `renderModes = ['Points','Sheet','Tiles','Net']`; `colormapNames` (14 maps). |
+| `lib/particles/useParticleState.ts` | Persisted state for every feature: `renderMode`, sheet (`sheetFill/Wire/Resolution/Shade/Adaptive/Density`), `tileSize`, net (`netCircles/Rays/Rings/Spokes/Width/Resolution`), `colormap`, `colorRepeat`, `lighting`/`lightStrength`, `reciprocal`. |
+| `lib/particles/useUniformSync.ts` | Syncs the new uniforms (`uColormap`, `uColorRepeat`, `uReciprocal`, `uLight`/`uLightStrength`, …); `objectMode` skips `userData.sheet`. |
+| `lib/colormaps.ts` | Shared GLSL palette library — added Turbo/Cubehelix/Hot/Copper/Cool/Cool–warm; `PALETTE_OPTIONS` kept in sync (fractals benefit too). |
+| `ComplexParticles/shaders/index.ts` | `vsCommon` shared GLSL: `domainWarp` (reciprocal sampling), `surfacePos`, colormap branch (honours Quantity + Brightness + Repeat). Point/sheet-fill/sheet-wire/**tile**/**net** vertex shaders + `applyExternalLight` in sheet/tile fragments. |
+| `ComplexParticles/ComplexParticles.tsx` | Per-branch materials/meshes for points + sheet fill + wire + **tiles** + **net**; geometry build/rebuild + visibility + uniform-sync effects (incl. net `uResolution` resize handler). |
+| `components/ParticleViewerShell.tsx` | **Color** (mode-aware) + **Surface** (per-mode Sheet/Tiles/Net controls) + **Domain** (Reciprocal sampling); decluttered visibility. |
+| `ComplexParticles/{README,EXPLAINER}.md` | Documented the Surface / Sheet mode (Tiles/Net/colormaps not yet written up). |
 
 ## Self-reflection
 
-1. **Another session?** Tune the sheet's default look (it inherits the points'
-   `cameraZ` / `opacity`; a Sheet-specific default distance + opacity would frame
-   it better out of the box), and consider seeding `seed` from a low-discrepancy
-   sequence so optional jitter wrinkles the surface coherently instead of just
-   translating it.
-2. **Change about what I produced?** The sheet shares the points' `opacity`
-   slider; a dedicated sheet opacity would avoid coupling the two modes' looks.
-3. **Not asked but important?** Whether multi-sheet (Riemann branch) *surfaces*
-   should stack translucently — they do now, which can be busy; a per-sheet hue
-   offset might help. Left as-is.
-4. **Overlooked together?** The additive-blending blow-out wasn't obvious until I
-   rendered it; the headless harness caught it immediately.
-5. **Difficult?** Judging a translucent WebGL surface without a display — solved
-   by the SwiftShader screenshot harness (seeding `localStorage` to flip the mode).
-6. **Easier?** A built-in way to drive app controls in the screenshot harness
-   (beyond seeding `localStorage`) would speed up visual iteration.
-7. **Follow-up value:** LOW — feature is complete, builds, and is verified; what
-   remains is optional aesthetic tuning.
+1. **Another session?** Mostly polish: a **context-aware colormap default**
+   (Quantity = magnitude when a sequential map is picked, phase for HSV); a
+   **dedicated sheet opacity** (it still shares the points' `opacity`); an
+   independent **reciprocal-sampling depth** control (currently tied to extent);
+   and writing up Tiles / Net / colormaps in README/EXPLAINER.
+2. **Change about what I produced?** The Color section's mode-aware visibility went
+   through two passes — I over-hid Quantity/Brightness in the declutter and had to
+   restore them. A clearer up-front model (which controls belong to which mode)
+   would have avoided the round-trip.
+3. **Not asked but important?** Net rays still pass exactly through the origin, so
+   they bundle at the Torus core; starting them at an inner radius would tidy that
+   without an extra toggle. Left as the user opted to switch rays off instead.
+4. **Overlooked together?** Screen-space line width needs the live drawing-buffer
+   size — easy to forget the resize handler; the ribbon would otherwise drift with
+   window size.
+5. **Difficult?** The ephemeral container repeatedly reverted the local checkout to
+   an old commit; `git reset --hard origin/...` per turn + frequent pushes made it
+   a non-issue but it's a real hazard for cloud sessions.
+6. **Easier?** A harness helper to drive app controls (beyond seeding
+   `localStorage`) would speed visual iteration; it worked but is verbose.
+7. **Follow-up value:** LOW — all features build, are pushed to
+   `origin/complex-sheet`, and were verified headlessly. What remains is optional
+   polish + docs, and deciding whether to merge the branch to `main` (it is **not**
+   deployed yet).

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -190,6 +190,8 @@ export default function ComplexParticles({
     uColourStyle: { value: state.colourStyle },
     uColormap: { value: state.colormap },
     uColorRepeat: { value: state.colorRepeat },
+    uReciprocal: { value: state.reciprocal ? 1 : 0 },
+    uWarpR: { value: netRadius() },
     uLight: { value: state.lighting ? 1 : 0 },
     uLightStrength: { value: state.lightStrength },
     uColourBy: { value: state.colourBy },
@@ -435,9 +437,11 @@ export default function ComplexParticles({
     rebuildSheetWireGeometry(wireGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
     rebuildTileGeometry(tileGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
     const [csx, csy] = sheetCellSize(state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    const warpR = netRadius();
     state.materialsRef.current.forEach(m => {
       if (m.uniforms.uCellSize) m.uniforms.uCellSize.value.set(csx, csy);
       if (m.uniforms.uDomainBox) m.uniforms.uDomainBox.value.set(bxMin, bxMax, byMin, byMax);
+      if (m.uniforms.uWarpR) m.uniforms.uWarpR.value = warpR;
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -5,13 +5,14 @@ import { Select, NumberInput } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
-import { vertexShader, fragmentShader, sheetFillVertexShader, sheetWireVertexShader, sheetFragmentShader } from './shaders';
+import { vertexShader, fragmentShader, sheetFillVertexShader, sheetWireVertexShader, sheetFragmentShader, tileVertexShader, tileFragmentShader } from './shaders';
 import { loadParticleTextures } from '../../lib/textures';
 import {
   useParticleState, useUniformSync, useViewControls,
   createParticleGeometry, rebuildGeometryBuffers, redistributeAdaptive,
   createSheetGeometry, rebuildSheetGeometry,
   createSheetWireGeometry, rebuildSheetWireGeometry, sheetCellSize,
+  createTileGeometry, rebuildTileGeometry,
   createAxes, createHopfScaffold, createHopfFibers, startAnimationLoop,
 } from '../../lib/particles';
 import { usePersistentState } from '../../lib/usePersistentState';
@@ -93,6 +94,10 @@ export default function ComplexParticles({
   const sheetWireGeomRef = useRef<THREE.BufferGeometry>();
   const fillMeshRef = useRef<THREE.Mesh[]>([]);
   const wireMeshRef = useRef<THREE.LineSegments[]>([]);
+  // Tiles render mode: one oriented quad per grid sample (its own geometry +
+  // mesh per Riemann sheet).
+  const tileGeomRef = useRef<THREE.BufferGeometry>();
+  const tileMeshRef = useRef<THREE.Mesh[]>([]);
   const scaffoldRef = useRef<HopfScaffold>();
   const fibersRef = useRef<HopfFibers>();
 
@@ -278,15 +283,39 @@ export default function ComplexParticles({
     return m;
   }
 
+  function createTileMaterial(b: number) {
+    const [csx, csy] = currentCellSize();
+    const m = new THREE.ShaderMaterial({
+      uniforms: {
+        ...makeUniforms(b),
+        uShade: { value: state.sheetShade },
+        uCellSize: { value: new THREE.Vector2(csx, csy) },
+        uMaxTile: { value: state.tileSize },
+      },
+      vertexShader: tileVertexShader,
+      fragmentShader: tileFragmentShader,
+      transparent: true,
+      depthWrite: true,
+      side: THREE.DoubleSide,
+      blending: THREE.NormalBlending,
+      vertexColors: true,
+    });
+    m.userData.branch = b;
+    m.userData.sheet = true;
+    return m;
+  }
+
   // Visibility follows the render mode: Points shows the cloud; Sheet shows the
   // filled surface and/or the wireframe overlay.
   const applyRenderVisibility = () => {
     const isSheet = state.renderMode === 'Sheet';
-    // In adaptive Sheet mode the point cloud stays visible underneath so it can
-    // show through wherever the stretched fill/wire dissolves to points.
-    pointsRef.current.forEach(o => { o.visible = !isSheet || state.sheetAdaptive; });
+    const isTiles = state.renderMode === 'Tiles';
+    // The point cloud shows in Points mode and, in adaptive Sheet mode, stays
+    // visible underneath so it shows through wherever the fill/wire dissolves.
+    pointsRef.current.forEach(o => { o.visible = state.renderMode === 'Points' || (isSheet && state.sheetAdaptive); });
     fillMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetFill; });
     wireMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetWire; });
+    tileMeshRef.current.forEach(o => { o.visible = isTiles; });
   };
 
   // (Re)create the per-branch objects: a point cloud, a filled sheet, and a
@@ -296,22 +325,27 @@ export default function ComplexParticles({
     const pointsGeom = state.geometryRef.current;
     const fillGeom = sheetGeomRef.current;
     const wireGeom = sheetWireGeomRef.current;
-    if (!pointsGeom || !fillGeom || !wireGeom) return;
+    const tileGeom = tileGeomRef.current;
+    if (!pointsGeom || !fillGeom || !wireGeom || !tileGeom) return;
     pointsRef.current.forEach(o => scene.remove(o));
     fillMeshRef.current.forEach(o => scene.remove(o));
     wireMeshRef.current.forEach(o => scene.remove(o));
+    tileMeshRef.current.forEach(o => scene.remove(o));
     state.materialsRef.current.forEach(m => m.dispose());
     state.materialsRef.current = [];
     pointsRef.current = [];
     fillMeshRef.current = [];
     wireMeshRef.current = [];
+    tileMeshRef.current = [];
     for (let b = 0; b < branchCount; b++) {
       const pm = createBranchMaterial(b);
       const fm = createSheetFillMaterial(b);
       const wm = createSheetWireMaterial(b);
+      const tm = createTileMaterial(b);
       const pts = new THREE.Points(pointsGeom, pm);
       const fill = new THREE.Mesh(fillGeom, fm);
       const wire = new THREE.LineSegments(wireGeom, wm);
+      const tiles = new THREE.Mesh(tileGeom, tm);
       // In adaptive Sheet mode the cloud and sheet overlap; without a fixed order
       // these depth-write-off transparent objects sort by distance and the
       // additive points can land on top of an opaque fill. Pin points behind, then
@@ -320,11 +354,12 @@ export default function ComplexParticles({
       pts.renderOrder = 0;
       fill.renderOrder = 1;
       wire.renderOrder = 2;
-      state.materialsRef.current.push(pm, fm, wm);
+      state.materialsRef.current.push(pm, fm, wm, tm);
       pointsRef.current.push(pts);
       fillMeshRef.current.push(fill);
       wireMeshRef.current.push(wire);
-      scene.add(pts, fill, wire);
+      tileMeshRef.current.push(tiles);
+      scene.add(pts, fill, wire, tiles);
     }
     applyRenderVisibility();
   };
@@ -357,10 +392,12 @@ export default function ComplexParticles({
   useEffect(() => {
     const fillGeom = sheetGeomRef.current;
     const wireGeom = sheetWireGeomRef.current;
-    if (!fillGeom || !wireGeom) return;
+    const tileGeom = tileGeomRef.current;
+    if (!fillGeom || !wireGeom || !tileGeom) return;
     const [bxMin, bxMax, byMin, byMax] = effectiveBounds();
     rebuildSheetGeometry(fillGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
     rebuildSheetWireGeometry(wireGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    rebuildTileGeometry(tileGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
     const [csx, csy] = sheetCellSize(state.sheetResolution, bxMin, bxMax, byMin, byMax);
     state.materialsRef.current.forEach(m => {
       if (m.uniforms.uCellSize) m.uniforms.uCellSize.value.set(csx, csy);
@@ -378,6 +415,13 @@ export default function ComplexParticles({
       if (m.uniforms.uShade) m.uniforms.uShade.value = state.sheetShade;
     });
   }, [state.sheetShade]);
+
+  // Push the max tile size to the tile materials.
+  useEffect(() => {
+    state.materialsRef.current.forEach(m => {
+      if (m.uniforms.uMaxTile) m.uniforms.uMaxTile.value = state.tileSize;
+    });
+  }, [state.tileSize]);
 
   // Show the sphere scaffold in the Hopf view (or once the Torus → Hopf collapse
   // is past halfway) and the donut scaffold in the Torus view; hide both in the
@@ -431,6 +475,7 @@ export default function ComplexParticles({
       state.geometryRef.current = geometry;
       sheetGeomRef.current = createSheetGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       sheetWireGeomRef.current = createSheetWireGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
+      tileGeomRef.current = createTileGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
 
       rebuildBranchObjects(scene);
 

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -192,9 +192,20 @@ export default function ComplexParticles({
     branchIndex: { value: branchMin + b },
   });
 
+  // Adaptive fade only applies while the sheet is on screen — in plain Points
+  // mode the cloud must show everywhere, so the point material's uAdaptive is
+  // gated on the render mode (the fill/wire are hidden outside Sheet mode anyway).
+  const adaptiveOn = () => state.renderMode === 'Sheet' && state.sheetAdaptive;
+
   function createBranchMaterial(b: number) {
+    const [csx, csy] = currentCellSize();
     const m = new THREE.ShaderMaterial({
-      uniforms: makeUniforms(b),
+      uniforms: {
+        ...makeUniforms(b),
+        uAdaptive: { value: adaptiveOn() ? 1 : 0 },
+        uDensity: { value: state.sheetDensity },
+        uCellSize: { value: new THREE.Vector2(csx, csy) },
+      },
       vertexShader,
       fragmentShader,
       transparent: true,
@@ -225,6 +236,8 @@ export default function ComplexParticles({
         ...makeUniforms(b),
         uShade: { value: state.sheetShade },
         uWire: { value: 0 },
+        uAdaptive: { value: adaptiveOn() ? 1 : 0 },
+        uDensity: { value: state.sheetDensity },
         uCellSize: { value: new THREE.Vector2(csx, csy) },
         uDomainBox: { value: new THREE.Vector4(bx0, bx1, by0, by1) },
       },
@@ -242,10 +255,14 @@ export default function ComplexParticles({
   }
 
   function createSheetWireMaterial(b: number) {
+    const [csx, csy] = currentCellSize();
     const [bx0, bx1, by0, by1] = effectiveBounds();
     const m = new THREE.ShaderMaterial({
       uniforms: {
         ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 1 },
+        uAdaptive: { value: adaptiveOn() ? 1 : 0 },
+        uDensity: { value: state.sheetDensity },
+        uCellSize: { value: new THREE.Vector2(csx, csy) },
         uDomainBox: { value: new THREE.Vector4(bx0, bx1, by0, by1) },
       },
       vertexShader: sheetWireVertexShader,
@@ -265,7 +282,9 @@ export default function ComplexParticles({
   // filled surface and/or the wireframe overlay.
   const applyRenderVisibility = () => {
     const isSheet = state.renderMode === 'Sheet';
-    pointsRef.current.forEach(o => { o.visible = !isSheet; });
+    // In adaptive Sheet mode the point cloud stays visible underneath so it can
+    // show through wherever the stretched fill/wire dissolves to points.
+    pointsRef.current.forEach(o => { o.visible = !isSheet || state.sheetAdaptive; });
     fillMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetFill; });
     wireMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetWire; });
   };
@@ -293,6 +312,14 @@ export default function ComplexParticles({
       const pts = new THREE.Points(pointsGeom, pm);
       const fill = new THREE.Mesh(fillGeom, fm);
       const wire = new THREE.LineSegments(wireGeom, wm);
+      // In adaptive Sheet mode the cloud and sheet overlap; without a fixed order
+      // these depth-write-off transparent objects sort by distance and the
+      // additive points can land on top of an opaque fill. Pin points behind, then
+      // fill, then wire, so a dense (opaque) fill cleanly covers the cloud and only
+      // the stretched, dissolved cells let the points show through.
+      pts.renderOrder = 0;
+      fill.renderOrder = 1;
+      wire.renderOrder = 2;
       state.materialsRef.current.push(pm, fm, wm);
       pointsRef.current.push(pts);
       fillMeshRef.current.push(fill);
@@ -312,7 +339,18 @@ export default function ComplexParticles({
   useEffect(() => {
     applyRenderVisibility();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [state.renderMode, state.sheetFill, state.sheetWire]);
+  }, [state.renderMode, state.sheetFill, state.sheetWire, state.sheetAdaptive]);
+
+  // Push the adaptive-density controls to every material (points + sheet fill +
+  // wire). The point cloud only fades in Sheet mode (adaptiveOn), so it stays a
+  // full cloud in plain Points mode.
+  useEffect(() => {
+    const on = adaptiveOn() ? 1 : 0;
+    state.materialsRef.current.forEach(m => {
+      if (m.uniforms.uAdaptive) m.uniforms.uAdaptive.value = on;
+      if (m.uniforms.uDensity) m.uniforms.uDensity.value = state.sheetDensity;
+    });
+  }, [state.renderMode, state.sheetAdaptive, state.sheetDensity]);
 
   // Rebuild the sheet fill + wire grids when the resolution or domain box
   // changes, and refresh the fill shader's cell size (for corner averaging).

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -185,6 +185,8 @@ export default function ComplexParticles({
     textureIndex: { value: state.textureIndex },
     uColourStyle: { value: state.colourStyle },
     uColormap: { value: state.colormap },
+    uLight: { value: state.lighting ? 1 : 0 },
+    uLightStrength: { value: state.lightStrength },
     uColourBy: { value: state.colourBy },
     uColourQty: { value: state.colourQuantity },
     uBrightnessQty: { value: state.brightnessQuantity },

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -448,10 +448,10 @@ export default function ComplexParticles({
   useEffect(() => {
     const netGeom = netGeomRef.current;
     if (!netGeom) return;
-    rebuildNetGeometry(netGeom, state.netRings, state.netSpokes, netRadius(), state.netMode);
+    rebuildNetGeometry(netGeom, state.netRings, state.netSpokes, netRadius(), state.netCircles, state.netRays);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    state.netRings, state.netSpokes, state.netMode,
+    state.netRings, state.netSpokes, state.netCircles, state.netRays,
     state.extentX, state.extentY, state.axisScale,
     state.boundsLock, state.xMin, state.xMax, state.yMin, state.yMax,
   ]);
@@ -523,7 +523,7 @@ export default function ComplexParticles({
       sheetGeomRef.current = createSheetGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       sheetWireGeomRef.current = createSheetWireGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       tileGeomRef.current = createTileGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
-      netGeomRef.current = createNetGeometry(state.netRings, state.netSpokes, netRadius(), state.netMode);
+      netGeomRef.current = createNetGeometry(state.netRings, state.netSpokes, netRadius(), state.netCircles, state.netRays);
 
       rebuildBranchObjects(scene);
 

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -5,7 +5,7 @@ import { Select, NumberInput } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
-import { vertexShader, fragmentShader, sheetFillVertexShader, sheetWireVertexShader, sheetFragmentShader, tileVertexShader, tileFragmentShader } from './shaders';
+import { vertexShader, fragmentShader, sheetFillVertexShader, sheetWireVertexShader, sheetFragmentShader, tileVertexShader, tileFragmentShader, netVertexShader, netFragmentShader } from './shaders';
 import { loadParticleTextures } from '../../lib/textures';
 import {
   useParticleState, useUniformSync, useViewControls,
@@ -13,6 +13,7 @@ import {
   createSheetGeometry, rebuildSheetGeometry,
   createSheetWireGeometry, rebuildSheetWireGeometry, sheetCellSize,
   createTileGeometry, rebuildTileGeometry,
+  createNetGeometry, rebuildNetGeometry,
   createAxes, createHopfScaffold, createHopfFibers, startAnimationLoop,
 } from '../../lib/particles';
 import { usePersistentState } from '../../lib/usePersistentState';
@@ -98,6 +99,9 @@ export default function ComplexParticles({
   // mesh per Riemann sheet).
   const tileGeomRef = useRef<THREE.BufferGeometry>();
   const tileMeshRef = useRef<THREE.Mesh[]>([]);
+  // Net render mode: a polar fibre net (circles + rays) drawn as LineSegments.
+  const netGeomRef = useRef<THREE.BufferGeometry>();
+  const netMeshRef = useRef<THREE.LineSegments[]>([]);
   const scaffoldRef = useRef<HopfScaffold>();
   const fibersRef = useRef<HopfFibers>();
 
@@ -286,6 +290,27 @@ export default function ComplexParticles({
     return m;
   }
 
+  // Radius of the polar fibre net: reach the farthest corner of the domain box.
+  const netRadius = (): number => {
+    const [bx0, bx1, by0, by1] = effectiveBounds();
+    return Math.max(Math.abs(bx0), Math.abs(bx1), Math.abs(by0), Math.abs(by1));
+  };
+
+  function createNetMaterial(b: number) {
+    const m = new THREE.ShaderMaterial({
+      uniforms: makeUniforms(b),
+      vertexShader: netVertexShader,
+      fragmentShader: netFragmentShader,
+      transparent: true,
+      depthWrite: false,
+      blending: THREE.NormalBlending,
+      vertexColors: true,
+    });
+    m.userData.branch = b;
+    m.userData.sheet = true;   // keep NormalBlending through the object-mode toggle
+    return m;
+  }
+
   function createTileMaterial(b: number) {
     const [csx, csy] = currentCellSize();
     const m = new THREE.ShaderMaterial({
@@ -319,6 +344,7 @@ export default function ComplexParticles({
     fillMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetFill; });
     wireMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetWire; });
     tileMeshRef.current.forEach(o => { o.visible = isTiles; });
+    netMeshRef.current.forEach(o => { o.visible = state.renderMode === 'Net'; });
   };
 
   // (Re)create the per-branch objects: a point cloud, a filled sheet, and a
@@ -329,26 +355,31 @@ export default function ComplexParticles({
     const fillGeom = sheetGeomRef.current;
     const wireGeom = sheetWireGeomRef.current;
     const tileGeom = tileGeomRef.current;
-    if (!pointsGeom || !fillGeom || !wireGeom || !tileGeom) return;
+    const netGeom = netGeomRef.current;
+    if (!pointsGeom || !fillGeom || !wireGeom || !tileGeom || !netGeom) return;
     pointsRef.current.forEach(o => scene.remove(o));
     fillMeshRef.current.forEach(o => scene.remove(o));
     wireMeshRef.current.forEach(o => scene.remove(o));
     tileMeshRef.current.forEach(o => scene.remove(o));
+    netMeshRef.current.forEach(o => scene.remove(o));
     state.materialsRef.current.forEach(m => m.dispose());
     state.materialsRef.current = [];
     pointsRef.current = [];
     fillMeshRef.current = [];
     wireMeshRef.current = [];
     tileMeshRef.current = [];
+    netMeshRef.current = [];
     for (let b = 0; b < branchCount; b++) {
       const pm = createBranchMaterial(b);
       const fm = createSheetFillMaterial(b);
       const wm = createSheetWireMaterial(b);
       const tm = createTileMaterial(b);
+      const nm = createNetMaterial(b);
       const pts = new THREE.Points(pointsGeom, pm);
       const fill = new THREE.Mesh(fillGeom, fm);
       const wire = new THREE.LineSegments(wireGeom, wm);
       const tiles = new THREE.Mesh(tileGeom, tm);
+      const net = new THREE.LineSegments(netGeom, nm);
       // In adaptive Sheet mode the cloud and sheet overlap; without a fixed order
       // these depth-write-off transparent objects sort by distance and the
       // additive points can land on top of an opaque fill. Pin points behind, then
@@ -357,12 +388,13 @@ export default function ComplexParticles({
       pts.renderOrder = 0;
       fill.renderOrder = 1;
       wire.renderOrder = 2;
-      state.materialsRef.current.push(pm, fm, wm, tm);
+      state.materialsRef.current.push(pm, fm, wm, tm, nm);
       pointsRef.current.push(pts);
       fillMeshRef.current.push(fill);
       wireMeshRef.current.push(wire);
       tileMeshRef.current.push(tiles);
-      scene.add(pts, fill, wire, tiles);
+      netMeshRef.current.push(net);
+      scene.add(pts, fill, wire, tiles, net);
     }
     applyRenderVisibility();
   };
@@ -409,6 +441,18 @@ export default function ComplexParticles({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     state.sheetResolution, state.extentX, state.extentY, state.axisScale,
+    state.boundsLock, state.xMin, state.xMax, state.yMin, state.yMax,
+  ]);
+
+  // Rebuild the fibre net when its counts/mode or the domain box change.
+  useEffect(() => {
+    const netGeom = netGeomRef.current;
+    if (!netGeom) return;
+    rebuildNetGeometry(netGeom, state.netRings, state.netSpokes, netRadius(), state.netMode);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    state.netRings, state.netSpokes, state.netMode,
+    state.extentX, state.extentY, state.axisScale,
     state.boundsLock, state.xMin, state.xMax, state.yMin, state.yMax,
   ]);
 
@@ -479,6 +523,7 @@ export default function ComplexParticles({
       sheetGeomRef.current = createSheetGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       sheetWireGeomRef.current = createSheetWireGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       tileGeomRef.current = createTileGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
+      netGeomRef.current = createNetGeometry(state.netRings, state.netSpokes, netRadius(), state.netMode);
 
       rebuildBranchObjects(scene);
 

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -5,11 +5,12 @@ import { Select, NumberInput } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
-import { vertexShader, fragmentShader } from './shaders';
+import { vertexShader, fragmentShader, sheetVertexShader, sheetFragmentShader } from './shaders';
 import { loadParticleTextures } from '../../lib/textures';
 import {
   useParticleState, useUniformSync, useViewControls,
   createParticleGeometry, rebuildGeometryBuffers, redistributeAdaptive,
+  createSheetGeometry, rebuildSheetGeometry,
   createAxes, createHopfScaffold, createHopfFibers, startAnimationLoop,
 } from '../../lib/particles';
 import { usePersistentState } from '../../lib/usePersistentState';
@@ -83,6 +84,11 @@ export default function ComplexParticles({
 
   const sceneRef = useRef<THREE.Scene>();
   const pointsRef = useRef<THREE.Points[]>([]);
+  // Sheet (surface) render mode: one shared regular-grid geometry, drawn per
+  // branch as a translucent filled mesh + a wireframe overlay.
+  const sheetGeomRef = useRef<THREE.BufferGeometry>();
+  const fillMeshRef = useRef<THREE.Mesh[]>([]);
+  const wireMeshRef = useRef<THREE.Mesh[]>([]);
   const scaffoldRef = useRef<HopfScaffold>();
   const fibersRef = useRef<HopfFibers>();
 
@@ -136,48 +142,55 @@ export default function ComplexParticles({
     });
   }, [quadA, quadB, quadC]);
 
-  // Each particle set renders the sheet at branchMin + i.
+  // Each material renders the Riemann sheet at branchMin + its branch. There are
+  // now several materials per branch (points + sheet fill + wire), so the branch
+  // is tagged on the material rather than read from its position in the list.
   useEffect(() => {
-    state.materialsRef.current.forEach((m, i) => {
-      m.uniforms.branchIndex.value = branchMin + i;
+    state.materialsRef.current.forEach(m => {
+      m.uniforms.branchIndex.value = branchMin + ((m.userData.branch as number) ?? 0);
     });
   }, [branchMin, branchMax]);
 
+  // The full uniform set shared by every material (points + sheet fill + wire),
+  // so useUniformSync / the animation loop / useViewControls drive them all
+  // uniformly. Each material gets its own fresh objects (no aliasing).
+  const makeUniforms = (b: number) => ({
+    time: { value: 0 },
+    opacity: { value: state.opacity },
+    functionType: { value: functionIndex },
+    exponentP: { value: expP },
+    exponentQ: { value: expQ === 0 ? 1 : expQ },
+    uQuadA: { value: new THREE.Vector2(quadA[0], quadA[1]) },
+    uQuadB: { value: new THREE.Vector2(quadB[0], quadB[1]) },
+    uQuadC: { value: new THREE.Vector2(quadC[0], quadC[1]) },
+    globalSize: { value: state.size },
+    intensity: { value: state.intensity },
+    shimmerAmp: { value: state.shimmer },
+    jitterAmp: { value: state.jitter },
+    uJitterMode: { value: state.jitterMode },
+    hueShift: { value: state.hueShift },
+    saturation: { value: state.saturation },
+    realView: { value: state.realViewRef.current ? 1 : 0 },
+    shapeType: { value: state.shapeIndex },
+    tex: { value: state.texturesRef.current[state.textureIndex] ?? new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1) },
+    textureIndex: { value: state.textureIndex },
+    uColourStyle: { value: state.colourStyle },
+    uColourBy: { value: state.colourBy },
+    uColourQty: { value: state.colourQuantity },
+    uBrightnessQty: { value: state.brightnessQuantity },
+    uInCoord: { value: state.inputCoord },
+    uOutCoord: { value: state.outputCoord },
+    uRotL: { value: { w: 1, v: new THREE.Vector3() } },
+    uRotR: { value: { w: 1, v: new THREE.Vector3() } },
+    uProjMode: { value: state.projRef.current },
+    uProjTarget: { value: state.projRef.current },
+    uProjAlpha: { value: 0 },
+    branchIndex: { value: branchMin + b },
+  });
+
   function createBranchMaterial(b: number) {
-    return new THREE.ShaderMaterial({
-      uniforms: {
-        time: { value: 0 },
-        opacity: { value: state.opacity },
-        functionType: { value: functionIndex },
-        exponentP: { value: expP },
-        exponentQ: { value: expQ === 0 ? 1 : expQ },
-        uQuadA: { value: new THREE.Vector2(quadA[0], quadA[1]) },
-        uQuadB: { value: new THREE.Vector2(quadB[0], quadB[1]) },
-        uQuadC: { value: new THREE.Vector2(quadC[0], quadC[1]) },
-        globalSize: { value: state.size },
-        intensity: { value: state.intensity },
-        shimmerAmp: { value: state.shimmer },
-        jitterAmp: { value: state.jitter },
-        uJitterMode: { value: state.jitterMode },
-        hueShift: { value: state.hueShift },
-        saturation: { value: state.saturation },
-        realView: { value: state.realViewRef.current ? 1 : 0 },
-        shapeType: { value: state.shapeIndex },
-        tex: { value: state.texturesRef.current[state.textureIndex] ?? new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1) },
-        textureIndex: { value: state.textureIndex },
-        uColourStyle: { value: state.colourStyle },
-        uColourBy: { value: state.colourBy },
-        uColourQty: { value: state.colourQuantity },
-        uBrightnessQty: { value: state.brightnessQuantity },
-        uInCoord: { value: state.inputCoord },
-        uOutCoord: { value: state.outputCoord },
-        uRotL: { value: { w: 1, v: new THREE.Vector3() } },
-        uRotR: { value: { w: 1, v: new THREE.Vector3() } },
-        uProjMode: { value: state.projRef.current },
-        uProjTarget: { value: state.projRef.current },
-        uProjAlpha: { value: 0 },
-        branchIndex: { value: branchMin + b },
-      },
+    const m = new THREE.ShaderMaterial({
+      uniforms: makeUniforms(b),
       vertexShader,
       fragmentShader,
       transparent: true,
@@ -185,22 +198,118 @@ export default function ComplexParticles({
       blending: THREE.AdditiveBlending,
       vertexColors: true,
     });
+    m.userData.branch = b;
+    return m;
   }
 
-  useEffect(() => {
-    if (!sceneRef.current || !state.geometryRef.current) return;
-    pointsRef.current.forEach(pts => sceneRef.current!.remove(pts));
+  // The sheet uses true alpha compositing (NormalBlending), not the points'
+  // additive glow — overlapping translucent triangles must read as a layered
+  // surface, not blow out to white. This is fixed regardless of background, so
+  // the objectMode effect leaves sheet materials' blending alone (userData.sheet).
+  function createSheetFillMaterial(b: number) {
+    const m = new THREE.ShaderMaterial({
+      uniforms: { ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 0 } },
+      vertexShader: sheetVertexShader,
+      fragmentShader: sheetFragmentShader,
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.NormalBlending,
+      vertexColors: true,
+    });
+    m.userData.branch = b;
+    m.userData.sheet = true;
+    return m;
+  }
+
+  function createSheetWireMaterial(b: number) {
+    const m = new THREE.ShaderMaterial({
+      uniforms: { ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 1 } },
+      vertexShader: sheetVertexShader,
+      fragmentShader: sheetFragmentShader,
+      transparent: true,
+      depthWrite: false,
+      side: THREE.DoubleSide,
+      blending: THREE.NormalBlending,
+      vertexColors: true,
+      wireframe: true,
+    });
+    m.userData.branch = b;
+    m.userData.sheet = true;
+    m.userData.sheetWire = true;
+    return m;
+  }
+
+  // Visibility follows the render mode: Points shows the cloud; Sheet shows the
+  // filled surface and/or the wireframe overlay.
+  const applyRenderVisibility = () => {
+    const isSheet = state.renderMode === 'Sheet';
+    pointsRef.current.forEach(o => { o.visible = !isSheet; });
+    fillMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetFill; });
+    wireMeshRef.current.forEach(o => { o.visible = isSheet && state.sheetWire; });
+  };
+
+  // (Re)create the per-branch objects: a point cloud, a filled sheet, and a
+  // wireframe sheet for each Riemann sheet. Used by both the initial mount and
+  // the branch-range effect.
+  const rebuildBranchObjects = (scene: THREE.Scene) => {
+    const pointsGeom = state.geometryRef.current;
+    const sheetGeom = sheetGeomRef.current;
+    if (!pointsGeom || !sheetGeom) return;
+    pointsRef.current.forEach(o => scene.remove(o));
+    fillMeshRef.current.forEach(o => scene.remove(o));
+    wireMeshRef.current.forEach(o => scene.remove(o));
     state.materialsRef.current.forEach(m => m.dispose());
     state.materialsRef.current = [];
     pointsRef.current = [];
+    fillMeshRef.current = [];
+    wireMeshRef.current = [];
     for (let b = 0; b < branchCount; b++) {
-      const material = createBranchMaterial(b);
-      state.materialsRef.current.push(material);
-      const pts = new THREE.Points(state.geometryRef.current, material);
-      sceneRef.current.add(pts);
+      const pm = createBranchMaterial(b);
+      const fm = createSheetFillMaterial(b);
+      const wm = createSheetWireMaterial(b);
+      const pts = new THREE.Points(pointsGeom, pm);
+      const fill = new THREE.Mesh(sheetGeom, fm);
+      const wire = new THREE.Mesh(sheetGeom, wm);
+      state.materialsRef.current.push(pm, fm, wm);
       pointsRef.current.push(pts);
+      fillMeshRef.current.push(fill);
+      wireMeshRef.current.push(wire);
+      scene.add(pts, fill, wire);
     }
+    applyRenderVisibility();
+  };
+
+  useEffect(() => {
+    if (!sceneRef.current || !state.geometryRef.current || !sheetGeomRef.current) return;
+    rebuildBranchObjects(sceneRef.current);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [branchCount]);
+
+  // Toggle which render mode's objects are visible without rebuilding them.
+  useEffect(() => {
+    applyRenderVisibility();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [state.renderMode, state.sheetFill, state.sheetWire]);
+
+  // Rebuild the shared sheet grid when its resolution or the domain box changes.
+  useEffect(() => {
+    const geom = sheetGeomRef.current;
+    if (!geom) return;
+    const [bxMin, bxMax, byMin, byMax] = effectiveBounds();
+    rebuildSheetGeometry(geom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    state.sheetResolution, state.extentX, state.extentY, state.axisScale,
+    state.boundsLock, state.xMin, state.xMax, state.yMin, state.yMax,
+  ]);
+
+  // Push the faceted-shading strength to the sheet materials (points lack uShade).
+  useEffect(() => {
+    state.materialsRef.current.forEach(m => {
+      if (m.uniforms.uShade) m.uniforms.uShade.value = state.sheetShade;
+    });
+  }, [state.sheetShade]);
 
   // Show the sphere scaffold in the Hopf view (or once the Torus → Hopf collapse
   // is past halfway) and the donut scaffold in the Torus view; hide both in the
@@ -252,16 +361,9 @@ export default function ComplexParticles({
       const [bxMin, bxMax, byMin, byMax] = effectiveBounds();
       const geometry = createParticleGeometry(state.particleCount, bxMin, bxMax, byMin, byMax, state.samplePattern);
       state.geometryRef.current = geometry;
+      sheetGeomRef.current = createSheetGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
 
-      state.materialsRef.current = [];
-      pointsRef.current = [];
-      for (let b = 0; b < branchCount; b++) {
-        const material = createBranchMaterial(b);
-        state.materialsRef.current.push(material);
-        const pts = new THREE.Points(geometry, material);
-        scene.add(pts);
-        pointsRef.current.push(pts);
-      }
+      rebuildBranchObjects(scene);
 
       const axes = createAxes(scene, state.hueShift, state.axisWidth);
       state.xAxisRef.current = axes.x;

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -219,12 +219,14 @@ export default function ComplexParticles({
 
   function createSheetFillMaterial(b: number) {
     const [csx, csy] = currentCellSize();
+    const [bx0, bx1, by0, by1] = effectiveBounds();
     const m = new THREE.ShaderMaterial({
       uniforms: {
         ...makeUniforms(b),
         uShade: { value: state.sheetShade },
         uWire: { value: 0 },
         uCellSize: { value: new THREE.Vector2(csx, csy) },
+        uDomainBox: { value: new THREE.Vector4(bx0, bx1, by0, by1) },
       },
       vertexShader: sheetFillVertexShader,
       fragmentShader: sheetFragmentShader,
@@ -240,8 +242,12 @@ export default function ComplexParticles({
   }
 
   function createSheetWireMaterial(b: number) {
+    const [bx0, bx1, by0, by1] = effectiveBounds();
     const m = new THREE.ShaderMaterial({
-      uniforms: { ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 1 } },
+      uniforms: {
+        ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 1 },
+        uDomainBox: { value: new THREE.Vector4(bx0, bx1, by0, by1) },
+      },
       vertexShader: sheetWireVertexShader,
       fragmentShader: sheetFragmentShader,
       transparent: true,
@@ -320,6 +326,7 @@ export default function ComplexParticles({
     const [csx, csy] = sheetCellSize(state.sheetResolution, bxMin, bxMax, byMin, byMax);
     state.materialsRef.current.forEach(m => {
       if (m.uniforms.uCellSize) m.uniforms.uCellSize.value.set(csx, csy);
+      if (m.uniforms.uDomainBox) m.uniforms.uDomainBox.value.set(bxMin, bxMax, byMin, byMax);
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -189,6 +189,7 @@ export default function ComplexParticles({
     textureIndex: { value: state.textureIndex },
     uColourStyle: { value: state.colourStyle },
     uColormap: { value: state.colormap },
+    uColorRepeat: { value: state.colorRepeat },
     uLight: { value: state.lighting ? 1 : 0 },
     uLightStrength: { value: state.lightStrength },
     uColourBy: { value: state.colourBy },

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -184,6 +184,7 @@ export default function ComplexParticles({
     tex: { value: state.texturesRef.current[state.textureIndex] ?? new THREE.DataTexture(new Uint8Array([255, 255, 255, 255]), 1, 1) },
     textureIndex: { value: state.textureIndex },
     uColourStyle: { value: state.colourStyle },
+    uColormap: { value: state.colormap },
     uColourBy: { value: state.colourBy },
     uColourQty: { value: state.colourQuantity },
     uBrightnessQty: { value: state.brightnessQuantity },

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -99,9 +99,10 @@ export default function ComplexParticles({
   // mesh per Riemann sheet).
   const tileGeomRef = useRef<THREE.BufferGeometry>();
   const tileMeshRef = useRef<THREE.Mesh[]>([]);
-  // Net render mode: a polar fibre net (circles + rays) drawn as LineSegments.
+  // Net render mode: a polar fibre net (circles + rays) drawn as screen-space
+  // ribbon meshes (so it can have a real pixel width).
   const netGeomRef = useRef<THREE.BufferGeometry>();
-  const netMeshRef = useRef<THREE.LineSegments[]>([]);
+  const netMeshRef = useRef<THREE.Mesh[]>([]);
   const scaffoldRef = useRef<HopfScaffold>();
   const fibersRef = useRef<HopfFibers>();
 
@@ -300,17 +301,25 @@ export default function ComplexParticles({
   };
 
   function createNetMaterial(b: number) {
+    const size = new THREE.Vector2(1, 1);
+    state.rendererRef.current?.getSize(size);
     const m = new THREE.ShaderMaterial({
-      uniforms: makeUniforms(b),
+      uniforms: {
+        ...makeUniforms(b),
+        uResolution: { value: size },
+        uLineWidth: { value: state.netWidth },
+      },
       vertexShader: netVertexShader,
       fragmentShader: netFragmentShader,
       transparent: true,
       depthWrite: false,
+      side: THREE.DoubleSide,
       blending: THREE.NormalBlending,
       vertexColors: true,
     });
     m.userData.branch = b;
     m.userData.sheet = true;   // keep NormalBlending through the object-mode toggle
+    m.userData.net = true;
     return m;
   }
 
@@ -382,7 +391,7 @@ export default function ComplexParticles({
       const fill = new THREE.Mesh(fillGeom, fm);
       const wire = new THREE.LineSegments(wireGeom, wm);
       const tiles = new THREE.Mesh(tileGeom, tm);
-      const net = new THREE.LineSegments(netGeom, nm);
+      const net = new THREE.Mesh(netGeom, nm);
       // In adaptive Sheet mode the cloud and sheet overlap; without a fixed order
       // these depth-write-off transparent objects sort by distance and the
       // additive points can land on top of an opaque fill. Pin points behind, then
@@ -453,13 +462,37 @@ export default function ComplexParticles({
   useEffect(() => {
     const netGeom = netGeomRef.current;
     if (!netGeom) return;
-    rebuildNetGeometry(netGeom, state.netRings, state.netSpokes, netRadius(), state.netCircles, state.netRays);
+    rebuildNetGeometry(netGeom, state.netRings, state.netSpokes, netRadius(), state.netCircles, state.netRays, state.netResolution);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    state.netRings, state.netSpokes, state.netCircles, state.netRays,
+    state.netRings, state.netSpokes, state.netCircles, state.netRays, state.netResolution,
     state.extentX, state.extentY, state.axisScale,
     state.boundsLock, state.xMin, state.xMax, state.yMin, state.yMax,
   ]);
+
+  // Push the net thread width to its materials.
+  useEffect(() => {
+    state.materialsRef.current.forEach(m => {
+      if (m.uniforms.uLineWidth) m.uniforms.uLineWidth.value = state.netWidth;
+    });
+  }, [state.netWidth]);
+
+  // Keep the net's screen-space width correct as the canvas resizes (the ribbon
+  // expansion is in pixels, so it needs the live drawing-buffer size).
+  useEffect(() => {
+    const sync = () => {
+      const r = state.rendererRef.current;
+      if (!r) return;
+      const s = new THREE.Vector2();
+      r.getSize(s);
+      state.materialsRef.current.forEach(m => {
+        if (m.uniforms.uResolution) (m.uniforms.uResolution.value as THREE.Vector2).copy(s);
+      });
+    };
+    sync();
+    window.addEventListener('resize', sync);
+    return () => window.removeEventListener('resize', sync);
+  });
 
   // Push the faceted-shading strength to the sheet materials (points lack uShade).
   useEffect(() => {
@@ -528,7 +561,7 @@ export default function ComplexParticles({
       sheetGeomRef.current = createSheetGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       sheetWireGeomRef.current = createSheetWireGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
       tileGeomRef.current = createTileGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
-      netGeomRef.current = createNetGeometry(state.netRings, state.netSpokes, netRadius(), state.netCircles, state.netRays);
+      netGeomRef.current = createNetGeometry(state.netRings, state.netSpokes, netRadius(), state.netCircles, state.netRays, state.netResolution);
 
       rebuildBranchObjects(scene);
 

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -5,12 +5,13 @@ import { Select, NumberInput } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
-import { vertexShader, fragmentShader, sheetVertexShader, sheetFragmentShader } from './shaders';
+import { vertexShader, fragmentShader, sheetFillVertexShader, sheetWireVertexShader, sheetFragmentShader } from './shaders';
 import { loadParticleTextures } from '../../lib/textures';
 import {
   useParticleState, useUniformSync, useViewControls,
   createParticleGeometry, rebuildGeometryBuffers, redistributeAdaptive,
   createSheetGeometry, rebuildSheetGeometry,
+  createSheetWireGeometry, rebuildSheetWireGeometry, sheetCellSize,
   createAxes, createHopfScaffold, createHopfFibers, startAnimationLoop,
 } from '../../lib/particles';
 import { usePersistentState } from '../../lib/usePersistentState';
@@ -84,11 +85,14 @@ export default function ComplexParticles({
 
   const sceneRef = useRef<THREE.Scene>();
   const pointsRef = useRef<THREE.Points[]>([]);
-  // Sheet (surface) render mode: one shared regular-grid geometry, drawn per
-  // branch as a translucent filled mesh + a wireframe overlay.
+  // Sheet (surface) render mode: a non-indexed per-quad fill geometry (flat
+  // averaged colour per rectangle) + a separate line geometry for the
+  // rectangular wireframe (row/column edges, no diagonals). Both are drawn per
+  // Riemann sheet.
   const sheetGeomRef = useRef<THREE.BufferGeometry>();
+  const sheetWireGeomRef = useRef<THREE.BufferGeometry>();
   const fillMeshRef = useRef<THREE.Mesh[]>([]);
-  const wireMeshRef = useRef<THREE.Mesh[]>([]);
+  const wireMeshRef = useRef<THREE.LineSegments[]>([]);
   const scaffoldRef = useRef<HopfScaffold>();
   const fibersRef = useRef<HopfFibers>();
 
@@ -206,10 +210,23 @@ export default function ComplexParticles({
   // additive glow — overlapping translucent triangles must read as a layered
   // surface, not blow out to white. This is fixed regardless of background, so
   // the objectMode effect leaves sheet materials' blending alone (userData.sheet).
+  // Current cell spacing (domain units per cell) for the fill shader's corner
+  // averaging — must track the domain box and sheet resolution.
+  const currentCellSize = (): [number, number] => {
+    const [bx0, bx1, by0, by1] = effectiveBounds();
+    return sheetCellSize(state.sheetResolution, bx0, bx1, by0, by1);
+  };
+
   function createSheetFillMaterial(b: number) {
+    const [csx, csy] = currentCellSize();
     const m = new THREE.ShaderMaterial({
-      uniforms: { ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 0 } },
-      vertexShader: sheetVertexShader,
+      uniforms: {
+        ...makeUniforms(b),
+        uShade: { value: state.sheetShade },
+        uWire: { value: 0 },
+        uCellSize: { value: new THREE.Vector2(csx, csy) },
+      },
+      vertexShader: sheetFillVertexShader,
       fragmentShader: sheetFragmentShader,
       transparent: true,
       depthWrite: false,
@@ -225,14 +242,12 @@ export default function ComplexParticles({
   function createSheetWireMaterial(b: number) {
     const m = new THREE.ShaderMaterial({
       uniforms: { ...makeUniforms(b), uShade: { value: state.sheetShade }, uWire: { value: 1 } },
-      vertexShader: sheetVertexShader,
+      vertexShader: sheetWireVertexShader,
       fragmentShader: sheetFragmentShader,
       transparent: true,
       depthWrite: false,
-      side: THREE.DoubleSide,
       blending: THREE.NormalBlending,
       vertexColors: true,
-      wireframe: true,
     });
     m.userData.branch = b;
     m.userData.sheet = true;
@@ -254,8 +269,9 @@ export default function ComplexParticles({
   // the branch-range effect.
   const rebuildBranchObjects = (scene: THREE.Scene) => {
     const pointsGeom = state.geometryRef.current;
-    const sheetGeom = sheetGeomRef.current;
-    if (!pointsGeom || !sheetGeom) return;
+    const fillGeom = sheetGeomRef.current;
+    const wireGeom = sheetWireGeomRef.current;
+    if (!pointsGeom || !fillGeom || !wireGeom) return;
     pointsRef.current.forEach(o => scene.remove(o));
     fillMeshRef.current.forEach(o => scene.remove(o));
     wireMeshRef.current.forEach(o => scene.remove(o));
@@ -269,8 +285,8 @@ export default function ComplexParticles({
       const fm = createSheetFillMaterial(b);
       const wm = createSheetWireMaterial(b);
       const pts = new THREE.Points(pointsGeom, pm);
-      const fill = new THREE.Mesh(sheetGeom, fm);
-      const wire = new THREE.Mesh(sheetGeom, wm);
+      const fill = new THREE.Mesh(fillGeom, fm);
+      const wire = new THREE.LineSegments(wireGeom, wm);
       state.materialsRef.current.push(pm, fm, wm);
       pointsRef.current.push(pts);
       fillMeshRef.current.push(fill);
@@ -292,12 +308,19 @@ export default function ComplexParticles({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [state.renderMode, state.sheetFill, state.sheetWire]);
 
-  // Rebuild the shared sheet grid when its resolution or the domain box changes.
+  // Rebuild the sheet fill + wire grids when the resolution or domain box
+  // changes, and refresh the fill shader's cell size (for corner averaging).
   useEffect(() => {
-    const geom = sheetGeomRef.current;
-    if (!geom) return;
+    const fillGeom = sheetGeomRef.current;
+    const wireGeom = sheetWireGeomRef.current;
+    if (!fillGeom || !wireGeom) return;
     const [bxMin, bxMax, byMin, byMax] = effectiveBounds();
-    rebuildSheetGeometry(geom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    rebuildSheetGeometry(fillGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    rebuildSheetWireGeometry(wireGeom, state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    const [csx, csy] = sheetCellSize(state.sheetResolution, bxMin, bxMax, byMin, byMax);
+    state.materialsRef.current.forEach(m => {
+      if (m.uniforms.uCellSize) m.uniforms.uCellSize.value.set(csx, csy);
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     state.sheetResolution, state.extentX, state.extentY, state.axisScale,
@@ -362,6 +385,7 @@ export default function ComplexParticles({
       const geometry = createParticleGeometry(state.particleCount, bxMin, bxMax, byMin, byMax, state.samplePattern);
       state.geometryRef.current = geometry;
       sheetGeomRef.current = createSheetGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
+      sheetWireGeomRef.current = createSheetWireGeometry(state.sheetResolution, bxMin, bxMax, byMin, byMax);
 
       rebuildBranchObjects(scene);
 

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -80,14 +80,20 @@ is bypassed while **Adaptive density** is on.)
 
 The same 4-D graph can be drawn two ways. **Points** (the default) scatters one
 particle per sample. **Sheet** instead stitches a regular grid of samples into a
-single continuous **surface** — the actual 2-D graph of `f`, drawn as a
-**translucent sheet** with an optional **wireframe** grid over it. Filled and
-wireframe can each be toggled, **Resolution** sets how fine the grid is, and
-**Shading** adds depth cues by darkening faces that turn edge-on to the camera.
-Because a surface needs grid topology, Sheet mode always samples a Cartesian grid
-(it ignores the Sampling pattern and the particle count, using its own
-Resolution). It's the clearest way to see folds, branch sheets, and how the
-surface drapes through each projection.
+single continuous **surface** — the actual 2-D graph of `f`. The grid's
+**rectangular cells** are drawn as a **translucent filled sheet** (each rectangle
+a single flat colour — the average of its four corners' domain colours) and/or a
+**wireframe** of the row/column edges. Filled and wireframe can each be toggled,
+**Resolution** sets how fine the grid is, and **Shading** adds depth cues by
+darkening faces that turn edge-on to the camera. Because a surface needs grid
+topology, Sheet mode always samples a Cartesian grid (it ignores the Sampling
+pattern and the particle count, using its own Resolution).
+
+The vertices are the same 4-D points as the cloud, so the **Perspective**
+projection can still evert the sheet where it stretches past the camera divide
+(`3 + Im f` crossing zero) — the linear **Drop-axis** and **Stereographic**
+projections show it as a single, non-folding surface. It's the clearest way to
+see folds, branch sheets, and how the surface drapes through each projection.
 
 ## 4-D rotations (the quarter-turn controls)
 

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -76,6 +76,19 @@ keeps near-linear maps (`f ≈ b·z`) crisp in the Hopf/Torus view — where a u
 Cartesian grid would leave one side of the fiber circle under-sampled. (Sampling
 is bypassed while **Adaptive density** is on.)
 
+## Render mode — points or sheet (Surface panel)
+
+The same 4-D graph can be drawn two ways. **Points** (the default) scatters one
+particle per sample. **Sheet** instead stitches a regular grid of samples into a
+single continuous **surface** — the actual 2-D graph of `f`, drawn as a
+**translucent sheet** with an optional **wireframe** grid over it. Filled and
+wireframe can each be toggled, **Resolution** sets how fine the grid is, and
+**Shading** adds depth cues by darkening faces that turn edge-on to the camera.
+Because a surface needs grid topology, Sheet mode always samples a Cartesian grid
+(it ignores the Sampling pattern and the particle count, using its own
+Resolution). It's the clearest way to see folds, branch sheets, and how the
+surface drapes through each projection.
+
 ## 4-D rotations (the quarter-turn controls)
 
 In 3-D you rotate *around an axis*; in 4-D you rotate *in a plane*. There are

--- a/src/animations/ComplexParticles/README.md
+++ b/src/animations/ComplexParticles/README.md
@@ -4,7 +4,9 @@ Visualizes a complex map `z → f(z)` using domain coloring in four
 dimensions. Each particle sits at the 4D point `(Re z, Im z, Re f(z),
 Im f(z))` and is projected to 3D using perspective, stereographic, or
 Hopf projection, plus optional drop-axis views. Particle color
-encodes either the input or the output complex number.
+encodes either the input or the output complex number. The graph can be
+drawn as a point cloud or as a single continuous translucent **sheet**
+(see the Surface controls below).
 
 ## Function
 
@@ -28,6 +30,11 @@ symmetric `-1…1`); single-valued functions ignore it.
 - **Particles** — size, opacity, intensity, sprite shape (sphere /
   hexagon / pyramid), texture (procedural checker / speckled / stone /
   metal, or HDR royal), and a light-background toggle.
+- **Surface** — render the graph as a point cloud (**Points**, the default)
+  or as a single continuous **Sheet**: a translucent triangle surface over a
+  regular grid, with toggleable **filled** and **wireframe** layers, a grid
+  **resolution**, and a **shading** amount for depth cues. Sheet mode uses its
+  own grid (independent of the sampling pattern and particle count).
 - **Motion** — shimmer (time-varying brightness) and jitter (positional
   noise), with a **Jitter mode**: *Scatter* (the default) perturbs the
   sampled domain point and re-evaluates f, so particles stay on the surface

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -253,17 +253,33 @@ vec3 calcColour(vec2 z, vec2 f){
     else if(uColourQty==3) param = 0.5 + 0.5*tanh(w.y);      // imag part
     else                   param = angle/TAU + 1.0;          // phase (default)
     float hue = fract(param + hueShift);
-    // Sequential colormaps (uColormap>0) override the HSV wheel: map MAGNITUDE
-    // through a perceptual ramp — the natural choice for reading magnitude. The
-    // scale is logarithmic in |·|. uColorRepeat==0 → one smooth saturating sweep
-    // (tanh of log) across the whole range; uColorRepeat>0 → tile the colormap in
-    // log-magnitude (that many cycles per e-fold) with a mirrored, seamless wave,
-    // giving repeating contour-like bands.
+    // Brightness (value), driven independently. Magnitude (default) gives the
+    // classic |·| → brightness; Uniform is flat (full strength); others squash.
+    float val;
+    if(uBrightnessQty==0)      val = fract(angle/TAU + 0.5);          // phase
+    else if(uBrightnessQty==2) val = 0.5 + 0.5*tanh(w.x);            // real part
+    else if(uBrightnessQty==3) val = 0.5 + 0.5*tanh(w.y);            // imag part
+    else if(uBrightnessQty==4) val = 1.0;                            // uniform (flat)
+    else                       val = 0.5*(1.0+tanh(log(r+1e-6)));    // magnitude
+    // Sequential colormaps (uColormap>0) replace the HSV wheel: the chosen
+    // Quantity drives the colormap axis (magnitude is log-scaled), and Brightness
+    // still modulates value (Uniform = flat, full-strength colour). uColorRepeat>0
+    // tiles the map along that axis with a mirrored, seamless wave (contour bands).
     if(uColormap > 0){
         float lg = log(r + 1e-6);
-        float s = (uColorRepeat > 0.0)
-            ? abs(fract(lg * uColorRepeat) * 2.0 - 1.0)        // repeating log bands (seamless)
-            : clamp(0.5*(1.0 + tanh(lg)), 0.0, 1.0);           // smooth, saturating
+        float s;
+        if(uColorRepeat > 0.0){
+            float raw = (uColourQty==2) ? w.x
+                      : (uColourQty==3) ? w.y
+                      : (uColourQty==0) ? angle/TAU
+                      :                   lg;                         // magnitude (log)
+            s = abs(fract(raw * uColorRepeat) * 2.0 - 1.0);          // seamless repeat
+        } else {
+            s = (uColourQty==2) ? 0.5 + 0.5*tanh(w.x)                // real
+              : (uColourQty==3) ? 0.5 + 0.5*tanh(w.y)                // imag
+              : (uColourQty==0) ? fract(angle/TAU + 0.5)             // phase
+              :                   clamp(0.5*(1.0 + tanh(lg)), 0.0, 1.0); // magnitude
+        }
         int scheme = (uColormap==1) ? 3      // Grayscale
                    : (uColormap==2) ? 4      // Viridis
                    : (uColormap==3) ? 5      // Magma
@@ -272,18 +288,10 @@ vec3 calcColour(vec2 z, vec2 f){
                    : (uColormap==6) ? 1      // Fire
                    : (uColormap==7) ? 2      // Ocean
                    :                  uColormap; // 8.. align with palette scheme ids
-        vec3 cmap = paletteColor(s * 255.0, scheme);
+        vec3 cmap = paletteColor(s * 255.0, scheme) * val;
         cmap = mix(vec3(dot(cmap, vec3(0.3333))), cmap, saturation);
         return cmap * intensity * (1.0 + shimmerAmp*sin(time + seed.x*TAU));
     }
-    // Brightness (value) is driven independently of hue. Magnitude (the default)
-    // gives the classic |.| -> brightness; the other quantities squash into [0,1].
-    float val;
-    if(uBrightnessQty==0)      val = fract(angle/TAU + 0.5);          // phase
-    else if(uBrightnessQty==2) val = 0.5 + 0.5*tanh(w.x);            // real part
-    else if(uBrightnessQty==3) val = 0.5 + 0.5*tanh(w.y);            // imag part
-    else if(uBrightnessQty==4) val = 1.0;                            // uniform
-    else                       val = 0.5*(1.0+tanh(log(r+1e-6)));    // magnitude
     if(uColourStyle==0){
         if(uBrightnessQty!=4) val = mix(val, val*(0.75+0.25*sin(TAU*log(r))), 0.5);
         return hsv2rgb(vec3(hue, saturation, val)) * intensity * (1.0 + shimmerAmp*sin(time + seed.x*TAU));

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -593,14 +593,27 @@ void main(){
 // shared surfacePos) and colours it by the domain colouring, so the concentric
 // circles and rays show how the function carries the polar fibres of the domain.
 export const netVertexShader = vsCommon + `
+attribute vec2 aOther;       // the segment's other endpoint (domain coords)
+attribute float aSide;       // ±1 ribbon side
+uniform vec2 uResolution;    // drawing-buffer size in px (for screen-space width)
+uniform float uLineWidth;    // ribbon width in px
 void main(){
   vec2 z = vec2(position.x, position.z);
+  vec4 clipA = projectionMatrix * modelViewMatrix * vec4(surfacePos(z), 1.0);
+  vec4 clipB = projectionMatrix * modelViewMatrix * vec4(surfacePos(aOther), 1.0);
+  // Screen-space direction of the segment, then offset perpendicular by half the
+  // width (in px → NDC) so the ribbon keeps a constant pixel thickness.
+  vec2 ndcA = clipA.xy / clipA.w;
+  vec2 ndcB = clipB.xy / clipB.w;
+  vec2 dirPx = (ndcB - ndcA) * uResolution;
+  vec2 dir = (length(dirPx) > 1e-6) ? normalize(dirPx) : vec2(1.0, 0.0);
+  vec2 nrm = vec2(-dir.y, dir.x);
+  vec2 offsetNdc = nrm * aSide * (uLineWidth * 0.5) / (0.5 * uResolution);
+  clipA.xy += offsetNdc * clipA.w;
+  gl_Position = clipA;
   vec2 zc = domainWarp(z);
   vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
-  vec3 pos3 = surfacePos(z);
-  vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
-  gl_Position = projectionMatrix * mv;
   vColor = calcColour(zc, f);
 }`;
 

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -44,6 +44,7 @@ uniform int   uProjTarget;
 uniform float uProjAlpha;
 uniform int   uColourStyle;
 uniform int   uColormap;
+uniform float uColorRepeat;
 uniform int   uColourBy;
 uniform int   uColourQty;
 uniform int   uBrightnessQty;
@@ -251,10 +252,16 @@ vec3 calcColour(vec2 z, vec2 f){
     else                   param = angle/TAU + 1.0;          // phase (default)
     float hue = fract(param + hueShift);
     // Sequential colormaps (uColormap>0) override the HSV wheel: map MAGNITUDE
-    // (|z|/|f|, squashed to [0,1]) through a perceptual ramp — the natural choice
-    // for reading magnitude as a smooth gradient. Saturation still desaturates.
+    // through a perceptual ramp — the natural choice for reading magnitude. The
+    // scale is logarithmic in |·|. uColorRepeat==0 → one smooth saturating sweep
+    // (tanh of log) across the whole range; uColorRepeat>0 → tile the colormap in
+    // log-magnitude (that many cycles per e-fold) with a mirrored, seamless wave,
+    // giving repeating contour-like bands.
     if(uColormap > 0){
-        float s = clamp(0.5*(1.0 + tanh(log(r + 1e-6))), 0.0, 1.0);
+        float lg = log(r + 1e-6);
+        float s = (uColorRepeat > 0.0)
+            ? abs(fract(lg * uColorRepeat) * 2.0 - 1.0)        // repeating log bands (seamless)
+            : clamp(0.5*(1.0 + tanh(lg)), 0.0, 1.0);           // smooth, saturating
         int scheme = (uColormap==1) ? 3      // Grayscale
                    : (uColormap==2) ? 4      // Viridis
                    : (uColormap==3) ? 5      // Magma

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -45,6 +45,8 @@ uniform float uProjAlpha;
 uniform int   uColourStyle;
 uniform int   uColormap;
 uniform float uColorRepeat;
+uniform int   uReciprocal;     // 1 → log-radial (reciprocal-symmetric) sampling
+uniform float uWarpR;          // domain radius for the warp
 uniform int   uColourBy;
 uniform int   uColourQty;
 uniform int   uBrightnessQty;
@@ -307,11 +309,25 @@ vec2 chartCoord(vec2 c, int mode){
   float a = atan(c.y, c.x);
   return vec2(mode==2 ? log(r+1e-6) : r, a);
 }
-// Full surface placement of a domain point (no jitter): chart → 4-vector →
+// Reciprocal-symmetric (log-radial) sampling warp. A uniform lattice radius r in
+// [0,R] is remapped so the unit circle sits at the middle of the range and the
+// sampling is uniform in log|z|: r=R/2 → |z|=1, r→0 → 1/R, r=R → R. This samples
+// as deeply inside the unit disk as outside (z ↔ 1/z symmetric). Angle is kept.
+// Applied inside surfacePos + the colour path, so every mode inherits it.
+vec2 domainWarp(vec2 z){
+  if(uReciprocal == 0) return z;
+  float r = length(z);
+  if(r < 1e-7) return z;
+  float R = max(uWarpR, 1e-3);
+  float rNew = pow(R, 2.0 * (r / R) - 1.0);
+  return z * (rNew / r);
+}
+// Full surface placement of a domain point (no jitter): warp → chart → 4-vector →
 // 4D rotation → projection → scale. The sheet shaders use this both to place
 // each vertex and to sample a cell's four corners so they can measure how far
 // the function has stretched that cell in 3D (the adaptive-density metric).
 vec3 surfacePos(vec2 zc){
+  zc = domainWarp(zc);
   vec2 fc = applyComplex(zc, functionType);
   if(length(fc) > 1e3) fc = normalize(fc)*1e3;
   vec2 zP = chartCoord(zc, uInCoord);
@@ -350,7 +366,7 @@ varying float vPointKeep;
 // clean z, then add the full independent 4D offset to (x, y, Re f, Im f), pushing
 // the point off the surface on all four axes. Colour uses the effective z/f, so
 // it stays consistent in both modes.
-void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(z, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColour(z,f);vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;}`;
+void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColour(zc,f);}`;
 
 export const fragmentShader = `
 uniform float opacity;
@@ -411,13 +427,14 @@ void main(){
   // Sample a cell centred on this grid node so the wire fades in step with the
   // fill where the function stretches the grid.
   vStretch = cellStretch(z - 0.5*uCellSize, uCellSize);
-  vec2 f = applyComplex(z, functionType);
+  vec2 zc = domainWarp(z);
+  vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vec3 pos3 = surfacePos(z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
-  vColor = calcColour(z, f);
+  vColor = calcColour(zc, f);
 }`;
 
 // Sheet FILL vertex shader: same surface placement, but each rectangle gets a
@@ -433,6 +450,7 @@ varying vec3 vViewPos;
 varying float vFade;
 varying float vStretch;
 vec3 cornerColour(vec2 zc){
+  zc = domainWarp(zc);
   vec2 fc = applyComplex(zc, functionType);
   if(length(fc) > 1e3) fc = normalize(fc)*1e3;
   return calcColour(zc, fc);
@@ -549,9 +567,10 @@ void main(){
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
-  vec2 f = applyComplex(z, functionType);
+  vec2 zc = domainWarp(z);
+  vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
-  vColor = calcColour(z, f);                 // one flat colour per tile (shared node)
+  vColor = calcColour(zc, f);                // one flat colour per tile (shared node)
 }`;
 
 // Tiles fragment: flat per-tile colour with a facing-ratio shade so the faceted
@@ -576,12 +595,13 @@ void main(){
 export const netVertexShader = vsCommon + `
 void main(){
   vec2 z = vec2(position.x, position.z);
-  vec2 f = applyComplex(z, functionType);
+  vec2 zc = domainWarp(z);
+  vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vec3 pos3 = surfacePos(z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   gl_Position = projectionMatrix * mv;
-  vColor = calcColour(z, f);
+  vColor = calcColour(zc, f);
 }`;
 
 // Fiber-net fragment: the line colour, a touch brighter/opaquer so the threads

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -2,7 +2,9 @@
 // function, the projection modes, and the domain-colouring (calcColour /
 // chartCoord). Both the point-cloud and the sheet vertex shaders are built from
 // this common block + their own main(), so the two render modes stay in lockstep.
-const vsCommon = `
+import { PALETTE_GLSL } from '../../../lib/colormaps';
+
+const vsCommon = PALETTE_GLSL + `
 // DOMAIN–COLORING VERTEX SHADER
 struct quat { float w; vec3 v; };
 
@@ -41,6 +43,7 @@ uniform int   uProjMode;
 uniform int   uProjTarget;
 uniform float uProjAlpha;
 uniform int   uColourStyle;
+uniform int   uColormap;
 uniform int   uColourBy;
 uniform int   uColourQty;
 uniform int   uBrightnessQty;
@@ -247,6 +250,22 @@ vec3 calcColour(vec2 z, vec2 f){
     else if(uColourQty==3) param = 0.5 + 0.5*tanh(w.y);      // imag part
     else                   param = angle/TAU + 1.0;          // phase (default)
     float hue = fract(param + hueShift);
+    // Sequential colormaps (uColormap>0) override the HSV wheel: map MAGNITUDE
+    // (|z|/|f|, squashed to [0,1]) through a perceptual ramp — the natural choice
+    // for reading magnitude as a smooth gradient. Saturation still desaturates.
+    if(uColormap > 0){
+        float s = clamp(0.5*(1.0 + tanh(log(r + 1e-6))), 0.0, 1.0);
+        int scheme = (uColormap==1) ? 3      // Grayscale
+                   : (uColormap==2) ? 4      // Viridis
+                   : (uColormap==3) ? 5      // Magma
+                   : (uColormap==4) ? 6      // Inferno
+                   : (uColormap==5) ? 7      // Plasma
+                   : (uColormap==6) ? 1      // Fire
+                   :                  2;     // Ocean
+        vec3 cmap = paletteColor(s * 255.0, scheme);
+        cmap = mix(vec3(dot(cmap, vec3(0.3333))), cmap, saturation);
+        return cmap * intensity * (1.0 + shimmerAmp*sin(time + seed.x*TAU));
+    }
     // Brightness (value) is driven independently of hue. Magnitude (the default)
     // gives the classic |.| -> brightness; the other quantities squash into [0,1].
     float val;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -335,9 +335,16 @@ void main(){
 // node (interpolated along the rectangle edges). Drawn as LineSegments of the
 // row/column edges only — no triangle diagonals. gl_PointSize is omitted.
 export const sheetWireVertexShader = vsCommon + `
+uniform vec4 uDomainBox;   // xMin, xMax, yMin, yMax
 varying vec3 vViewPos;
+varying float vFade;
 void main(){
   vec2 z = vec2(position.x, position.z);
+  {
+    float ex = min(position.x - uDomainBox.x, uDomainBox.y - position.x) / max(uDomainBox.y - uDomainBox.x, 1e-4);
+    float ey = min(position.z - uDomainBox.z, uDomainBox.w - position.z) / max(uDomainBox.w - uDomainBox.z, 1e-4);
+    vFade = smoothstep(0.0, 0.16, min(ex, ey));   // 0 at the perimeter → no boundary
+  }
   vec4 jit = (seed*2. - 1.) * jitterAmp;          // seed is 0 → uniform shift
   if(uJitterMode==0) z += jit.xy;
   vec2 f = applyComplex(z, functionType);
@@ -364,7 +371,9 @@ void main(){
 export const sheetFillVertexShader = vsCommon + `
 attribute vec2 cellBase;
 uniform vec2 uCellSize;
+uniform vec4 uDomainBox;   // xMin, xMax, yMin, yMax
 varying vec3 vViewPos;
+varying float vFade;
 vec3 cornerColour(vec2 zc){
   vec2 fc = applyComplex(zc, functionType);
   if(length(fc) > 1e3) fc = normalize(fc)*1e3;
@@ -372,6 +381,14 @@ vec3 cornerColour(vec2 zc){
 }
 void main(){
   vec2 z = vec2(position.x, position.z);
+  {
+    // Fade by the cell centre's distance to the domain edge so the whole
+    // rectangle dissolves together (uniform per cell → no torn perimeter).
+    vec2 c = cellBase + 0.5 * uCellSize;
+    float ex = min(c.x - uDomainBox.x, uDomainBox.y - c.x) / max(uDomainBox.y - uDomainBox.x, 1e-4);
+    float ey = min(c.y - uDomainBox.z, uDomainBox.w - c.y) / max(uDomainBox.w - uDomainBox.z, 1e-4);
+    vFade = smoothstep(0.0, 0.16, min(ex, ey));   // 0 at the perimeter → no boundary
+  }
   vec4 jit = (seed*2. - 1.) * jitterAmp;          // seed is 0 → uniform shift
   if(uJitterMode==0) z += jit.xy;
   vec2 f = applyComplex(z, functionType);
@@ -405,6 +422,7 @@ uniform float uShade;
 uniform int   uWire;
 varying vec3 vColor;
 varying vec3 vViewPos;
+varying float vFade;
 void main(){
   vec3 col = vColor;
   float alpha = opacity;
@@ -416,5 +434,7 @@ void main(){
     float shade = mix(1.0, 0.45 + 0.55*facing, clamp(uShade, 0.0, 1.0));
     col *= shade;
   }
+  alpha *= vFade;                                  // dissolve at the domain edge → no boundary
+  if(alpha < 0.003) discard;
   gl_FragColor = vec4(col, alpha);
 }`;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -281,18 +281,50 @@ vec2 chartCoord(vec2 c, int mode){
   float a = atan(c.y, c.x);
   return vec2(mode==2 ? log(r+1e-6) : r, a);
 }
+// Full surface placement of a domain point (no jitter): chart → 4-vector →
+// 4D rotation → projection → scale. The sheet shaders use this both to place
+// each vertex and to sample a cell's four corners so they can measure how far
+// the function has stretched that cell in 3D (the adaptive-density metric).
+vec3 surfacePos(vec2 zc){
+  vec2 fc = applyComplex(zc, functionType);
+  if(length(fc) > 1e3) fc = normalize(fc)*1e3;
+  vec2 zP = chartCoord(zc, uInCoord);
+  vec2 fP = chartCoord(fc, uOutCoord);
+  vec4 p4 = vec4(zP.x, zP.y, fP.x, fP.y);
+  p4 = quatRotate4D(p4, uRotL, uRotR);
+  vec3 Po = project(p4, uProjMode);
+  vec3 Pn = project(p4, uProjTarget);
+  return mix(Po, Pn, uProjAlpha) * 1.5;
+}
+// Largest deformed edge of the cell of size 'cell' whose lower-left corner is
+// 'base' — a scale-stable measure of local sparseness (big = stretched).
+float cellStretch(vec2 base, vec2 cell){
+  vec3 q00 = surfacePos(base);
+  vec3 q10 = surfacePos(base + vec2(cell.x, 0.0));
+  vec3 q01 = surfacePos(base + vec2(0.0, cell.y));
+  vec3 q11 = surfacePos(base + cell);
+  return max(max(length(q10-q00), length(q01-q00)),
+             max(length(q11-q01), length(q11-q10)));
+}
 `;
 
 // Point-cloud vertex shader: shared library + a main that places one gl_Point
 // per sampled vertex.
 export const vertexShader = vsCommon + `
+// Adaptive Sheet mode draws the point cloud and the sheet together; uCellSize +
+// uDensity let the points fade out exactly where the sheet's fill takes over, so
+// the two are complementary (points only show where the surface is stretched).
+uniform int   uAdaptive;
+uniform float uDensity;
+uniform vec2  uCellSize;
+varying float vPointKeep;
 // Jitter has two modes (uJitterMode). 0 = Scatter the sampling: perturb the
 // domain point z by the 4D seed's xy, then evaluate f there, so the particle
 // stays exactly on the graph surface of f. 1 = Fuzz the cloud: evaluate f at the
 // clean z, then add the full independent 4D offset to (x, y, Re f, Im f), pushing
 // the point off the surface on all four axes. Colour uses the effective z/f, so
 // it stays consistent in both modes.
-void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(z, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColour(z,f);}`;
+void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vec2 f = applyComplex(z, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(z, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColour(z,f);vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;}`;
 
 export const fragmentShader = `
 uniform float opacity;
@@ -300,9 +332,10 @@ uniform int   shapeType;
 uniform sampler2D tex;
 uniform int textureIndex;
 varying vec3 vColor;
+varying float vPointKeep;
 void main(){
   vec2 d = gl_PointCoord - vec2(0.5);
-  float alpha = opacity;
+  float alpha = opacity * vPointKeep;
   vec3 col = vColor;
 
   if(shapeType==0){
@@ -336,8 +369,10 @@ void main(){
 // row/column edges only — no triangle diagonals. gl_PointSize is omitted.
 export const sheetWireVertexShader = vsCommon + `
 uniform vec4 uDomainBox;   // xMin, xMax, yMin, yMax
+uniform vec2 uCellSize;    // domain units per cell (for the adaptive metric)
 varying vec3 vViewPos;
 varying float vFade;
+varying float vStretch;
 void main(){
   vec2 z = vec2(position.x, position.z);
   {
@@ -347,16 +382,12 @@ void main(){
   }
   vec4 jit = (seed*2. - 1.) * jitterAmp;          // seed is 0 → uniform shift
   if(uJitterMode==0) z += jit.xy;
+  // Sample a cell centred on this grid node so the wire fades in step with the
+  // fill where the function stretches the grid.
+  vStretch = cellStretch(z - 0.5*uCellSize, uCellSize);
   vec2 f = applyComplex(z, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
-  vec2 zPlot = chartCoord(z, uInCoord);
-  vec2 fPlot = chartCoord(f, uOutCoord);
-  vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);
-  if(uJitterMode==1) p4 += jit;
-  p4 = quatRotate4D(p4, uRotL, uRotR);
-  vec3 Pold = project(p4, uProjMode);
-  vec3 Pnew = project(p4, uProjTarget);
-  vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;
+  vec3 pos3 = surfacePos(z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
@@ -374,6 +405,7 @@ uniform vec2 uCellSize;
 uniform vec4 uDomainBox;   // xMin, xMax, yMin, yMax
 varying vec3 vViewPos;
 varying float vFade;
+varying float vStretch;
 vec3 cornerColour(vec2 zc){
   vec2 fc = applyComplex(zc, functionType);
   if(length(fc) > 1e3) fc = normalize(fc)*1e3;
@@ -391,16 +423,10 @@ void main(){
   }
   vec4 jit = (seed*2. - 1.) * jitterAmp;          // seed is 0 → uniform shift
   if(uJitterMode==0) z += jit.xy;
-  vec2 f = applyComplex(z, functionType);
-  if(length(f) > 1e3) f = normalize(f)*1e3;
-  vec2 zPlot = chartCoord(z, uInCoord);
-  vec2 fPlot = chartCoord(f, uOutCoord);
-  vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);
-  if(uJitterMode==1) p4 += jit;
-  p4 = quatRotate4D(p4, uRotL, uRotR);
-  vec3 Pold = project(p4, uProjMode);
-  vec3 Pnew = project(p4, uProjTarget);
-  vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;
+  // How far the function has stretched this cell in 3D (per-cell, uniform across
+  // its six verts since they share cellBase) → drives the adaptive fade.
+  vStretch = cellStretch(cellBase, uCellSize);
+  vec3 pos3 = surfacePos(z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
@@ -420,9 +446,12 @@ export const sheetFragmentShader = `
 uniform float opacity;
 uniform float uShade;
 uniform int   uWire;
+uniform int   uAdaptive;
+uniform float uDensity;
 varying vec3 vColor;
 varying vec3 vViewPos;
 varying float vFade;
+varying float vStretch;
 void main(){
   vec3 col = vColor;
   float alpha = opacity;
@@ -435,6 +464,11 @@ void main(){
     col *= shade;
   }
   alpha *= vFade;                                  // dissolve at the domain edge → no boundary
+  if(uAdaptive==1){
+    // Keep the sheet where the cell is dense; dissolve it where the function has
+    // stretched the cell past the threshold so the point cloud shows through.
+    alpha *= 1.0 - smoothstep(uDensity, uDensity*2.0, vStretch);
+  }
   if(alpha < 0.003) discard;
   gl_FragColor = vec4(col, alpha);
 }`;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -1,4 +1,8 @@
-export const vertexShader = `
+// Shared vertex-shader library: the 4D quaternion rotation, every complex
+// function, the projection modes, and the domain-colouring (calcColour /
+// chartCoord). Both the point-cloud and the sheet vertex shaders are built from
+// this common block + their own main(), so the two render modes stay in lockstep.
+const vsCommon = `
 // DOMAIN–COLORING VERTEX SHADER
 struct quat { float w; vec3 v; };
 
@@ -277,6 +281,11 @@ vec2 chartCoord(vec2 c, int mode){
   float a = atan(c.y, c.x);
   return vec2(mode==2 ? log(r+1e-6) : r, a);
 }
+`;
+
+// Point-cloud vertex shader: shared library + a main that places one gl_Point
+// per sampled vertex.
+export const vertexShader = vsCommon + `
 // Jitter has two modes (uJitterMode). 0 = Scatter the sampling: perturb the
 // domain point z by the 4D seed's xy, then evaluate f there, so the particle
 // stays exactly on the graph surface of f. 1 = Fuzz the cloud: evaluate f at the
@@ -318,6 +327,57 @@ void main(){
     vec4 samp = texture2D(tex, gl_PointCoord);
     col *= samp.rgb;
     alpha *= samp.a;
+  }
+  gl_FragColor = vec4(col, alpha);
+}`;
+
+// Sheet vertex shader: identical surface math to the point cloud (shared vsCommon
+// library) but stitches the regular grid into a continuous surface. It carries
+// the view-space position to the fragment shader so the fill can be shaded from
+// screen-space derivatives. gl_PointSize is omitted (meaningless for triangles).
+export const sheetVertexShader = vsCommon + `
+varying vec3 vViewPos;
+void main(){
+  vec2 z = vec2(position.x, position.z);
+  vec4 jit = (seed*2. - 1.) * jitterAmp;          // seed is 0 → uniform shift
+  if(uJitterMode==0) z += jit.xy;
+  vec2 f = applyComplex(z, functionType);
+  if(length(f) > 1e3) f = normalize(f)*1e3;
+  vec2 zPlot = chartCoord(z, uInCoord);
+  vec2 fPlot = chartCoord(f, uOutCoord);
+  vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);
+  if(uJitterMode==1) p4 += jit;
+  p4 = quatRotate4D(p4, uRotL, uRotR);
+  vec3 Pold = project(p4, uProjMode);
+  vec3 Pnew = project(p4, uProjTarget);
+  vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;
+  vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
+  vViewPos = mv.xyz;
+  gl_Position = projectionMatrix * mv;
+  vColor = calcColour(z, f);
+}`;
+
+// Sheet fragment shader: a flat translucent fill (uWire==0), shaded by the
+// facing ratio of the face normal recovered from screen-space derivatives of the
+// view-space position — so the otherwise-flat translucent surface reads as a
+// solid sheet. When uWire==1 the same mesh is drawn as a brighter, more opaque
+// wireframe overlay (no shading), so the grid lines stay legible over the fill.
+export const sheetFragmentShader = `
+uniform float opacity;
+uniform float uShade;
+uniform int   uWire;
+varying vec3 vColor;
+varying vec3 vViewPos;
+void main(){
+  vec3 col = vColor;
+  float alpha = opacity;
+  if(uWire==1){
+    alpha = clamp(opacity*1.4 + 0.25, 0.0, 1.0);
+  } else {
+    vec3 n = normalize(cross(dFdx(vViewPos), dFdy(vViewPos)));
+    float facing = abs(n.z);                       // 1 face-on, 0 edge-on
+    float shade = mix(1.0, 0.45 + 0.55*facing, clamp(uShade, 0.0, 1.0));
+    col *= shade;
   }
   gl_FragColor = vec4(col, alpha);
 }`;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -331,11 +331,10 @@ void main(){
   gl_FragColor = vec4(col, alpha);
 }`;
 
-// Sheet vertex shader: identical surface math to the point cloud (shared vsCommon
-// library) but stitches the regular grid into a continuous surface. It carries
-// the view-space position to the fragment shader so the fill can be shaded from
-// screen-space derivatives. gl_PointSize is omitted (meaningless for triangles).
-export const sheetVertexShader = vsCommon + `
+// Sheet WIREFRAME vertex shader: the shared surface math, one colour per grid
+// node (interpolated along the rectangle edges). Drawn as LineSegments of the
+// row/column edges only — no triangle diagonals. gl_PointSize is omitted.
+export const sheetWireVertexShader = vsCommon + `
 varying vec3 vViewPos;
 void main(){
   vec2 z = vec2(position.x, position.z);
@@ -355,6 +354,44 @@ void main(){
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
   vColor = calcColour(z, f);
+}`;
+
+// Sheet FILL vertex shader: same surface placement, but each rectangle gets a
+// single flat colour = the average of the domain-colouring at its four corners
+// (found from the cell's lower-left domain point `cellBase` plus `uCellSize`).
+// The geometry is non-indexed (6 verts per cell) so every vertex of a cell shares
+// that cell's `cellBase`, making the whole rectangle one colour.
+export const sheetFillVertexShader = vsCommon + `
+attribute vec2 cellBase;
+uniform vec2 uCellSize;
+varying vec3 vViewPos;
+vec3 cornerColour(vec2 zc){
+  vec2 fc = applyComplex(zc, functionType);
+  if(length(fc) > 1e3) fc = normalize(fc)*1e3;
+  return calcColour(zc, fc);
+}
+void main(){
+  vec2 z = vec2(position.x, position.z);
+  vec4 jit = (seed*2. - 1.) * jitterAmp;          // seed is 0 → uniform shift
+  if(uJitterMode==0) z += jit.xy;
+  vec2 f = applyComplex(z, functionType);
+  if(length(f) > 1e3) f = normalize(f)*1e3;
+  vec2 zPlot = chartCoord(z, uInCoord);
+  vec2 fPlot = chartCoord(f, uOutCoord);
+  vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);
+  if(uJitterMode==1) p4 += jit;
+  p4 = quatRotate4D(p4, uRotL, uRotR);
+  vec3 Pold = project(p4, uProjMode);
+  vec3 Pnew = project(p4, uProjTarget);
+  vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;
+  vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
+  vViewPos = mv.xyz;
+  gl_Position = projectionMatrix * mv;
+  vec3 c = cornerColour(cellBase)
+         + cornerColour(cellBase + vec2(uCellSize.x, 0.0))
+         + cornerColour(cellBase + vec2(0.0, uCellSize.y))
+         + cornerColour(cellBase + uCellSize);
+  vColor = c * 0.25;
 }`;
 
 // Sheet fragment shader: a flat translucent fill (uWire==0), shaded by the

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -562,3 +562,26 @@ void main(){
   vec3 col = applyExternalLight(vColor * shade, vNormalView, vViewPos, gl_FrontFacing);
   gl_FragColor = vec4(col, opacity);
 }`;
+
+// Fiber-net vertex shader: places each polar-lattice node on the surface (the
+// shared surfacePos) and colours it by the domain colouring, so the concentric
+// circles and rays show how the function carries the polar fibres of the domain.
+export const netVertexShader = vsCommon + `
+void main(){
+  vec2 z = vec2(position.x, position.z);
+  vec2 f = applyComplex(z, functionType);
+  if(length(f) > 1e3) f = normalize(f)*1e3;
+  vec3 pos3 = surfacePos(z);
+  vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
+  gl_Position = projectionMatrix * mv;
+  vColor = calcColour(z, f);
+}`;
+
+// Fiber-net fragment: the line colour, a touch brighter/opaquer so the threads
+// stay legible over the dark background.
+export const netFragmentShader = `
+uniform float opacity;
+varying vec3 vColor;
+void main(){
+  gl_FragColor = vec4(vColor, clamp(opacity*1.3 + 0.2, 0.0, 1.0));
+}`;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -456,12 +456,31 @@ void main(){
   vColor = c * 0.25;
 }`;
 
+// Shared external-light snippet: a single directional light that shades whichever
+// side of the surface faces the camera (so it reads in 3D), plus a cool/dim tint
+// on back faces so "inside" is visibly distinct from "outside". Off when uLight==0.
+const fsLighting = `
+uniform int   uLight;
+uniform float uLightStrength;
+vec3 applyExternalLight(vec3 col, vec3 N, vec3 viewPos, bool front){
+  if(uLight == 0) return col;
+  vec3 L = normalize(vec3(-0.35, 0.55, 0.75));
+  vec3 V = normalize(-viewPos);
+  if(dot(N, V) < 0.0) N = -N;                       // light the side we actually see
+  float ndl = max(dot(N, L), 0.0);
+  float lit = mix(1.0, 0.18 + 0.9*ndl, clamp(uLightStrength, 0.0, 1.0));
+  col *= lit;
+  if(!front) col = mix(col, col*vec3(0.5, 0.62, 0.95), 0.6); // inside: cooler & dimmer
+  return col;
+}
+`;
+
 // Sheet fragment shader: a flat translucent fill (uWire==0), shaded by the
 // facing ratio of the face normal recovered from screen-space derivatives of the
 // view-space position — so the otherwise-flat translucent surface reads as a
 // solid sheet. When uWire==1 the same mesh is drawn as a brighter, more opaque
 // wireframe overlay (no shading), so the grid lines stay legible over the fill.
-export const sheetFragmentShader = `
+export const sheetFragmentShader = fsLighting + `
 uniform float opacity;
 uniform float uShade;
 uniform int   uWire;
@@ -481,6 +500,7 @@ void main(){
     float facing = abs(n.z);                       // 1 face-on, 0 edge-on
     float shade = mix(1.0, 0.45 + 0.55*facing, clamp(uShade, 0.0, 1.0));
     col *= shade;
+    col = applyExternalLight(col, n, vViewPos, gl_FrontFacing);
   }
   alpha *= vFade;                                  // dissolve at the domain edge → no boundary
   if(uAdaptive==1){
@@ -503,6 +523,8 @@ attribute vec2 corner;       // ±0.5 quad corner
 uniform vec2  uCellSize;     // domain units per cell (the sample spacing)
 uniform float uMaxTile;      // max world-space half-... edge length per tile
 varying float vFacing;       // |view-space normal . z| for depth shading
+varying vec3  vNormalView;   // signed view-space normal (for external lighting)
+varying vec3  vViewPos;      // view-space position (for external lighting)
 void main(){
   vec2 z = vec2(position.x, position.z);
   vec3 c0 = surfacePos(z);
@@ -515,8 +537,10 @@ void main(){
   vec3 dvC = dv * min(1.0, uMaxTile / lv);
   vec3 pos3 = c0 + corner.x * duC + corner.y * dvC;
   vec3 nrm = normalize(cross(du, dv));
-  vFacing = abs(normalize(normalMatrix * nrm).z);
+  vNormalView = normalize(normalMatrix * nrm);
+  vFacing = abs(vNormalView.z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
+  vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
   vec2 f = applyComplex(z, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
@@ -524,13 +548,17 @@ void main(){
 }`;
 
 // Tiles fragment: flat per-tile colour with a facing-ratio shade so the faceted
-// fabric reads in 3D. Opaque (tiles occlude via the depth buffer).
-export const tileFragmentShader = `
+// fabric reads in 3D, plus the optional external light (with inside/outside tint).
+// Opaque (tiles occlude via the depth buffer).
+export const tileFragmentShader = fsLighting + `
 uniform float opacity;
 uniform float uShade;
-varying vec3 vColor;
+varying vec3  vColor;
 varying float vFacing;
+varying vec3  vNormalView;
+varying vec3  vViewPos;
 void main(){
   float shade = mix(1.0, 0.45 + 0.55*vFacing, clamp(uShade, 0.0, 1.0));
-  gl_FragColor = vec4(vColor * shade, opacity);
+  vec3 col = applyExternalLight(vColor * shade, vNormalView, vViewPos, gl_FrontFacing);
+  gl_FragColor = vec4(col, opacity);
 }`;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -472,3 +472,46 @@ void main(){
   if(alpha < 0.003) discard;
   gl_FragColor = vec4(col, alpha);
 }`;
+
+// Sheet TILES vertex shader: one oriented quad per grid sample. The node is
+// placed on the surface, then the quad is expanded along the two local deformed
+// grid directions (central differences of surfacePos over one cell) so the tile
+// is a square stretched + sheared to fit the grid. Each edge vector is clamped to
+// uMaxTile world units: below it neighbouring tiles meet edge-to-edge (a solid
+// fabric), past it they detach into a field of separated squares (the points).
+export const tileVertexShader = vsCommon + `
+attribute vec2 corner;       // ±0.5 quad corner
+uniform vec2  uCellSize;     // domain units per cell (the sample spacing)
+uniform float uMaxTile;      // max world-space half-... edge length per tile
+varying float vFacing;       // |view-space normal . z| for depth shading
+void main(){
+  vec2 z = vec2(position.x, position.z);
+  vec3 c0 = surfacePos(z);
+  // Local deformed grid directions (one cell wide), via central differences.
+  vec3 du = 0.5 * (surfacePos(z + vec2(uCellSize.x, 0.0)) - surfacePos(z - vec2(uCellSize.x, 0.0)));
+  vec3 dv = 0.5 * (surfacePos(z + vec2(0.0, uCellSize.y)) - surfacePos(z - vec2(0.0, uCellSize.y)));
+  float lu = max(length(du), 1e-6);
+  float lv = max(length(dv), 1e-6);
+  vec3 duC = du * min(1.0, uMaxTile / lu);   // clamp edge length → tiles cap, then detach
+  vec3 dvC = dv * min(1.0, uMaxTile / lv);
+  vec3 pos3 = c0 + corner.x * duC + corner.y * dvC;
+  vec3 nrm = normalize(cross(du, dv));
+  vFacing = abs(normalize(normalMatrix * nrm).z);
+  vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
+  gl_Position = projectionMatrix * mv;
+  vec2 f = applyComplex(z, functionType);
+  if(length(f) > 1e3) f = normalize(f)*1e3;
+  vColor = calcColour(z, f);                 // one flat colour per tile (shared node)
+}`;
+
+// Tiles fragment: flat per-tile colour with a facing-ratio shade so the faceted
+// fabric reads in 3D. Opaque (tiles occlude via the depth buffer).
+export const tileFragmentShader = `
+uniform float opacity;
+uniform float uShade;
+varying vec3 vColor;
+varying float vFacing;
+void main(){
+  float shade = mix(1.0, 0.45 + 0.55*vFacing, clamp(uShade, 0.0, 1.0));
+  gl_FragColor = vec4(vColor * shade, opacity);
+}`;

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -270,7 +270,8 @@ vec3 calcColour(vec2 z, vec2 f){
                    : (uColormap==4) ? 6      // Inferno
                    : (uColormap==5) ? 7      // Plasma
                    : (uColormap==6) ? 1      // Fire
-                   :                  2;     // Ocean
+                   : (uColormap==7) ? 2      // Ocean
+                   :                  uColormap; // 8.. align with palette scheme ids
         vec3 cmap = paletteColor(s * 255.0, scheme);
         cmap = mix(vec3(dot(cmap, vec3(0.3333))), cmap, saturation);
         return cmap * intensity * (1.0 + shimmerAmp*sin(time + seed.x*TAU));

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -219,6 +219,11 @@ export default function ParticleViewerShell({
             onChange={state.setSamplePattern}
           />
           <Checkbox
+            label="Reciprocal sampling (inside ↔ outside |z|=1)"
+            checked={state.reciprocal}
+            onChange={state.setReciprocal}
+          />
+          <Checkbox
             label="± symmetric bounds"
             checked={state.boundsLock}
             onChange={onBoundsLockChange}

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -12,7 +12,7 @@ import { clearPersistedState } from '../lib/usePersistentState';
 import {
   ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames, colormapNames,
   SamplePattern, samplePatternNames, JitterMode, AXIS_COLORS,
-  shapeNames, textureNames, viewTypes, motionModes, renderModes, netModeNames,
+  shapeNames, textureNames, viewTypes, motionModes, renderModes,
   useGestureRotation,
 } from '../lib/particles';
 import type { ParticleState, ViewAxis } from '../lib/particles';
@@ -486,18 +486,16 @@ export default function ParticleViewerShell({
           )}
           {state.renderMode === 'Net' && (
             <>
-              <Pills
-                label="Fibers"
-                options={netModeNames.map(m => ({ value: m, label: m }))}
-                value={state.netMode}
-                onChange={state.setNetMode}
-              />
-              {state.netMode !== 'Rays' && (
+              <Checkbox label="Circles (constant |z|)"
+                checked={state.netCircles} onChange={state.setNetCircles} />
+              {state.netCircles && (
                 <Slider label="Circles" value={state.netRings}
-                  min={1} max={60} step={1}
+                  min={1} max={250} step={1}
                   onChange={state.setNetRings} format={v => `${v}`} />
               )}
-              {state.netMode !== 'Circles' && (
+              <Checkbox label="Rays (constant arg z)"
+                checked={state.netRays} onChange={state.setNetRays} />
+              {state.netRays && (
                 <Slider label="Rays" value={state.netSpokes}
                   min={2} max={96} step={1}
                   onChange={state.setNetSpokes} format={v => `${v}`} />

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -449,6 +449,19 @@ export default function ParticleViewerShell({
               )}
             </>
           )}
+          {state.renderMode === 'Tiles' && (
+            <>
+              <Slider label="Resolution" value={state.sheetResolution}
+                min={8} max={500} step={1}
+                onChange={state.setSheetResolution} format={v => `${v}²`} />
+              <Slider label="Tile size" value={state.tileSize}
+                min={0.02} max={2} step={0.01}
+                onChange={state.setTileSize} format={v => v.toFixed(2)} />
+              <Slider label="Shading" value={state.sheetShade}
+                min={0} max={1} step={0.01}
+                onChange={state.setSheetShade} format={v => v.toFixed(2)} />
+            </>
+          )}
         </Section>
 
         <Section title="Motion" icon="〜">

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -440,6 +440,13 @@ export default function ParticleViewerShell({
               <Slider label="Shading" value={state.sheetShade}
                 min={0} max={1} step={0.01}
                 onChange={state.setSheetShade} format={v => v.toFixed(2)} />
+              <Checkbox label="Adaptive (points where stretched)"
+                checked={state.sheetAdaptive} onChange={state.setSheetAdaptive} />
+              {state.sheetAdaptive && (
+                <Slider label="Density" value={state.sheetDensity}
+                  min={0.05} max={3} step={0.05}
+                  onChange={state.setSheetDensity} format={v => v.toFixed(2)} />
+              )}
             </>
           )}
         </Section>

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -10,7 +10,7 @@ import { useResponsive } from '../styles/responsive';
 import { planes, Plane } from '../math/constants';
 import { clearPersistedState } from '../lib/usePersistentState';
 import {
-  ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames,
+  ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames, colormapNames,
   SamplePattern, samplePatternNames, JitterMode, AXIS_COLORS,
   shapeNames, textureNames, viewTypes, motionModes, renderModes,
   useGestureRotation,
@@ -385,14 +385,22 @@ export default function ParticleViewerShell({
             value={state.brightnessQuantity}
             onChange={state.setBrightnessQuantity}
           />
-          <Pills
-            label="Style"
-            options={Object.keys(ColorStyle)
-              .filter(k => isNaN(Number(k)))
-              .map(k => ({ value: ColorStyle[k as keyof typeof ColorStyle], label: k }))}
-            value={state.colourStyle}
-            onChange={state.setColourStyle}
+          <Select
+            label="Colormap"
+            options={colormapNames.map((name, i) => ({ value: i, label: name }))}
+            value={state.colormap}
+            onChange={state.setColormap}
           />
+          {state.colormap === 0 && (
+            <Pills
+              label="Style"
+              options={Object.keys(ColorStyle)
+                .filter(k => isNaN(Number(k)))
+                .map(k => ({ value: ColorStyle[k as keyof typeof ColorStyle], label: k }))}
+              value={state.colourStyle}
+              onChange={state.setColourStyle}
+            />
+          )}
           <Slider label="Hue shift" value={state.hueShift}
             min={R.hueShift.min} max={R.hueShift.max} step={R.hueShift.step}
             onChange={state.setHueShift} format={v => v.toFixed(2)} />

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -511,6 +511,12 @@ export default function ParticleViewerShell({
                   min={2} max={96} step={1}
                   onChange={state.setNetSpokes} format={v => `${v}`} />
               )}
+              <Slider label="Width" value={state.netWidth}
+                min={0.5} max={16} step={0.5}
+                onChange={state.setNetWidth} format={v => `${v.toFixed(1)}px`} />
+              <Slider label="Resolution" value={state.netResolution}
+                min={16} max={400} step={1}
+                onChange={state.setNetResolution} format={v => `${v}`} />
             </>
           )}
         </Section>

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -334,27 +334,6 @@ export default function ParticleViewerShell({
             onChange={state.setCameraZ}
             format={v => v.toFixed(1)}
           />
-          {!compact && (
-            <table className="cp-orient-matrix">
-              <thead>
-                <tr>
-                  {(['x', 'y', 'v', 'u'] as const).map(k => (
-                    <th
-                      key={k}
-                      style={{ color: `hsl(${((AXIS_COLORS[k] + state.hueShift) % 1) * 360},100%,55%)` }}
-                    >{k}</th>
-                  ))}
-                </tr>
-              </thead>
-              <tbody>
-                {state.orientationMatrix.map((row, i) => (
-                  <tr key={i}>
-                    {row.map((v, j) => <td key={j}>{fmtMatrixCell(v)}</td>)}
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          )}
         </Section>
 
         <Section title="Color" icon="◑">
@@ -368,74 +347,83 @@ export default function ParticleViewerShell({
             onChange={state.setColourBy}
           />
           <Select
-            label="Hue"
-            options={[
-              { value: ColourQuantity.Phase, label: 'Phase (arg)' },
-              { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
-              { value: ColourQuantity.Real, label: 'Real part' },
-              { value: ColourQuantity.Imag, label: 'Imag part' },
-            ]}
-            value={state.colourQuantity}
-            onChange={state.setColourQuantity}
-          />
-          <Select
-            label="Brightness"
-            options={[
-              { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
-              { value: ColourQuantity.Uniform, label: 'Uniform (flat)' },
-              { value: ColourQuantity.Phase, label: 'Phase (arg)' },
-              { value: ColourQuantity.Real, label: 'Real part' },
-              { value: ColourQuantity.Imag, label: 'Imag part' },
-            ]}
-            value={state.brightnessQuantity}
-            onChange={state.setBrightnessQuantity}
-          />
-          <Select
             label="Colormap"
             options={colormapNames.map((name, i) => ({ value: i, label: name }))}
             value={state.colormap}
             onChange={state.setColormap}
           />
-          {state.colormap > 0 && (
+          {/* Phase wheel: the cyclic HSV controls. A sequential colormap ignores
+              these (it tracks magnitude), so we hide them and show its Repeat. */}
+          {state.colormap === 0 ? (
+            <>
+              <Select
+                label="Hue"
+                options={[
+                  { value: ColourQuantity.Phase, label: 'Phase (arg)' },
+                  { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
+                  { value: ColourQuantity.Real, label: 'Real part' },
+                  { value: ColourQuantity.Imag, label: 'Imag part' },
+                ]}
+                value={state.colourQuantity}
+                onChange={state.setColourQuantity}
+              />
+              <Select
+                label="Brightness"
+                options={[
+                  { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
+                  { value: ColourQuantity.Uniform, label: 'Uniform (flat)' },
+                  { value: ColourQuantity.Phase, label: 'Phase (arg)' },
+                  { value: ColourQuantity.Real, label: 'Real part' },
+                  { value: ColourQuantity.Imag, label: 'Imag part' },
+                ]}
+                value={state.brightnessQuantity}
+                onChange={state.setBrightnessQuantity}
+              />
+              <Pills
+                label="Style"
+                options={Object.keys(ColorStyle)
+                  .filter(k => isNaN(Number(k)))
+                  .map(k => ({ value: ColorStyle[k as keyof typeof ColorStyle], label: k }))}
+                value={state.colourStyle}
+                onChange={state.setColourStyle}
+              />
+              <Slider label="Hue shift" value={state.hueShift}
+                min={R.hueShift.min} max={R.hueShift.max} step={R.hueShift.step}
+                onChange={state.setHueShift} format={v => v.toFixed(2)} />
+            </>
+          ) : (
             <Slider label="Repeat (log bands)" value={state.colorRepeat}
               min={0} max={4} step={0.05}
               onChange={state.setColorRepeat}
               format={v => v === 0 ? 'off' : v.toFixed(2)} />
           )}
-          {state.colormap === 0 && (
-            <Pills
-              label="Style"
-              options={Object.keys(ColorStyle)
-                .filter(k => isNaN(Number(k)))
-                .map(k => ({ value: ColorStyle[k as keyof typeof ColorStyle], label: k }))}
-              value={state.colourStyle}
-              onChange={state.setColourStyle}
-            />
-          )}
-          <Slider label="Hue shift" value={state.hueShift}
-            min={R.hueShift.min} max={R.hueShift.max} step={R.hueShift.step}
-            onChange={state.setHueShift} format={v => v.toFixed(2)} />
           <Slider label="Saturation" value={state.saturation}
             min={R.saturation.min} max={R.saturation.max} step={R.saturation.step}
             onChange={state.setSaturation} format={v => v.toFixed(2)} />
         </Section>
 
         <Section title="Particles" icon="✦">
-          <Slider label="Size" value={state.size}
-            min={R.size.min} max={R.size.max} step={R.size.step}
-            onChange={state.setSize} format={v => v.toFixed(1)} />
+          {state.renderMode === 'Points' && (
+            <Slider label="Size" value={state.size}
+              min={R.size.min} max={R.size.max} step={R.size.step}
+              onChange={state.setSize} format={v => v.toFixed(1)} />
+          )}
           <Slider label="Opacity" value={state.opacity}
             min={R.opacity.min} max={R.opacity.max} step={R.opacity.step}
             onChange={state.setOpacity} format={v => v.toFixed(2)} />
           <Slider label="Intensity" value={state.intensity}
             min={R.intensity.min} max={R.intensity.max} step={R.intensity.step}
             onChange={state.setIntensity} format={v => v.toFixed(2)} />
-          <Select label="Shape"
-            options={shapeNames.map((s, i) => ({ value: i, label: s }))}
-            value={state.shapeIndex} onChange={state.setShapeIndex} />
-          <Select label="Texture"
-            options={textureNames.map((t, i) => ({ value: i, label: t }))}
-            value={state.textureIndex} onChange={state.setTextureIndex} />
+          {state.renderMode === 'Points' && (
+            <>
+              <Select label="Shape"
+                options={shapeNames.map((s, i) => ({ value: i, label: s }))}
+                value={state.shapeIndex} onChange={state.setShapeIndex} />
+              <Select label="Texture"
+                options={textureNames.map((t, i) => ({ value: i, label: t }))}
+                value={state.textureIndex} onChange={state.setTextureIndex} />
+            </>
+          )}
           <Checkbox label="Light background"
             checked={state.objectMode} onChange={state.setObjectMode} />
         </Section>
@@ -553,6 +541,27 @@ export default function ParticleViewerShell({
           <Slider label="Axis width" value={state.axisWidth}
             min={R.axisWidth.min} max={R.axisWidth.max} step={R.axisWidth.step}
             onChange={state.setAxisWidth} format={v => v.toFixed(1)} />
+          {!compact && (
+            <table className="cp-orient-matrix">
+              <thead>
+                <tr>
+                  {(['x', 'y', 'v', 'u'] as const).map(k => (
+                    <th
+                      key={k}
+                      style={{ color: `hsl(${((AXIS_COLORS[k] + state.hueShift) % 1) * 360},100%,55%)` }}
+                    >{k}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {state.orientationMatrix.map((row, i) => (
+                  <tr key={i}>
+                    {row.map((v, j) => <td key={j}>{fmtMatrixCell(v)}</td>)}
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
         </Section>
 
         <Section title="About" icon="ⓘ">

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -435,7 +435,7 @@ export default function ParticleViewerShell({
               <Checkbox label="Wireframe"
                 checked={state.sheetWire} onChange={state.setSheetWire} />
               <Slider label="Resolution" value={state.sheetResolution}
-                min={8} max={200} step={1}
+                min={8} max={500} step={1}
                 onChange={state.setSheetResolution} format={v => `${v}²`} />
               <Slider label="Shading" value={state.sheetShade}
                 min={0} max={1} step={0.01}

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -455,6 +455,13 @@ export default function ParticleViewerShell({
                   min={0.05} max={3} step={0.05}
                   onChange={state.setSheetDensity} format={v => v.toFixed(2)} />
               )}
+              <Checkbox label="External light (inside/outside)"
+                checked={state.lighting} onChange={state.setLighting} />
+              {state.lighting && (
+                <Slider label="Light" value={state.lightStrength}
+                  min={0} max={1} step={0.01}
+                  onChange={state.setLightStrength} format={v => v.toFixed(2)} />
+              )}
             </>
           )}
           {state.renderMode === 'Tiles' && (
@@ -468,6 +475,13 @@ export default function ParticleViewerShell({
               <Slider label="Shading" value={state.sheetShade}
                 min={0} max={1} step={0.01}
                 onChange={state.setSheetShade} format={v => v.toFixed(2)} />
+              <Checkbox label="External light (inside/outside)"
+                checked={state.lighting} onChange={state.setLighting} />
+              {state.lighting && (
+                <Slider label="Light" value={state.lightStrength}
+                  min={0} max={1} step={0.01}
+                  onChange={state.setLightStrength} format={v => v.toFixed(2)} />
+              )}
             </>
           )}
         </Section>

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -12,7 +12,7 @@ import { clearPersistedState } from '../lib/usePersistentState';
 import {
   ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames, colormapNames,
   SamplePattern, samplePatternNames, JitterMode, AXIS_COLORS,
-  shapeNames, textureNames, viewTypes, motionModes, renderModes,
+  shapeNames, textureNames, viewTypes, motionModes, renderModes, netModeNames,
   useGestureRotation,
 } from '../lib/particles';
 import type { ParticleState, ViewAxis } from '../lib/particles';
@@ -481,6 +481,26 @@ export default function ParticleViewerShell({
                 <Slider label="Light" value={state.lightStrength}
                   min={0} max={1} step={0.01}
                   onChange={state.setLightStrength} format={v => v.toFixed(2)} />
+              )}
+            </>
+          )}
+          {state.renderMode === 'Net' && (
+            <>
+              <Pills
+                label="Fibers"
+                options={netModeNames.map(m => ({ value: m, label: m }))}
+                value={state.netMode}
+                onChange={state.setNetMode}
+              />
+              {state.netMode !== 'Rays' && (
+                <Slider label="Circles" value={state.netRings}
+                  min={1} max={60} step={1}
+                  onChange={state.setNetRings} format={v => `${v}`} />
+              )}
+              {state.netMode !== 'Circles' && (
+                <Slider label="Rays" value={state.netSpokes}
+                  min={2} max={96} step={1}
+                  onChange={state.setNetSpokes} format={v => `${v}`} />
               )}
             </>
           )}

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -12,7 +12,7 @@ import { clearPersistedState } from '../lib/usePersistentState';
 import {
   ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames,
   SamplePattern, samplePatternNames, JitterMode, AXIS_COLORS,
-  shapeNames, textureNames, viewTypes, motionModes,
+  shapeNames, textureNames, viewTypes, motionModes, renderModes,
   useGestureRotation,
 } from '../lib/particles';
 import type { ParticleState, ViewAxis } from '../lib/particles';
@@ -419,6 +419,29 @@ export default function ParticleViewerShell({
             value={state.textureIndex} onChange={state.setTextureIndex} />
           <Checkbox label="Light background"
             checked={state.objectMode} onChange={state.setObjectMode} />
+        </Section>
+
+        <Section title="Surface" icon="▥">
+          <Pills
+            label="Render"
+            options={renderModes.map(m => ({ value: m, label: m }))}
+            value={state.renderMode}
+            onChange={state.setRenderMode}
+          />
+          {state.renderMode === 'Sheet' && (
+            <>
+              <Checkbox label="Filled sheet"
+                checked={state.sheetFill} onChange={state.setSheetFill} />
+              <Checkbox label="Wireframe"
+                checked={state.sheetWire} onChange={state.setSheetWire} />
+              <Slider label="Resolution" value={state.sheetResolution}
+                min={8} max={200} step={1}
+                onChange={state.setSheetResolution} format={v => `${v}²`} />
+              <Slider label="Shading" value={state.sheetShade}
+                min={0} max={1} step={0.01}
+                onChange={state.setSheetShade} format={v => v.toFixed(2)} />
+            </>
+          )}
         </Section>
 
         <Section title="Motion" icon="〜">

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -391,6 +391,12 @@ export default function ParticleViewerShell({
             value={state.colormap}
             onChange={state.setColormap}
           />
+          {state.colormap > 0 && (
+            <Slider label="Repeat (log bands)" value={state.colorRepeat}
+              min={0} max={4} step={0.05}
+              onChange={state.setColorRepeat}
+              format={v => v === 0 ? 'off' : v.toFixed(2)} />
+          )}
           {state.colormap === 0 && (
             <Pills
               label="Style"

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -352,33 +352,35 @@ export default function ParticleViewerShell({
             value={state.colormap}
             onChange={state.setColormap}
           />
-          {/* Phase wheel: the cyclic HSV controls. A sequential colormap ignores
-              these (it tracks magnitude), so we hide them and show its Repeat. */}
+          {/* Which quantity the colour represents — drives the colormap axis, or
+              the hue of the HSV Phase wheel. */}
+          <Select
+            label="Quantity"
+            options={[
+              { value: ColourQuantity.Phase, label: 'Phase (arg)' },
+              { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
+              { value: ColourQuantity.Real, label: 'Real part' },
+              { value: ColourQuantity.Imag, label: 'Imag part' },
+            ]}
+            value={state.colourQuantity}
+            onChange={state.setColourQuantity}
+          />
+          <Select
+            label="Brightness"
+            options={[
+              { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
+              { value: ColourQuantity.Uniform, label: 'Uniform (flat)' },
+              { value: ColourQuantity.Phase, label: 'Phase (arg)' },
+              { value: ColourQuantity.Real, label: 'Real part' },
+              { value: ColourQuantity.Imag, label: 'Imag part' },
+            ]}
+            value={state.brightnessQuantity}
+            onChange={state.setBrightnessQuantity}
+          />
+          {/* Style + Hue shift only affect the HSV Phase wheel; sequential
+              colormaps show their Repeat (log bands) control instead. */}
           {state.colormap === 0 ? (
             <>
-              <Select
-                label="Hue"
-                options={[
-                  { value: ColourQuantity.Phase, label: 'Phase (arg)' },
-                  { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
-                  { value: ColourQuantity.Real, label: 'Real part' },
-                  { value: ColourQuantity.Imag, label: 'Imag part' },
-                ]}
-                value={state.colourQuantity}
-                onChange={state.setColourQuantity}
-              />
-              <Select
-                label="Brightness"
-                options={[
-                  { value: ColourQuantity.Modulus, label: 'Magnitude (|·|)' },
-                  { value: ColourQuantity.Uniform, label: 'Uniform (flat)' },
-                  { value: ColourQuantity.Phase, label: 'Phase (arg)' },
-                  { value: ColourQuantity.Real, label: 'Real part' },
-                  { value: ColourQuantity.Imag, label: 'Imag part' },
-                ]}
-                value={state.brightnessQuantity}
-                onChange={state.setBrightnessQuantity}
-              />
               <Pills
                 label="Style"
                 options={Object.keys(ColorStyle)

--- a/src/config/defaults.ts
+++ b/src/config/defaults.ts
@@ -57,7 +57,7 @@ export const COMPLEX_PARTICLES_DEFAULTS = {
     shimmer: { min: 0, max: 1, step: 0.01 },
     jitter: { min: 0, max: 0.5, step: 0.005 },
     hueShift: { min: 0, max: 1, step: 0.01 },
-    cameraZ: { min: 2, max: 50, step: 0.1 },
+    cameraZ: { min: 2, max: 200, step: 0.1 },
     axisWidth: { min: 0.5, max: 5, step: 0.1 },
     extent: { min: 1, max: 12, step: 0.5 },
     adaptiveAlpha: { min: 0, max: 3, step: 0.1 },

--- a/src/lib/colormaps.ts
+++ b/src/lib/colormaps.ts
@@ -51,6 +51,39 @@ export const PALETTE_GLSL = /* glsl */ `
     const vec3 c6=vec3(-3.658713842777788,-22.93153465461149,18.19190778539828);
     return c0+x*(c1+x*(c2+x*(c3+x*(c4+x*(c5+x*c6)))));
   }
+  // Google's Turbo, via Anton Mikhailov's polynomial approximation.
+  vec3 cmTurbo(float x){
+    const vec4 kR4=vec4(0.13572138,4.61539260,-42.66032258,132.13108234);
+    const vec4 kG4=vec4(0.09140261,2.19418839,4.84296658,-14.18503333);
+    const vec4 kB4=vec4(0.10667330,12.64194608,-60.58204836,110.36276771);
+    const vec2 kR2=vec2(-152.94239396,59.28637943);
+    const vec2 kG2=vec2(4.27729857,2.82956604);
+    const vec2 kB2=vec2(-89.90310912,27.34824973);
+    x=clamp(x,0.0,1.0);
+    vec4 v4=vec4(1.0,x,x*x,x*x*x);
+    vec2 v2=v4.zw*v4.z;
+    return vec3(dot(v4,kR4)+dot(v2,kR2), dot(v4,kG4)+dot(v2,kG2), dot(v4,kB4)+dot(v2,kB2));
+  }
+  // Dave Green's cubehelix (perceptually monotonic in brightness).
+  vec3 cmCubehelix(float x){
+    const float PI=3.14159265359;
+    float a=1.2*x*(1.0-x)/2.0;
+    float phi=2.0*PI*(0.5/3.0 - 1.5*x);
+    float cp=cos(phi), sp=sin(phi);
+    return clamp(vec3(
+      x + a*(-0.14861*cp + 1.78277*sp),
+      x + a*(-0.29227*cp - 0.90649*sp),
+      x + a*( 1.97294*cp)
+    ),0.0,1.0);
+  }
+  vec3 cmHot(float x){    return clamp(vec3(x*3.0, x*3.0-1.0, x*3.0-2.0),0.0,1.0); }
+  vec3 cmCopper(float x){ return clamp(vec3(x*1.25, x*0.7812, x*0.4975),0.0,1.0); }
+  vec3 cmCool(float x){   return clamp(vec3(x, 1.0-x, 1.0),0.0,1.0); }
+  // Blue–white–red diverging (good for signed quantities around the midpoint).
+  vec3 cmCoolWarm(float x){
+    vec3 lo=vec3(0.23,0.30,0.75), mid=vec3(0.95,0.95,0.95), hi=vec3(0.71,0.02,0.15);
+    return (x<0.5) ? mix(lo,mid,x*2.0) : mix(mid,hi,(x-0.5)*2.0);
+  }
   vec3 paletteColor(float t, int scheme){
     float x = clamp(t/255.0, 0.0, 1.0);
     if(scheme==0){
@@ -74,6 +107,18 @@ export const PALETTE_GLSL = /* glsl */ `
       return clamp(cmInferno(x),0.0,1.0);
     }else if(scheme==7){
       return clamp(cmPlasma(x),0.0,1.0);
+    }else if(scheme==8){
+      return cmTurbo(x);
+    }else if(scheme==9){
+      return cmCubehelix(x);
+    }else if(scheme==10){
+      return cmHot(x);
+    }else if(scheme==11){
+      return cmCopper(x);
+    }else if(scheme==12){
+      return cmCool(x);
+    }else if(scheme==13){
+      return cmCoolWarm(x);
     }
     return vec3(x); // 3 = Grayscale (and fallback)
   }
@@ -89,4 +134,10 @@ export const PALETTE_OPTIONS: { value: number; label: string }[] = [
   { value: 5, label: 'Magma' },
   { value: 6, label: 'Inferno' },
   { value: 7, label: 'Plasma' },
+  { value: 8, label: 'Turbo' },
+  { value: 9, label: 'Cubehelix' },
+  { value: 10, label: 'Hot' },
+  { value: 11, label: 'Copper' },
+  { value: 12, label: 'Cool' },
+  { value: 13, label: 'Cool–warm' },
 ];

--- a/src/lib/particles/createSheetGeometry.ts
+++ b/src/lib/particles/createSheetGeometry.ts
@@ -1,37 +1,104 @@
 import * as THREE from 'three';
 
-/** Build a regular (res × res cells) indexed triangle grid spanning the domain
- *  box x ∈ [xMin,xMax], z ∈ [yMin,yMax]. The vertices match the points layout
- *  (pos.x = x, pos.y = 0, pos.z = y), so the shared vertex shader maps them onto
- *  the function surface exactly as it does the point cloud — but here adjacent
- *  vertices are stitched into triangles, giving a continuous sheet (and, via
- *  `wireframe`, a grid mesh). `seed` is all-zero so any Jitter applies as a
- *  uniform translation rather than tearing the surface apart. */
+/** Cell spacing (domain units per grid cell) for a `res×res` sheet over the box
+ *  x ∈ [xMin,xMax], y ∈ [yMin,yMax]. The fill shader needs this to find a quad's
+ *  four corners from its stored lower-left `cellBase`. */
+export function sheetCellSize(
+  res: number, xMin: number, xMax: number, yMin: number, yMax: number,
+): [number, number] {
+  const cells = Math.max(1, Math.floor(res));
+  return [(xMax - xMin) / cells, (yMax - yMin) / cells];
+}
+
+/** Build the **filled** sheet: a regular grid of rectangular cells over the
+ *  domain box, each cell two triangles. The geometry is **non-indexed** (6
+ *  vertices per cell) so every vertex of a cell can carry that cell's lower-left
+ *  domain point in `cellBase` — the fill shader colours each rectangle by the
+ *  average of its four corner colours (one flat colour per cell). Vertex
+ *  positions still match the points layout (pos.x = x, pos.y = 0, pos.z = y), so
+ *  the shared surface math maps them onto the function graph exactly as the
+ *  point cloud. `seed` is zero so any Jitter shifts the sheet uniformly rather
+ *  than tearing it. */
 export function createSheetGeometry(
   res: number,
-  xMin: number = -4,
-  xMax: number = 4,
-  yMin: number = -4,
-  yMax: number = 4,
+  xMin: number = -4, xMax: number = 4, yMin: number = -4, yMax: number = 4,
 ): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
   fillSheet(geometry, res, xMin, xMax, yMin, yMax);
   return geometry;
 }
 
-/** Restamp an existing sheet geometry's buffers for a new resolution / box. */
 export function rebuildSheetGeometry(
   geometry: THREE.BufferGeometry,
   res: number,
-  xMin: number = -4,
-  xMax: number = 4,
-  yMin: number = -4,
-  yMax: number = 4,
+  xMin: number = -4, xMax: number = 4, yMin: number = -4, yMax: number = 4,
 ): void {
   fillSheet(geometry, res, xMin, xMax, yMin, yMax);
 }
 
+/** Build the **wireframe** sheet: the same grid drawn as `LineSegments` of only
+ *  the row and column edges — i.e. rectangle borders, with no triangle diagonals.
+ *  Indexed (one vertex per grid node) and uses the same shared surface math, so
+ *  the lines land exactly on the edges of the filled cells. */
+export function createSheetWireGeometry(
+  res: number,
+  xMin: number = -4, xMax: number = 4, yMin: number = -4, yMax: number = 4,
+): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+  fillSheetWire(geometry, res, xMin, xMax, yMin, yMax);
+  return geometry;
+}
+
+export function rebuildSheetWireGeometry(
+  geometry: THREE.BufferGeometry,
+  res: number,
+  xMin: number = -4, xMax: number = 4, yMin: number = -4, yMax: number = 4,
+): void {
+  fillSheetWire(geometry, res, xMin, xMax, yMin, yMax);
+}
+
 function fillSheet(
+  geometry: THREE.BufferGeometry,
+  res: number,
+  xMin: number, xMax: number, yMin: number, yMax: number,
+): void {
+  const cells = Math.max(1, Math.floor(res));
+  const [dx, dy] = sheetCellSize(cells, xMin, xMax, yMin, yMax);
+  const quadCount = cells * cells;
+  const vertCount = quadCount * 6; // two triangles per cell, non-indexed
+
+  const pos = new Float32Array(vertCount * 3);
+  const base = new Float32Array(vertCount * 2); // cell lower-left domain point
+  const seeds = new Float32Array(vertCount * 4); // zeros: jitter → uniform shift
+  const sizes = new Float32Array(vertCount).fill(1);
+
+  let v = 0;
+  const put = (x: number, y: number, bx: number, by: number) => {
+    pos[3 * v] = x; pos[3 * v + 1] = 0; pos[3 * v + 2] = y;
+    base[2 * v] = bx; base[2 * v + 1] = by;
+    v++;
+  };
+
+  for (let j = 0; j < cells; j++) {
+    const y0 = yMin + j * dy, y1 = y0 + dy;
+    for (let i = 0; i < cells; i++) {
+      const x0 = xMin + i * dx, x1 = x0 + dx;
+      // Triangle 1: (x0,y0) (x1,y0) (x1,y1)
+      put(x0, y0, x0, y0); put(x1, y0, x0, y0); put(x1, y1, x0, y0);
+      // Triangle 2: (x0,y0) (x1,y1) (x0,y1)
+      put(x0, y0, x0, y0); put(x1, y1, x0, y0); put(x0, y1, x0, y0);
+    }
+  }
+
+  geometry.setIndex(null);
+  geometry.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geometry.setAttribute('cellBase', new THREE.BufferAttribute(base, 2));
+  geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+  geometry.setAttribute('seed', new THREE.BufferAttribute(seeds, 4));
+  geometry.setDrawRange(0, vertCount);
+}
+
+function fillSheetWire(
   geometry: THREE.BufferGeometry,
   res: number,
   xMin: number, xMax: number, yMin: number, yMax: number,
@@ -42,7 +109,7 @@ function fillSheet(
   const spanX = xMax - xMin, spanY = yMax - yMin;
 
   const pos = new Float32Array(vertCount * 3);
-  const seeds = new Float32Array(vertCount * 4); // zeros: jitter → uniform shift
+  const seeds = new Float32Array(vertCount * 4);
   const sizes = new Float32Array(vertCount).fill(1);
 
   for (let j = 0; j < n; j++) {
@@ -55,17 +122,18 @@ function fillSheet(
     }
   }
 
-  // Two triangles per cell. Uint32 so high resolutions (vertices > 65535) work.
-  const index = new Uint32Array(cells * cells * 6);
+  // Only horizontal + vertical edges (rectangle borders), never diagonals.
+  const segs = 2 * n * (cells); // n rows × cells + n cols × cells
+  const index = new Uint32Array(segs * 2);
   let t = 0;
-  for (let j = 0; j < cells; j++) {
-    for (let i = 0; i < cells; i++) {
-      const a = j * n + i;
-      const b = a + 1;
-      const c = a + n;
-      const d = c + 1;
-      index[t++] = a; index[t++] = b; index[t++] = d;
-      index[t++] = a; index[t++] = d; index[t++] = c;
+  for (let j = 0; j < n; j++) {
+    for (let i = 0; i < cells; i++) {            // horizontal edges
+      index[t++] = j * n + i; index[t++] = j * n + i + 1;
+    }
+  }
+  for (let i = 0; i < n; i++) {
+    for (let j = 0; j < cells; j++) {            // vertical edges
+      index[t++] = j * n + i; index[t++] = (j + 1) * n + i;
     }
   }
 

--- a/src/lib/particles/createSheetGeometry.ts
+++ b/src/lib/particles/createSheetGeometry.ts
@@ -57,6 +57,70 @@ export function rebuildSheetWireGeometry(
   fillSheetWire(geometry, res, xMin, xMax, yMin, yMax);
 }
 
+/** Build the **tiles** geometry: one quad per grid node (a regular `(res+1)²`
+ *  lattice of sample points), each quad carrying its node's domain point in
+ *  `position` and a `corner` sign in {−0.5,+0.5}². The tile shader places the
+ *  node on the surface and expands the quad along the two local deformed grid
+ *  directions, so every tile is a square stretched + oriented to fit the grid.
+ *  Non-indexed (6 verts per tile). `seed`/`size` are zero/one as in the sheet. */
+export function createTileGeometry(
+  res: number,
+  xMin: number = -4, xMax: number = 4, yMin: number = -4, yMax: number = 4,
+): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+  fillTiles(geometry, res, xMin, xMax, yMin, yMax);
+  return geometry;
+}
+
+export function rebuildTileGeometry(
+  geometry: THREE.BufferGeometry,
+  res: number,
+  xMin: number = -4, xMax: number = 4, yMin: number = -4, yMax: number = 4,
+): void {
+  fillTiles(geometry, res, xMin, xMax, yMin, yMax);
+}
+
+function fillTiles(
+  geometry: THREE.BufferGeometry,
+  res: number,
+  xMin: number, xMax: number, yMin: number, yMax: number,
+): void {
+  const cells = Math.max(1, Math.floor(res));
+  const n = cells + 1;                 // sample nodes per side
+  const dx = (xMax - xMin) / cells, dy = (yMax - yMin) / cells;
+  const tileCount = n * n;
+  const vertCount = tileCount * 6;     // two triangles per tile, non-indexed
+
+  const pos = new Float32Array(vertCount * 3);
+  const corner = new Float32Array(vertCount * 2);
+  const seeds = new Float32Array(vertCount * 4); // zero → jitter is a uniform shift
+  const sizes = new Float32Array(vertCount).fill(1);
+
+  // The four corner signs, as two triangles.
+  const cx = [-0.5, 0.5, 0.5, -0.5, 0.5, -0.5];
+  const cy = [-0.5, -0.5, 0.5, -0.5, 0.5, 0.5];
+
+  let v = 0;
+  for (let j = 0; j < n; j++) {
+    const y = yMin + j * dy;
+    for (let i = 0; i < n; i++) {
+      const x = xMin + i * dx;
+      for (let k = 0; k < 6; k++) {
+        pos[3 * v] = x; pos[3 * v + 1] = 0; pos[3 * v + 2] = y;
+        corner[2 * v] = cx[k]; corner[2 * v + 1] = cy[k];
+        v++;
+      }
+    }
+  }
+
+  geometry.setIndex(null);
+  geometry.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geometry.setAttribute('corner', new THREE.BufferAttribute(corner, 2));
+  geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+  geometry.setAttribute('seed', new THREE.BufferAttribute(seeds, 4));
+  geometry.setDrawRange(0, vertCount);
+}
+
 function fillSheet(
   geometry: THREE.BufferGeometry,
   res: number,

--- a/src/lib/particles/createSheetGeometry.ts
+++ b/src/lib/particles/createSheetGeometry.ts
@@ -80,41 +80,41 @@ export function rebuildTileGeometry(
   fillTiles(geometry, res, xMin, xMax, yMin, yMax);
 }
 
-export type NetMode = 'Both' | 'Circles' | 'Rays';
-
 /** Build the **fiber net**: a polar lattice of line segments over the disk of
  *  radius `radius`, drawn as `LineSegments` and placed on the surface by the net
  *  vertex shader. `rings` concentric circles (constant |z|) and `spokes` rays
  *  (constant arg z) reveal how the function carries the polar fibres of the
  *  domain — circles map to one family of curves, rays to the orthogonal family.
- *  `mode` selects which families are drawn. Circles/rays are sampled finely so
- *  they stay smooth independent of how many of them there are. */
+ *  `circles`/`rays` toggle each family. Circles/rays are sampled finely so they
+ *  stay smooth independent of how many of them there are. */
 export function createNetGeometry(
-  rings: number, spokes: number, radius: number, mode: NetMode = 'Both',
+  rings: number, spokes: number, radius: number,
+  circles: boolean = true, rays: boolean = true,
 ): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
-  fillNet(geometry, rings, spokes, radius, mode);
+  fillNet(geometry, rings, spokes, radius, circles, rays);
   return geometry;
 }
 
 export function rebuildNetGeometry(
   geometry: THREE.BufferGeometry,
-  rings: number, spokes: number, radius: number, mode: NetMode = 'Both',
+  rings: number, spokes: number, radius: number,
+  circles: boolean = true, rays: boolean = true,
 ): void {
-  fillNet(geometry, rings, spokes, radius, mode);
+  fillNet(geometry, rings, spokes, radius, circles, rays);
 }
 
 function fillNet(
   geometry: THREE.BufferGeometry,
-  rings: number, spokes: number, radius: number, mode: NetMode,
+  rings: number, spokes: number, radius: number, circles: boolean, rays: boolean,
 ): void {
   const Rr = Math.max(1, Math.floor(rings));
   const Sp = Math.max(1, Math.floor(spokes));
   const TAU = Math.PI * 2;
   const circleSamples = 160;   // points around each circle (smoothness)
   const raySamples = 80;       // points along each ray (smoothness)
-  const wantCircles = mode !== 'Rays';
-  const wantRays = mode !== 'Circles';
+  const wantCircles = circles;
+  const wantRays = rays;
 
   const pos: number[] = [];
   const index: number[] = [];

--- a/src/lib/particles/createSheetGeometry.ts
+++ b/src/lib/particles/createSheetGeometry.ts
@@ -80,6 +80,81 @@ export function rebuildTileGeometry(
   fillTiles(geometry, res, xMin, xMax, yMin, yMax);
 }
 
+export type NetMode = 'Both' | 'Circles' | 'Rays';
+
+/** Build the **fiber net**: a polar lattice of line segments over the disk of
+ *  radius `radius`, drawn as `LineSegments` and placed on the surface by the net
+ *  vertex shader. `rings` concentric circles (constant |z|) and `spokes` rays
+ *  (constant arg z) reveal how the function carries the polar fibres of the
+ *  domain — circles map to one family of curves, rays to the orthogonal family.
+ *  `mode` selects which families are drawn. Circles/rays are sampled finely so
+ *  they stay smooth independent of how many of them there are. */
+export function createNetGeometry(
+  rings: number, spokes: number, radius: number, mode: NetMode = 'Both',
+): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+  fillNet(geometry, rings, spokes, radius, mode);
+  return geometry;
+}
+
+export function rebuildNetGeometry(
+  geometry: THREE.BufferGeometry,
+  rings: number, spokes: number, radius: number, mode: NetMode = 'Both',
+): void {
+  fillNet(geometry, rings, spokes, radius, mode);
+}
+
+function fillNet(
+  geometry: THREE.BufferGeometry,
+  rings: number, spokes: number, radius: number, mode: NetMode,
+): void {
+  const Rr = Math.max(1, Math.floor(rings));
+  const Sp = Math.max(1, Math.floor(spokes));
+  const TAU = Math.PI * 2;
+  const circleSamples = 160;   // points around each circle (smoothness)
+  const raySamples = 80;       // points along each ray (smoothness)
+  const wantCircles = mode !== 'Rays';
+  const wantRays = mode !== 'Circles';
+
+  const pos: number[] = [];
+  const index: number[] = [];
+  let v = 0;
+  const addVert = (x: number, y: number) => { pos.push(x, 0, y); return v++; };
+
+  if (wantCircles) {
+    for (let i = 1; i <= Rr; i++) {
+      const r = (i / Rr) * radius;
+      const first = v;
+      for (let s = 0; s < circleSamples; s++) {
+        const th = (s / circleSamples) * TAU;
+        addVert(r * Math.cos(th), r * Math.sin(th));
+      }
+      for (let s = 0; s < circleSamples; s++) {
+        index.push(first + s, first + ((s + 1) % circleSamples)); // closed loop
+      }
+    }
+  }
+  if (wantRays) {
+    for (let j = 0; j < Sp; j++) {
+      const th = (j / Sp) * TAU;
+      const ct = Math.cos(th), st = Math.sin(th);
+      const first = v;
+      for (let t = 0; t <= raySamples; t++) {
+        const r = (t / raySamples) * radius;
+        addVert(r * ct, r * st);
+      }
+      for (let t = 0; t < raySamples; t++) index.push(first + t, first + t + 1);
+    }
+  }
+
+  const n = v;
+  geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
+  geometry.setAttribute('size', new THREE.BufferAttribute(new Float32Array(n).fill(1), 1));
+  geometry.setAttribute('seed', new THREE.BufferAttribute(new Float32Array(n * 4), 4));
+  geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(index), 1));
+  geometry.setDrawRange(0, index.length);
+}
+
 function fillTiles(
   geometry: THREE.BufferGeometry,
   res: number,

--- a/src/lib/particles/createSheetGeometry.ts
+++ b/src/lib/particles/createSheetGeometry.ts
@@ -80,75 +80,88 @@ export function rebuildTileGeometry(
   fillTiles(geometry, res, xMin, xMax, yMin, yMax);
 }
 
-/** Build the **fiber net**: a polar lattice of line segments over the disk of
- *  radius `radius`, drawn as `LineSegments` and placed on the surface by the net
- *  vertex shader. `rings` concentric circles (constant |z|) and `spokes` rays
- *  (constant arg z) reveal how the function carries the polar fibres of the
- *  domain — circles map to one family of curves, rays to the orthogonal family.
- *  `circles`/`rays` toggle each family. Circles/rays are sampled finely so they
- *  stay smooth independent of how many of them there are. */
+/** Build the **fiber net**: a polar lattice over the disk of radius `radius`,
+ *  built as **screen-space ribbons** (each segment a camera-facing quad) so the
+ *  net vertex shader can give it a real, controllable pixel width. `rings`
+ *  concentric circles (constant |z|) and `spokes` rays (constant arg z) reveal
+ *  how the function carries the polar fibres of the domain. `circles`/`rays`
+ *  toggle each family; `resolution` is the sample count along each curve.
+ *  Each vertex stores its anchor point in `position`, the segment's other end in
+ *  `aOther`, and a `aSide` ±1; the shader offsets it perpendicular to the segment
+ *  in screen space. */
 export function createNetGeometry(
   rings: number, spokes: number, radius: number,
-  circles: boolean = true, rays: boolean = true,
+  circles: boolean = true, rays: boolean = true, resolution: number = 128,
 ): THREE.BufferGeometry {
   const geometry = new THREE.BufferGeometry();
-  fillNet(geometry, rings, spokes, radius, circles, rays);
+  fillNet(geometry, rings, spokes, radius, circles, rays, resolution);
   return geometry;
 }
 
 export function rebuildNetGeometry(
   geometry: THREE.BufferGeometry,
   rings: number, spokes: number, radius: number,
-  circles: boolean = true, rays: boolean = true,
+  circles: boolean = true, rays: boolean = true, resolution: number = 128,
 ): void {
-  fillNet(geometry, rings, spokes, radius, circles, rays);
+  fillNet(geometry, rings, spokes, radius, circles, rays, resolution);
 }
 
 function fillNet(
   geometry: THREE.BufferGeometry,
-  rings: number, spokes: number, radius: number, circles: boolean, rays: boolean,
+  rings: number, spokes: number, radius: number,
+  circles: boolean, rays: boolean, resolution: number,
 ): void {
   const Rr = Math.max(1, Math.floor(rings));
   const Sp = Math.max(1, Math.floor(spokes));
   const TAU = Math.PI * 2;
-  const circleSamples = 160;   // points around each circle (smoothness)
-  const raySamples = 80;       // points along each ray (smoothness)
-  const wantCircles = circles;
-  const wantRays = rays;
+  const circleSamples = Math.max(8, Math.floor(resolution));
+  const raySamples = Math.max(4, Math.floor(resolution / 2));
 
   const pos: number[] = [];
+  const other: number[] = [];
+  const side: number[] = [];
   const index: number[] = [];
   let v = 0;
-  const addVert = (x: number, y: number) => { pos.push(x, 0, y); return v++; };
+  const addVert = (ax: number, ay: number, ox: number, oy: number, s: number) => {
+    pos.push(ax, 0, ay); other.push(ox, oy); side.push(s); return v++;
+  };
+  // One ribbon quad per segment a→b: two anchored at a, two at b, sides ±1.
+  const addSegment = (ax: number, ay: number, bx: number, by: number) => {
+    // At the b end the segment direction is reversed, so the side sign is flipped
+    // there to keep both edges of the ribbon on the same physical side (no twist).
+    const i0 = addVert(ax, ay, bx, by, -1); // a, physical −
+    const i1 = addVert(ax, ay, bx, by, 1);  // a, physical +
+    const i2 = addVert(bx, by, ax, ay, -1); // b, physical +
+    const i3 = addVert(bx, by, ax, ay, 1);  // b, physical −
+    index.push(i0, i1, i2, i0, i2, i3);
+  };
 
-  if (wantCircles) {
+  if (circles) {
     for (let i = 1; i <= Rr; i++) {
       const r = (i / Rr) * radius;
-      const first = v;
       for (let s = 0; s < circleSamples; s++) {
-        const th = (s / circleSamples) * TAU;
-        addVert(r * Math.cos(th), r * Math.sin(th));
-      }
-      for (let s = 0; s < circleSamples; s++) {
-        index.push(first + s, first + ((s + 1) % circleSamples)); // closed loop
+        const th0 = (s / circleSamples) * TAU;
+        const th1 = ((s + 1) / circleSamples) * TAU;
+        addSegment(r * Math.cos(th0), r * Math.sin(th0), r * Math.cos(th1), r * Math.sin(th1));
       }
     }
   }
-  if (wantRays) {
+  if (rays) {
     for (let j = 0; j < Sp; j++) {
       const th = (j / Sp) * TAU;
       const ct = Math.cos(th), st = Math.sin(th);
-      const first = v;
-      for (let t = 0; t <= raySamples; t++) {
-        const r = (t / raySamples) * radius;
-        addVert(r * ct, r * st);
+      for (let t = 0; t < raySamples; t++) {
+        const r0 = (t / raySamples) * radius;
+        const r1 = ((t + 1) / raySamples) * radius;
+        addSegment(r0 * ct, r0 * st, r1 * ct, r1 * st);
       }
-      for (let t = 0; t < raySamples; t++) index.push(first + t, first + t + 1);
     }
   }
 
   const n = v;
   geometry.setAttribute('position', new THREE.BufferAttribute(new Float32Array(pos), 3));
+  geometry.setAttribute('aOther', new THREE.BufferAttribute(new Float32Array(other), 2));
+  geometry.setAttribute('aSide', new THREE.BufferAttribute(new Float32Array(side), 1));
   geometry.setAttribute('size', new THREE.BufferAttribute(new Float32Array(n).fill(1), 1));
   geometry.setAttribute('seed', new THREE.BufferAttribute(new Float32Array(n * 4), 4));
   geometry.setIndex(new THREE.BufferAttribute(new Uint32Array(index), 1));

--- a/src/lib/particles/createSheetGeometry.ts
+++ b/src/lib/particles/createSheetGeometry.ts
@@ -1,0 +1,77 @@
+import * as THREE from 'three';
+
+/** Build a regular (res × res cells) indexed triangle grid spanning the domain
+ *  box x ∈ [xMin,xMax], z ∈ [yMin,yMax]. The vertices match the points layout
+ *  (pos.x = x, pos.y = 0, pos.z = y), so the shared vertex shader maps them onto
+ *  the function surface exactly as it does the point cloud — but here adjacent
+ *  vertices are stitched into triangles, giving a continuous sheet (and, via
+ *  `wireframe`, a grid mesh). `seed` is all-zero so any Jitter applies as a
+ *  uniform translation rather than tearing the surface apart. */
+export function createSheetGeometry(
+  res: number,
+  xMin: number = -4,
+  xMax: number = 4,
+  yMin: number = -4,
+  yMax: number = 4,
+): THREE.BufferGeometry {
+  const geometry = new THREE.BufferGeometry();
+  fillSheet(geometry, res, xMin, xMax, yMin, yMax);
+  return geometry;
+}
+
+/** Restamp an existing sheet geometry's buffers for a new resolution / box. */
+export function rebuildSheetGeometry(
+  geometry: THREE.BufferGeometry,
+  res: number,
+  xMin: number = -4,
+  xMax: number = 4,
+  yMin: number = -4,
+  yMax: number = 4,
+): void {
+  fillSheet(geometry, res, xMin, xMax, yMin, yMax);
+}
+
+function fillSheet(
+  geometry: THREE.BufferGeometry,
+  res: number,
+  xMin: number, xMax: number, yMin: number, yMax: number,
+): void {
+  const cells = Math.max(1, Math.floor(res));
+  const n = cells + 1;            // vertices per side
+  const vertCount = n * n;
+  const spanX = xMax - xMin, spanY = yMax - yMin;
+
+  const pos = new Float32Array(vertCount * 3);
+  const seeds = new Float32Array(vertCount * 4); // zeros: jitter → uniform shift
+  const sizes = new Float32Array(vertCount).fill(1);
+
+  for (let j = 0; j < n; j++) {
+    const y = yMin + (j / cells) * spanY;
+    for (let i = 0; i < n; i++) {
+      const k = j * n + i;
+      pos[3 * k] = xMin + (i / cells) * spanX;
+      pos[3 * k + 1] = 0;
+      pos[3 * k + 2] = y;
+    }
+  }
+
+  // Two triangles per cell. Uint32 so high resolutions (vertices > 65535) work.
+  const index = new Uint32Array(cells * cells * 6);
+  let t = 0;
+  for (let j = 0; j < cells; j++) {
+    for (let i = 0; i < cells; i++) {
+      const a = j * n + i;
+      const b = a + 1;
+      const c = a + n;
+      const d = c + 1;
+      index[t++] = a; index[t++] = b; index[t++] = d;
+      index[t++] = a; index[t++] = d; index[t++] = c;
+    }
+  }
+
+  geometry.setAttribute('position', new THREE.BufferAttribute(pos, 3));
+  geometry.setAttribute('size', new THREE.BufferAttribute(sizes, 1));
+  geometry.setAttribute('seed', new THREE.BufferAttribute(seeds, 4));
+  geometry.setIndex(new THREE.BufferAttribute(index, 1));
+  geometry.setDrawRange(0, index.length);
+}

--- a/src/lib/particles/index.ts
+++ b/src/lib/particles/index.ts
@@ -6,7 +6,10 @@ export type { ViewAxis } from './useViewControls';
 export { useGestureRotation } from './useGestureRotation';
 export { createParticleGeometry, rebuildGeometryBuffers, redistributeAdaptive } from './createParticleGeometry';
 export type { AdaptiveOptions } from './createParticleGeometry';
-export { createSheetGeometry, rebuildSheetGeometry } from './createSheetGeometry';
+export {
+  createSheetGeometry, rebuildSheetGeometry,
+  createSheetWireGeometry, rebuildSheetWireGeometry, sheetCellSize,
+} from './createSheetGeometry';
 export { createAxes, AXIS_LENGTH } from './createAxes';
 export { createHopfScaffold } from './createHopfScaffold';
 export type { HopfScaffold } from './createHopfScaffold';

--- a/src/lib/particles/index.ts
+++ b/src/lib/particles/index.ts
@@ -20,7 +20,7 @@ export { startAnimationLoop } from './createAnimationLoop';
 export type { AnimationLoopDeps } from './createAnimationLoop';
 export type { ViewPoint, Axis } from './types';
 export {
-  ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames,
+  ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames, colormapNames,
   SamplePattern, samplePatternNames, JitterMode, renderModes,
   shapeNames, textureNames, viewTypes, motionModes, dropModes, AXIS_COLORS,
 } from './types';

--- a/src/lib/particles/index.ts
+++ b/src/lib/particles/index.ts
@@ -10,7 +10,9 @@ export {
   createSheetGeometry, rebuildSheetGeometry,
   createSheetWireGeometry, rebuildSheetWireGeometry, sheetCellSize,
   createTileGeometry, rebuildTileGeometry,
+  createNetGeometry, rebuildNetGeometry,
 } from './createSheetGeometry';
+export type { NetMode } from './createSheetGeometry';
 export { createAxes, AXIS_LENGTH } from './createAxes';
 export { createHopfScaffold } from './createHopfScaffold';
 export type { HopfScaffold } from './createHopfScaffold';
@@ -21,7 +23,7 @@ export type { AnimationLoopDeps } from './createAnimationLoop';
 export type { ViewPoint, Axis } from './types';
 export {
   ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames, colormapNames,
-  SamplePattern, samplePatternNames, JitterMode, renderModes,
+  SamplePattern, samplePatternNames, JitterMode, renderModes, netModeNames,
   shapeNames, textureNames, viewTypes, motionModes, dropModes, AXIS_COLORS,
 } from './types';
 export type { RenderMode } from './types';

--- a/src/lib/particles/index.ts
+++ b/src/lib/particles/index.ts
@@ -12,7 +12,6 @@ export {
   createTileGeometry, rebuildTileGeometry,
   createNetGeometry, rebuildNetGeometry,
 } from './createSheetGeometry';
-export type { NetMode } from './createSheetGeometry';
 export { createAxes, AXIS_LENGTH } from './createAxes';
 export { createHopfScaffold } from './createHopfScaffold';
 export type { HopfScaffold } from './createHopfScaffold';
@@ -23,7 +22,7 @@ export type { AnimationLoopDeps } from './createAnimationLoop';
 export type { ViewPoint, Axis } from './types';
 export {
   ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames, colormapNames,
-  SamplePattern, samplePatternNames, JitterMode, renderModes, netModeNames,
+  SamplePattern, samplePatternNames, JitterMode, renderModes,
   shapeNames, textureNames, viewTypes, motionModes, dropModes, AXIS_COLORS,
 } from './types';
 export type { RenderMode } from './types';

--- a/src/lib/particles/index.ts
+++ b/src/lib/particles/index.ts
@@ -9,6 +9,7 @@ export type { AdaptiveOptions } from './createParticleGeometry';
 export {
   createSheetGeometry, rebuildSheetGeometry,
   createSheetWireGeometry, rebuildSheetWireGeometry, sheetCellSize,
+  createTileGeometry, rebuildTileGeometry,
 } from './createSheetGeometry';
 export { createAxes, AXIS_LENGTH } from './createAxes';
 export { createHopfScaffold } from './createHopfScaffold';

--- a/src/lib/particles/index.ts
+++ b/src/lib/particles/index.ts
@@ -6,6 +6,7 @@ export type { ViewAxis } from './useViewControls';
 export { useGestureRotation } from './useGestureRotation';
 export { createParticleGeometry, rebuildGeometryBuffers, redistributeAdaptive } from './createParticleGeometry';
 export type { AdaptiveOptions } from './createParticleGeometry';
+export { createSheetGeometry, rebuildSheetGeometry } from './createSheetGeometry';
 export { createAxes, AXIS_LENGTH } from './createAxes';
 export { createHopfScaffold } from './createHopfScaffold';
 export type { HopfScaffold } from './createHopfScaffold';
@@ -16,6 +17,7 @@ export type { AnimationLoopDeps } from './createAnimationLoop';
 export type { ViewPoint, Axis } from './types';
 export {
   ColorStyle, ColourBy, ColourQuantity, CoordMode, coordModeNames,
-  SamplePattern, samplePatternNames, JitterMode,
+  SamplePattern, samplePatternNames, JitterMode, renderModes,
   shapeNames, textureNames, viewTypes, motionModes, dropModes, AXIS_COLORS,
 } from './types';
+export type { RenderMode } from './types';

--- a/src/lib/particles/types.ts
+++ b/src/lib/particles/types.ts
@@ -49,6 +49,7 @@ export const coordModeNames = ['Cartesian', 'Polar', 'Log-polar'] as const;
  *  (Viridis…Plasma) and a few extras, suitable for reading |z| / |f| as height. */
 export const colormapNames = [
   'Phase wheel', 'Grayscale', 'Viridis', 'Magma', 'Inferno', 'Plasma', 'Fire', 'Ocean',
+  'Turbo', 'Cubehelix', 'Hot', 'Copper', 'Cool', 'Cool–warm',
 ] as const;
 
 /** How the domain points are laid out before f is applied. Radial patterns

--- a/src/lib/particles/types.ts
+++ b/src/lib/particles/types.ts
@@ -87,10 +87,13 @@ export const viewTypes = [
 export const motionModes = ['Quaternion', 'Fixed'] as const;
 export const dropModes = ['None', 'DropX', 'DropY', 'DropU', 'DropV'] as const;
 
-/** How the sampled surface is drawn: a cloud of point particles, or a single
+/** How the sampled surface is drawn: a cloud of point particles, a single
  *  continuous translucent sheet (a wireframe/filled triangle mesh over a regular
- *  grid). Sheet mode ignores the sampling pattern and uses its own resolution. */
-export const renderModes = ['Points', 'Sheet'] as const;
+ *  grid), or Tiles — one oriented quad per grid sample, stretched along the local
+ *  deformation and capped at a maximum size, so dense regions form a solid fabric
+ *  and stretched regions tear apart into a field of separated tiles (points).
+ *  Sheet/Tiles ignore the sampling pattern and use their own resolution. */
+export const renderModes = ['Points', 'Sheet', 'Tiles'] as const;
 export type RenderMode = (typeof renderModes)[number];
 
 export const AXIS_COLORS = {

--- a/src/lib/particles/types.ts
+++ b/src/lib/particles/types.ts
@@ -87,6 +87,12 @@ export const viewTypes = [
 export const motionModes = ['Quaternion', 'Fixed'] as const;
 export const dropModes = ['None', 'DropX', 'DropY', 'DropU', 'DropV'] as const;
 
+/** How the sampled surface is drawn: a cloud of point particles, or a single
+ *  continuous translucent sheet (a wireframe/filled triangle mesh over a regular
+ *  grid). Sheet mode ignores the sampling pattern and uses its own resolution. */
+export const renderModes = ['Points', 'Sheet'] as const;
+export type RenderMode = (typeof renderModes)[number];
+
 export const AXIS_COLORS = {
   x: 0,
   y: 0.25,

--- a/src/lib/particles/types.ts
+++ b/src/lib/particles/types.ts
@@ -104,9 +104,6 @@ export const dropModes = ['None', 'DropX', 'DropY', 'DropU', 'DropV'] as const;
 export const renderModes = ['Points', 'Sheet', 'Tiles', 'Net'] as const;
 export type RenderMode = (typeof renderModes)[number];
 
-/** Which families of the polar fibre net to draw in Net mode. */
-export const netModeNames = ['Both', 'Circles', 'Rays'] as const;
-
 export const AXIS_COLORS = {
   x: 0,
   y: 0.25,

--- a/src/lib/particles/types.ts
+++ b/src/lib/particles/types.ts
@@ -43,6 +43,14 @@ export enum CoordMode {
 
 export const coordModeNames = ['Cartesian', 'Polar', 'Log-polar'] as const;
 
+/** Colour palette applied to the chosen quantity. 'Phase wheel' (index 0) keeps
+ *  the cyclic HSV domain-colouring (driven by the Hue/Style controls); the rest
+ *  are sequential ramps mapped to **magnitude** — the perceptual matplotlib maps
+ *  (Viridis…Plasma) and a few extras, suitable for reading |z| / |f| as height. */
+export const colormapNames = [
+  'Phase wheel', 'Grayscale', 'Viridis', 'Magma', 'Inferno', 'Plasma', 'Fire', 'Ocean',
+] as const;
+
 /** How the domain points are laid out before f is applied. Radial patterns
  *  sample a disk (radius = max half-extent, centred on the domain box); Grid /
  *  Squares / Random use the rectangular box. Polar spreads points evenly in

--- a/src/lib/particles/types.ts
+++ b/src/lib/particles/types.ts
@@ -101,8 +101,11 @@ export const dropModes = ['None', 'DropX', 'DropY', 'DropU', 'DropV'] as const;
  *  deformation and capped at a maximum size, so dense regions form a solid fabric
  *  and stretched regions tear apart into a field of separated tiles (points).
  *  Sheet/Tiles ignore the sampling pattern and use their own resolution. */
-export const renderModes = ['Points', 'Sheet', 'Tiles'] as const;
+export const renderModes = ['Points', 'Sheet', 'Tiles', 'Net'] as const;
 export type RenderMode = (typeof renderModes)[number];
+
+/** Which families of the polar fibre net to draw in Net mode. */
+export const netModeNames = ['Both', 'Circles', 'Rays'] as const;
 
 export const AXIS_COLORS = {
   x: 0,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -83,6 +83,12 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // Faceted shading strength on the filled sheet (0 = flat colour, 1 = full
   // facing-ratio shading) — gives the translucent surface depth cues.
   const [sheetShade, setSheetShade] = usePersistentState(pk('sheetShade'), 0.6);
+  // Adaptive density: where the function stretches the grid so a cell's deformed
+  // size in 3D exceeds `sheetDensity`, the fill/wire dissolves and the underlying
+  // point cloud shows through — so dense regions read as a solid sheet and sparse
+  // (stretched) regions fall back to points. Off → a uniform sheet everywhere.
+  const [sheetAdaptive, setSheetAdaptive] = usePersistentState(pk('sheetAdaptive'), true);
+  const [sheetDensity, setSheetDensity] = usePersistentState(pk('sheetDensity'), 0.6);
   const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
   const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
@@ -213,6 +219,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     sheetWire, setSheetWire,
     sheetResolution, setSheetResolution,
     sheetShade, setSheetShade,
+    sheetAdaptive, setSheetAdaptive,
+    sheetDensity, setSheetDensity,
     objectMode, setObjectMode,
     shapeIndex, setShapeIndex,
     textureIndex, setTextureIndex,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -108,6 +108,9 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   const [netSpokes, setNetSpokes] = usePersistentState(pk('netSpokes'), 24);
   const [netCircles, setNetCircles] = usePersistentState(pk('netCircles'), true);
   const [netRays, setNetRays] = usePersistentState(pk('netRays'), false);
+  // Net thread width (px, screen-space ribbons) and per-curve sample count.
+  const [netWidth, setNetWidth] = usePersistentState(pk('netWidth'), 2.5);
+  const [netResolution, setNetResolution] = usePersistentState(pk('netResolution'), 128);
   const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
   const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
@@ -253,6 +256,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     netSpokes, setNetSpokes,
     netCircles, setNetCircles,
     netRays, setNetRays,
+    netWidth, setNetWidth,
+    netResolution, setNetResolution,
     lighting, setLighting,
     lightStrength, setLightStrength,
     objectMode, setObjectMode,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -113,6 +113,9 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // colormaps mapped to magnitude (Grayscale / Viridis / Magma / Inferno / Plasma /
   // Fire / Ocean), for reading |z| / |f|.
   const [colormap, setColormap] = usePersistentState(pk('colormap'), 0);
+  // Sequential-colormap scale: 0 = one smooth saturating sweep over log-magnitude;
+  // >0 = repeat the colormap that many cycles per e-fold of |·| (log-spaced bands).
+  const [colorRepeat, setColorRepeat] = usePersistentState(pk('colorRepeat'), 0);
   const [colourBy, setColourBy] = usePersistentState<ColourBy>(pk('colourBy'), ColourBy.Domain);
   // Which scalar of the chosen source drives the colour wheel (hue). Phase keeps
   // the classic domain-colouring look; Modulus colours by |z| / |f|, etc.
@@ -253,6 +256,7 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     realView, setRealView,
     colourStyle, setColourStyle,
     colormap, setColormap,
+    colorRepeat, setColorRepeat,
     colourBy, setColourBy,
     colourQuantity, setColourQuantity,
     brightnessQuantity, setBrightnessQuantity,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -83,6 +83,11 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // Faceted shading strength on the filled sheet (0 = flat colour, 1 = full
   // facing-ratio shading) — gives the translucent surface depth cues.
   const [sheetShade, setSheetShade] = usePersistentState(pk('sheetShade'), 0.6);
+  // External directional light for Sheet/Tiles: lights the side you're facing so
+  // the surface reads in 3D, and tints back faces cooler/dimmer so you can tell
+  // "inside" from "outside" of the surface. `lightStrength` blends flat→fully lit.
+  const [lighting, setLighting] = usePersistentState(pk('lighting'), false);
+  const [lightStrength, setLightStrength] = usePersistentState(pk('lightStrength'), 0.7);
   // Adaptive density: where the function stretches the grid so a cell's deformed
   // size in 3D exceeds `sheetDensity`, the fill/wire dissolves and the underlying
   // point cloud shows through — so dense regions read as a solid sheet and sparse
@@ -230,6 +235,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     sheetAdaptive, setSheetAdaptive,
     sheetDensity, setSheetDensity,
     tileSize, setTileSize,
+    lighting, setLighting,
+    lightStrength, setLightStrength,
     objectMode, setObjectMode,
     shapeIndex, setShapeIndex,
     textureIndex, setTextureIndex,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -4,7 +4,6 @@ import { ProjectionMode } from '../viewpoint';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import { usePersistentState } from '../usePersistentState';
 import { ViewPoint, ColorStyle, ColourBy, ColourQuantity, CoordMode, SamplePattern, JitterMode, Axis, motionModes, dropModes, RenderMode } from './types';
-import type { NetMode } from './createSheetGeometry';
 
 export interface UseParticleStateOptions {
   count?: number;
@@ -100,10 +99,11 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // it they detach into a field of separated squares (the "points").
   const [tileSize, setTileSize] = usePersistentState(pk('tileSize'), 0.35);
   // Net mode: a polar fibre net — `netRings` concentric circles (constant |z|)
-  // and `netSpokes` rays (constant arg z); `netMode` selects which families show.
+  // and `netSpokes` rays (constant arg z); each family toggles independently.
   const [netRings, setNetRings] = usePersistentState(pk('netRings'), 14);
   const [netSpokes, setNetSpokes] = usePersistentState(pk('netSpokes'), 24);
-  const [netMode, setNetMode] = usePersistentState<NetMode>(pk('netMode'), 'Both');
+  const [netCircles, setNetCircles] = usePersistentState(pk('netCircles'), true);
+  const [netRays, setNetRays] = usePersistentState(pk('netRays'), false);
   const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
   const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
@@ -243,7 +243,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     tileSize, setTileSize,
     netRings, setNetRings,
     netSpokes, setNetSpokes,
-    netMode, setNetMode,
+    netCircles, setNetCircles,
+    netRays, setNetRays,
     lighting, setLighting,
     lightStrength, setLightStrength,
     objectMode, setObjectMode,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -3,7 +3,7 @@ import * as THREE from 'three';
 import { ProjectionMode } from '../viewpoint';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import { usePersistentState } from '../usePersistentState';
-import { ViewPoint, ColorStyle, ColourBy, ColourQuantity, CoordMode, SamplePattern, JitterMode, Axis, motionModes, dropModes } from './types';
+import { ViewPoint, ColorStyle, ColourBy, ColourQuantity, CoordMode, SamplePattern, JitterMode, Axis, motionModes, dropModes, RenderMode } from './types';
 
 export interface UseParticleStateOptions {
   count?: number;
@@ -70,6 +70,19 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   const [adaptive, setAdaptive] = usePersistentState(pk('adaptive'), COMPLEX_PARTICLES_DEFAULTS.initial.adaptive);
   /** Exponent biasing strength for adaptive sampling. */
   const [adaptiveAlpha, setAdaptiveAlpha] = usePersistentState(pk('adaptiveAlpha'), COMPLEX_PARTICLES_DEFAULTS.initial.adaptiveAlpha);
+  // ---- Surface (sheet) rendering ----
+  // Draw the sampled surface as a point cloud ('Points', default) or as a single
+  // continuous translucent sheet ('Sheet') built from a regular triangle grid.
+  const [renderMode, setRenderMode] = usePersistentState<RenderMode>(pk('renderMode'), 'Points');
+  // In Sheet mode: show the translucent filled surface and/or the wireframe grid.
+  const [sheetFill, setSheetFill] = usePersistentState(pk('sheetFill'), true);
+  const [sheetWire, setSheetWire] = usePersistentState(pk('sheetWire'), true);
+  // Grid resolution (cells per side) of the sheet mesh — independent of the
+  // particle count, since a sheet needs regular grid topology.
+  const [sheetResolution, setSheetResolution] = usePersistentState(pk('sheetResolution'), 80);
+  // Faceted shading strength on the filled sheet (0 = flat colour, 1 = full
+  // facing-ratio shading) — gives the translucent surface depth cues.
+  const [sheetShade, setSheetShade] = usePersistentState(pk('sheetShade'), 0.6);
   const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
   const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
@@ -195,6 +208,11 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     samplePattern, setSamplePattern,
     adaptive, setAdaptive,
     adaptiveAlpha, setAdaptiveAlpha,
+    renderMode, setRenderMode,
+    sheetFill, setSheetFill,
+    sheetWire, setSheetWire,
+    sheetResolution, setSheetResolution,
+    sheetShade, setSheetShade,
     objectMode, setObjectMode,
     shapeIndex, setShapeIndex,
     textureIndex, setTextureIndex,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -4,6 +4,7 @@ import { ProjectionMode } from '../viewpoint';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
 import { usePersistentState } from '../usePersistentState';
 import { ViewPoint, ColorStyle, ColourBy, ColourQuantity, CoordMode, SamplePattern, JitterMode, Axis, motionModes, dropModes, RenderMode } from './types';
+import type { NetMode } from './createSheetGeometry';
 
 export interface UseParticleStateOptions {
   count?: number;
@@ -98,6 +99,11 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // with the local cell. Below it tiles meet edge-to-edge (a solid fabric); past
   // it they detach into a field of separated squares (the "points").
   const [tileSize, setTileSize] = usePersistentState(pk('tileSize'), 0.35);
+  // Net mode: a polar fibre net — `netRings` concentric circles (constant |z|)
+  // and `netSpokes` rays (constant arg z); `netMode` selects which families show.
+  const [netRings, setNetRings] = usePersistentState(pk('netRings'), 14);
+  const [netSpokes, setNetSpokes] = usePersistentState(pk('netSpokes'), 24);
+  const [netMode, setNetMode] = usePersistentState<NetMode>(pk('netMode'), 'Both');
   const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
   const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
@@ -235,6 +241,9 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     sheetAdaptive, setSheetAdaptive,
     sheetDensity, setSheetDensity,
     tileSize, setTileSize,
+    netRings, setNetRings,
+    netSpokes, setNetSpokes,
+    netMode, setNetMode,
     lighting, setLighting,
     lightStrength, setLightStrength,
     objectMode, setObjectMode,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -98,6 +98,10 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
   const [realView, setRealView] = useState(false);
   const [colourStyle, setColourStyle] = usePersistentState<ColorStyle>(pk('colourStyle'), ColorStyle.HSV);
+  // Palette: 0 = Phase wheel (HSV domain colouring, the default); 1..7 = sequential
+  // colormaps mapped to magnitude (Grayscale / Viridis / Magma / Inferno / Plasma /
+  // Fire / Ocean), for reading |z| / |f|.
+  const [colormap, setColormap] = usePersistentState(pk('colormap'), 0);
   const [colourBy, setColourBy] = usePersistentState<ColourBy>(pk('colourBy'), ColourBy.Domain);
   // Which scalar of the chosen source drives the colour wheel (hue). Phase keeps
   // the classic domain-colouring look; Modulus colours by |z| / |f|, etc.
@@ -231,6 +235,7 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     textureIndex, setTextureIndex,
     realView, setRealView,
     colourStyle, setColourStyle,
+    colormap, setColormap,
     colourBy, setColourBy,
     colourQuantity, setColourQuantity,
     brightnessQuantity, setBrightnessQuantity,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -89,6 +89,10 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // (stretched) regions fall back to points. Off → a uniform sheet everywhere.
   const [sheetAdaptive, setSheetAdaptive] = usePersistentState(pk('sheetAdaptive'), true);
   const [sheetDensity, setSheetDensity] = usePersistentState(pk('sheetDensity'), 0.6);
+  // Tiles mode: maximum world-space edge length of a tile before it stops growing
+  // with the local cell. Below it tiles meet edge-to-edge (a solid fabric); past
+  // it they detach into a field of separated squares (the "points").
+  const [tileSize, setTileSize] = usePersistentState(pk('tileSize'), 0.35);
   const [objectMode, setObjectMode] = usePersistentState(pk('objectMode'), false);
   const [shapeIndex, setShapeIndex] = usePersistentState(pk('shapeIndex'), 1);
   const [textureIndex, setTextureIndex] = usePersistentState(pk('textureIndex'), 0);
@@ -221,6 +225,7 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     sheetShade, setSheetShade,
     sheetAdaptive, setSheetAdaptive,
     sheetDensity, setSheetDensity,
+    tileSize, setTileSize,
     objectMode, setObjectMode,
     shapeIndex, setShapeIndex,
     textureIndex, setTextureIndex,

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -66,6 +66,10 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // How the (non-adaptive) domain grid is laid out: Cartesian grid, polar,
   // rings, spokes, web, squares, or random scatter.
   const [samplePattern, setSamplePattern] = usePersistentState<SamplePattern>(pk('samplePattern'), SamplePattern.Grid);
+  // Reciprocal-symmetric sampling: warp the domain radius to be uniform in log|z|
+  // (the unit circle at the middle), so samples reach as deeply inside |z|<1 as
+  // outside. Applies to every render mode (points, sheet, tiles, net).
+  const [reciprocal, setReciprocal] = usePersistentState(pk('reciprocal'), false);
   /** When true, sample more densely where |f'(z)| is large. */
   const [adaptive, setAdaptive] = usePersistentState(pk('adaptive'), COMPLEX_PARTICLES_DEFAULTS.initial.adaptive);
   /** Exponent biasing strength for adaptive sampling. */
@@ -234,6 +238,7 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     axisScale, setAxisScale,
     axisScaleRef,
     samplePattern, setSamplePattern,
+    reciprocal, setReciprocal,
     adaptive, setAdaptive,
     adaptiveAlpha, setAdaptiveAlpha,
     renderMode, setRenderMode,

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -124,6 +124,10 @@ export function useUniformSync(state: ParticleState): void {
   }, [state.colourStyle]);
 
   useEffect(() => {
+    materialsRef.current.forEach(m => { m.uniforms.uColormap.value = state.colormap; });
+  }, [state.colormap]);
+
+  useEffect(() => {
     materialsRef.current.forEach(m => { m.uniforms.uColourBy.value = state.colourBy; });
   }, [state.colourBy]);
 

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -128,6 +128,13 @@ export function useUniformSync(state: ParticleState): void {
   }, [state.colormap]);
 
   useEffect(() => {
+    materialsRef.current.forEach(m => {
+      if (m.uniforms.uLight) m.uniforms.uLight.value = state.lighting ? 1 : 0;
+      if (m.uniforms.uLightStrength) m.uniforms.uLightStrength.value = state.lightStrength;
+    });
+  }, [state.lighting, state.lightStrength]);
+
+  useEffect(() => {
     materialsRef.current.forEach(m => { m.uniforms.uColourBy.value = state.colourBy; });
   }, [state.colourBy]);
 

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -135,6 +135,12 @@ export function useUniformSync(state: ParticleState): void {
 
   useEffect(() => {
     materialsRef.current.forEach(m => {
+      if (m.uniforms.uReciprocal) m.uniforms.uReciprocal.value = state.reciprocal ? 1 : 0;
+    });
+  }, [state.reciprocal]);
+
+  useEffect(() => {
+    materialsRef.current.forEach(m => {
       if (m.uniforms.uLight) m.uniforms.uLight.value = state.lighting ? 1 : 0;
       if (m.uniforms.uLightStrength) m.uniforms.uLightStrength.value = state.lightStrength;
     });

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -98,6 +98,9 @@ export function useUniformSync(state: ParticleState): void {
       rendererRef.current.setClearColor(state.objectMode ? 0xffffff : 0x000000);
     }
     materialsRef.current.forEach(m => {
+      // Sheet materials keep their own NormalBlending + no depth-write (true
+      // translucency); only the point cloud follows the object/light-bg toggle.
+      if (m.userData.sheet) return;
       m.blending = state.objectMode ? THREE.NormalBlending : THREE.AdditiveBlending;
       m.depthWrite = state.objectMode;
     });

--- a/src/lib/particles/useUniformSync.ts
+++ b/src/lib/particles/useUniformSync.ts
@@ -129,6 +129,12 @@ export function useUniformSync(state: ParticleState): void {
 
   useEffect(() => {
     materialsRef.current.forEach(m => {
+      if (m.uniforms.uColorRepeat) m.uniforms.uColorRepeat.value = state.colorRepeat;
+    });
+  }, [state.colorRepeat]);
+
+  useEffect(() => {
+    materialsRef.current.forEach(m => {
       if (m.uniforms.uLight) m.uniforms.uLight.value = state.lighting ? 1 : 0;
       if (m.uniforms.uLightStrength) m.uniforms.uLightStrength.value = state.lightStrength;
     });


### PR DESCRIPTION
## Summary

Adds a **Surface** render mode to the Complex Particles viewer: the complex
function's graph can now be drawn as a single continuous **translucent sheet**
over a regular grid (with a toggleable **wireframe** overlay), alongside the
existing point cloud.

A new **Surface** control section switches between:
- **Points** — the existing particle cloud (unchanged), and
- **Sheet** — a translucent triangle surface over a regular grid, with toggleable
  **Filled sheet** + **Wireframe** layers, a **Resolution** slider, and a
  **Shading** slider for depth cues.

## How it works (reuses the existing engine)

- `lib/particles/createSheetGeometry.ts` (new) — a regular `res×res` indexed
  triangle grid (+ rebuild helper). Vertices carry a zero `seed`, so any Jitter
  translates the sheet uniformly instead of tearing it.
- The sheet shares the **exact same** surface/projection/colour GLSL as the
  points view: the shared library is extracted into `vsCommon`, and a new
  `sheetVertexShader` / `sheetFragmentShader` add faceted shading (screen-space
  derivatives of the view-space position) plus a `uWire` flag for the wireframe
  overlay. So every projection mode, 4D rotation, colour setting, and Riemann
  sheet works on the sheet identically.
- Sheet materials use **NormalBlending** (true alpha compositing) rather than the
  points' additive blending — without this a double-sided translucent surface
  blows out to solid white from overdraw. They're tagged `userData.sheet` so the
  light-background (`objectMode`) effect leaves their blending alone.
- New persisted state (`renderMode`, `sheetFill`, `sheetWire`, `sheetResolution`,
  `sheetShade`) and a **Surface** section in `ParticleViewerShell`.
- `branchIndex` now reads `userData.branch` instead of a material's list position
  (there are now several materials per Riemann sheet).

## Testing

- `npm run build` passes.
- Verified with the headless SwiftShader screenshot harness across `z²` and `eᶻ`
  (filled+wireframe and wireframe-only); confirmed **Points mode is unregressed**.
  No GLSL compile errors.

## Notes

Sheet mode samples its own Cartesian grid (its `sheetResolution`), ignoring the
sampling pattern and particle count — a continuous surface needs grid topology.
It currently shares the points' Distance/Opacity defaults, so for fast-growing
`f` you may want to zoom out; a Sheet-specific default distance/opacity is a
natural follow-up polish.

https://claude.ai/code/session_01HYLTU7chMoG9zGcYM2egU6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HYLTU7chMoG9zGcYM2egU6)_