### PR TITLE
Make session skills agent-invokable

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: handoff
-description: "Create a handoff document for the current animath session. Invoke manually at the end of a conversation — never auto-invoke."
-disable-model-invocation: true
+description: "Create a handoff document for the current animath session. Invoke at the end of a conversation when the user or an agent asks to wrap up / hand off the session (e.g. /handoff) — do not auto-invoke spontaneously."
 ---
 
 # Handoff Document Generator

--- a/.claude/skills/start-session/SKILL.md
+++ b/.claude/skills/start-session/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: start-session
-description: "Start a new working session on animath. Reads the latest handoff, creates a progress report, and presents context. Invoke manually at the beginning of a conversation — never auto-invoke."
-disable-model-invocation: true
+description: "Start a new working session on animath. Reads the latest handoff, creates a progress report, and presents context. Invoke at the beginning of a conversation when the user or an agent asks to start/kick off a session (e.g. /start-session) — do not auto-invoke spontaneously."
 argument-hint: "[session focus, one sentence]"
 ---
 

--- a/.claude/skills/three-hats/SKILL.md
+++ b/.claude/skills/three-hats/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: three-hats
-description: "Evaluate an animath plan, proposal, or design decision from three independent expert perspectives (framework maintainer, architecture consultant, math-visualization & pedagogy), then synthesize. Invoke manually."
-disable-model-invocation: true
+description: "Evaluate an animath plan, proposal, or design decision from three independent expert perspectives (framework maintainer, architecture consultant, math-visualization & pedagogy), then synthesize. Invoke when the user or an agent asks for a multi-lens plan/design review (e.g. /three-hats) — do not auto-invoke spontaneously."
 argument-hint: "<plan / proposal / question, or a path to one>"
 ---
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,8 +54,9 @@ currently no automated tests, linter, or formatter.
 
 ## Session Skills
 
