### PR TITLE
docs: don't sync main at session start (stacked-branch safe)

### DIFF
--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -49,7 +49,10 @@ short and topical** so the folders stay tidy.
    names, if any. Skim `CLAUDE.md` / `AGENTS.md` for any conventions relevant to the
    focus. Remember the parallel-branch rule: shared files (`src/index.tsx`,
    `src/apps.ts`, `CLAUDE.md`, `README.md`) are **append-only** — never reorder
-   existing entries.
+   existing entries. **Do not `git pull` / `merge origin/main` to start** — the
+   fresh clone is already current, and this branch may be stacked on another
+   feature branch (see CLAUDE.md → *Branch sync*). Main-sync happens only at PR
+   finalization.
 6. **Create the progress report** at
    `docs/sessions/progress/<branch-slug>/YYYY-MM-DD-SNN-description.md` by copying
    `docs/sessions/_template-progress.md` and filling the `[bracketed]` frontmatter
@@ -121,6 +124,10 @@ it wasn't written, it didn't happen.
   will rely on it to understand what happened, what was decided, and why. Without
   the Why, the record is incomplete and decisions become unauditable.
 - Do NOT begin any implementation, investigation, or code changes.
+- Do NOT `git pull` or merge `origin/main` during startup — begin from the branch
+  as checked out. Syncing `main` happens only when finalizing a PR, and only for
+  branches that target `main` (stacked branches sync their own base). See
+  CLAUDE.md → *Branch sync*.
 - Do NOT run scripts or explore the codebase beyond resolving the branch slug,
   reading the handoff, and the orientation skim in step 5.
 - After presenting the summary, STOP and wait for the user to direct next steps.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,25 @@ Follow **docs/BUILDING_AN_APP.md**. In short:
 > matter — the re-sync is cheap because the edits are additive. See
 > **docs/BUILDING_AN_APP.md §8** for the full workflow.
 
+### Branch sync (don't pull `main` at session start)
+
+The repo is **cloned fresh each session** and your working branch is already
+checked out, so there is nothing to "catch up" before you begin. **Do not
+`git pull` / `git merge origin/main` at the start of a session** — it pulls
+unrelated work into your diff and triggers premature conflicts in the append-only
+shared files (`index.tsx`, `apps.ts`, `CLAUDE.md`, `README.md`).
+
+Sync with `main` **only when finalizing a PR** — the single prescribed point
+(`git fetch && git merge origin/main`, keep every app's entries, re-run
+`npm run build`; see the parallel-branches note above and **BUILDING_AN_APP.md §8**)
+— and only if your branch actually targets `main`.
+
+> [!IMPORTANT]
+> **If your branch is stacked on another feature branch** (created from
+> `claude/<other>` rather than `main`), sync against **that base**, never `main` —
+> merging `main` would drag in work your branch was never meant to carry. Check your
+> base with `git merge-base` / the branch you forked from if unsure.
+
 ### Deployment
 
 Pushing to `main` triggers the **Deploy demo** GitHub Pages workflow


### PR DESCRIPTION
## What & why

Agents often reflexively `git pull` / `merge origin/main` at session start. But the repo is **cloned fresh each session** and the working branch is already checked out, so there's nothing to catch up — and a start-of-session merge:

- pulls unrelated work into the diff,
- triggers **premature conflicts** in the append-only shared files (`index.tsx`, `apps.ts`, `CLAUDE.md`, `README.md`), and
- is **outright wrong for a branch stacked on another feature branch** (merging `main` drags in work the branch was never meant to carry).

CLAUDE.md already says to sync `main` *only when finalizing a PR* — so the behavior is agents doing it at the wrong time, not a missing rule. This makes it an explicit **don't-at-start** and spells out the stacked-branch case.

## Changes

- **`CLAUDE.md`** — new *Branch sync* subsection under Development Workflow: fresh clone is already current; sync `main` only at PR finalization (and only if the branch targets `main`); stacked branches sync **their base, not main**.
- **`.claude/skills/start-session/SKILL.md`** — a step-5 note + a Rules bullet reinforcing it.

Docs-only; no code paths touched.

https://claude.ai/code/session_01VEYdGS9xW4MXHvT8vzfNJN

---
_Generated by [Claude Code](https://claude.ai/code/session_01VEYdGS9xW4MXHvT8vzfNJN)_