-Three manually-invoked Claude Code skills live in `.claude/skills/` (slash
-commands; they never auto-invoke): **`/start-session`** (orient + open a progress
+Three Claude Code skills live in `.claude/skills/` — invokable both by a human
+(slash command) and by an agent (via the Skill tool), on explicit request rather
+than auto-triggered: **`/start-session`** (orient + open a progress
 report), **`/handoff`** (distil the session, using `npm run build` for status), and
 **`/three-hats`** (parallel design review from three lenses). Session notes are
 committed as self-contained **HTML** under

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -418,8 +418,9 @@ For per-PR preview URLs, see `docs/PREVIEW_DEPLOYS.md`.
 
 ### Agent session skills (`.claude/skills/`)
 
-Three manually-invoked Claude Code skills support the session workflow (type the
-slash command; they never auto-invoke):
+Three Claude Code skills support the session workflow. Both a human (typing the
+slash command) and an agent (via the Skill tool) can invoke them; they are
+invoked **on explicit request**, not auto-triggered spontaneously:
 
 - **`/start-session`** — reads the latest handoff, opens a progress report, and
   orients (branch + which app, the append-only parallel-branch rule). Run it first.

--- a/docs/sessions/progress/agent-invokable-skills-mr5k24/2026-06-10-S01-agent-invokable-skills.md
+++ b/docs/sessions/progress/agent-invokable-skills-mr5k24/2026-06-10-S01-agent-invokable-skills.md
@@ -1,0 +1,85 @@
+---
+kind: progress
+session: 2026-06-10-S01
+date: 2026-06-10
+title: Make session skills agent-invokable
+branch: claude/agent-invokable-skills-mr5k24
+slug: agent-invokable-skills-mr5k24
+status: in-progress
+build: not-run
+followup: null
+pr: 206
+app: general
+---
+
+# Make session skills agent-invokable
+
+## Session purpose
+
+Make the `.claude/skills/` session skills (`start-session`, `handoff`,
+`three-hats`) invokable by an agent (not only by a human typing the slash
+command), and land it as a quick PR to `main` so it doesn't need revisiting —
+then actually run `/start-session` via the Skill tool.
+
+## Previous session
+
+First tracked session on this branch. The most recent handoff for continuity is
+[control-center-category-filter / 2026-06-10-S01](../../handoff/control-center-category-filter/2026-06-10-S01.md)
+(PR #204, completed, build passing) — a tooling/docs session on the cross-branch
+control center that also touched these same skill files. Unrelated topic, but
+relevant because it last edited the `handoff`/`start-session` skill descriptions.
+
+## Working notes
+
+<!-- Newest entry first. -->
+
+### 🟡 milestone · 22:07 — Ran /start-session via the Skill tool
+**Why:** Demonstrate the fix end-to-end — an agent invoking a skill that was
+previously human-only — and open the session record.
+
+After the PR was up, invoked `start-session` through the Skill tool (the very
+capability this branch adds). Resolved slug `agent-invokable-skills-mr5k24`
+(new branch, no prior handoff), read the latest cross-branch handoff for
+continuity, and wrote this progress report.
+
+### 🟢 code · 22:05 — Opened PR #206 to main
+**Why:** User asked for a quick PR to `main` so the invocation barrier doesn't
+recur.
+
+Committed (`b484c1f`), pushed `claude/agent-invokable-skills-mr5k24`, opened
+[PR #206](https://github.com/piyarsquare/animath/pull/206) → `main`. Docs/skill
+metadata only — no app or build-surface code changed.
+
+### 🟢 code · 22:03 — Removed `disable-model-invocation` from all three skills
+**Why:** That frontmatter flag is exactly what blocks the model/agent from
+invoking a skill — it restricts invocation to a human typing the slash command.
+
+Deleted `disable-model-invocation: true` from `start-session`, `handoff`, and
+`three-hats`. Reworded each `description` so the trigger is an **explicit
+request** (e.g. `/start-session`) rather than spontaneous auto-invocation —
+preserving the original "don't fire on your own" intent while allowing an agent
+to call them when asked. Updated the matching prose in `CLAUDE.md` and
+`AGENTS.md` (both previously said the skills "never auto-invoke") to say they're
+invokable by both humans and agents on explicit request. Confirmed the skills
+re-registered as model-invokable in the live skill list.
+
+### 🔵 finding · 22:01 — Root cause: `disable-model-invocation: true`
+**Why:** Establish why the skills couldn't be agent-invoked before changing
+anything.
+
+All three session skills carried `disable-model-invocation: true`. That is the
+documented gate that prevents the model (an agent) from invoking a skill; only a
+human slash command could trigger them. The descriptions also said "never
+auto-invoke," which is the behavior to preserve — the fix is to allow invocation
+on request, not to make them auto-trigger.
+
+## Open / not done
+
+- **PR #206 not merged** — awaiting review/merge to `main`. The local branch
+  already has the updated skills, so this session can use them now.
+- **`npm run build` not run** — changes are docs/skill-metadata only (no `src/`),
+  so the build surface is untouched; not run this session.
+- **Optional consistency pass** — other `.claude/` skills (e.g. `deep-research`,
+  `update-config`) are global/harness skills, not part of this repo's session
+  workflow; left untouched. If "all skills" is meant to include any future
+  repo-local skills, apply the same frontmatter convention.


### PR DESCRIPTION
## What

The three session-workflow skills in `.claude/skills/` (`start-session`, `handoff`, `three-hats`) carried `disable-model-invocation: true` in their frontmatter. That flag means **only a human typing the slash command** can run them — an agent cannot invoke them via the Skill tool. This PR makes them agent-invokable.

## Changes

- **Remove `disable-model-invocation: true`** from all three skills, so an agent can invoke them via the Skill tool.
- **Reword each `description`** so the trigger is an *explicit request* (e.g. `/start-session`) rather than spontaneous auto-invocation — preserving the original intent that these don't fire on their own, while still allowing an agent to call them when asked.
- **Update the matching prose** in `CLAUDE.md` and `AGENTS.md` (which previously said the skills "never auto-invoke") to reflect that they're invokable by both humans and agents, on explicit request.

## Why

So a request like "use the start-session skill" can be honored by an agent directly, without a human having to type the slash command. This avoids having to revisit the invocation barrier each session.

No code or build-surface changes — docs/skill metadata only.

https://claude.ai/code/session_01PkbTvPbNFKKAMdCus6BUZ1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PkbTvPbNFKKAMdCus6BUZ1)_