### PR TITLE
Complex Particles: bounded turntable orbit by default + full-bleed mobile views

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,7 +292,11 @@ become **layouts** (`views[id].open`).
 
 Particle viewers split **looking** (gestures) from **navigating** (buttons):
 
-- **1-finger / mouse drag** orbits the camera (never the 4D rotation).
+- **1-finger / mouse drag** orbits the camera (never the 4D rotation). The
+  Camera panel's **Orbit** toggle picks the style: **Turntable** (default) is
+  the bounded orbit — azimuth around world-up, elevation clamped at the poles,
+  so "up" stays up and the view is easy to recenter by hand — and **Free** is
+  the unbounded trackball that tumbles past the poles and can roll.
 - **2-finger drag** pans the look-at target; on desktop, **right-drag**,
   **held `Space`+drag** or `Shift`+drag pan (the phone keeps a Drag
   Orbit | Pan pill for one-finger choice).

--- a/docs/sessions/handoff/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/handoff/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -1,0 +1,129 @@
+---
+kind: handoff
+session: 2026-06-12-S01
+date: 2026-06-12
+title: Bounded orbit · mobile layout · checkboxes · loading screen · randomized hero
+branch: claude/particle-rotation-mobile-layout-nlworx
+slug: particle-rotation-mobile-layout-nlworx
+status: completed
+build: passing
+followup: null
+pr: null
+app: complex-particles, chrome
+---
+
+# Bounded orbit · mobile layout · checkboxes · loading screen · randomized hero
+
+> [!NOTE]
+> A user-driven polish session: nine small, mostly independent fixes across the
+> particle viewer and the workspace chrome. All committed and pushed to the
+> branch; no PR opened yet (user has not asked).
+
+## Summary
+
+A sweep of UX fixes requested live by the user, one after another. Started with
+two Complex Particles asks (restore the bounded camera orbit; make mobile views
+fill the screen) and grew into a chrome-wide polish pass: visible checkboxes in
+every skin, mobile sheet layering, a branded loading screen, single-tap menu
+dismiss, per-skin `color-scheme`, no first-paint skin flash, and a "package
+drop" randomized landing hero. Build/lint/tests green throughout (`tsc && vite
+build` passes; `npm test` 22/22; `npm run lint` 0 errors, 60 baseline warnings).
+Everything verified with headless screenshots + scripted interaction.
+
+## What changed
+
+1. **Bounded "turntable" orbit is the default again** (was a free trackball that
+   was hard to recenter). New persisted `orbitMode` (`turntable` | `free`) with
+   a Camera-panel **Orbit** toggle. Turntable accumulates azimuth/elevation in
+   refs → writes `camQuat`, so pan/reset/Hopf-ambient-orbit are unchanged; a
+   drag re-syncs from the current orientation on pointer-down.
+2. **Mobile views fill the screen.** Phone top bar floats as a translucent pill;
+   view cards flex-fill the stage. **Single-view apps go full-bleed (immersive)**
+   with the bar + dock overlaid and a floating full-screen button to escape to
+   chrome-free fullscreen. Multi-view apps split the stage.
+3. **Checkboxes visible in every skin.** Native checkboxes painted from the
+   unset page `color-scheme`, so light-accent skins (Blueprint) lost the box.
+   Replaced with one global token-styled `input[type="checkbox"]` in theme.css.
+4. **Phone bottom sheet sits above the action strip** (was z 50 vs actionbar
+   130 — buttons poked through). Lifted sheet/scrim to 135/136.
+5. **Branded loading screen** for lazy routes (was a blank div): pulsing brand
+   mark + spinning accent ring, skin-aware. Wired in `index.tsx` + `App.tsx`.
+6. **Single-tap menu dismiss on mobile.** Scrims dismissed on `onClick` on bare
+   divs (Safari needs two taps); switched to `onPointerDown` + `cursor:pointer`.
+7. **`color-scheme` per skin** so native selects/scrollbars match.
+8. **No first-paint skin flash** — `index.html` boot script seeds `data-theme`
+   + per-skin body background before the bundle loads.
+9. **Randomized landing hero** (package drop): "Small worlds you can A, B, and
+   C." — three random verbs, strangest last, click-to-reroll with cross-fade.
+   Blueprint verbs use `--accent-2` (its accent == fg); Phosphor title drops to
+   30px (mono display font ran wide).
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`src/lib/particles/useGestureRotation.ts:134`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/lib/particles/useGestureRotation.ts#L134) | Orbit branch: bounded turntable vs free trackball |
+| [`src/lib/particles/useParticleState.ts:38`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/lib/particles/useParticleState.ts#L38) | `orbitMode` + `azimuthRef`/`elevationRef` |
+| [`src/components/ParticleViewerShell.tsx:301`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/components/ParticleViewerShell.tsx#L301) | Camera-panel Orbit toggle |
+| [`src/chrome/workspace/PhoneWorkspace.tsx:29`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/chrome/workspace/PhoneWorkspace.tsx#L29) | `immersive` flag + floating full-screen button + onPointerDown scrim |
+| [`src/chrome/workspace/layers.ts:26`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/chrome/workspace/layers.ts#L26) | z-scale: phoneScrim/phoneSheet above actionbar |
+| [`src/chrome/theme.css:283`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/chrome/theme.css#L283) | Global checkbox; immersive/phone CSS; hero verb rules + skin overrides |
+| [`src/chrome/LoadingScreen.tsx`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/chrome/LoadingScreen.tsx) | Suspense fallback splash |
+| [`src/chrome/heroVerbs.ts`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/chrome/heroVerbs.ts) | Verb pool + `rollHeroVerbs()` |
+| [`src/chrome/Gallery.tsx:18`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/src/chrome/Gallery.tsx#L18) | Hero markup + reroll/cross-fade |
+| [`index.html:21`](https://github.com/piyarsquare/animath/blob/d21074a0078776f3a641d5203fda35c1997907e7/index.html#L21) | Per-skin boot background + data-theme seed script |
+
+## Open / not done
+
+- **No PR.** Branch `claude/particle-rotation-mobile-layout-nlworx` is 9 commits
+  ahead, build green. Open one when the user asks; sync `main` first per
+  CLAUDE.md (append-only shared files: `index.tsx`, `apps.ts`, `CLAUDE.md`,
+  `README.md` — this session touched `index.tsx`, `index.html`, `CLAUDE.md`).
+- **Not tested on a real device.** Everything mobile/touch was verified in
+  headless Chromium with touch emulation. The **single-tap dismiss** fix targets
+  an iOS-Safari clickability heuristic that cannot be reproduced here — highest
+  unproven item. Recommend a real-phone pass on the preview build.
+- **Orbit *feel* unverified by hand** — bounded recentering was validated by
+  logic + static screenshots, not by actually dragging.
+
+## Context
+
+- Verification was done by building, serving `npm run preview` (port 4173), and
+  driving `scripts/shoot.mjs` (headless WebGL via SwiftShader) at `VIEWPORT=...`.
+  For touch/interaction I wrote one-off puppeteer scripts **inside the repo dir**
+  (so `puppeteer` resolves from `node_modules`) and deleted them after.
+- To screenshot a non-default skin: `SKIN=blueprint node scripts/shoot.mjs '#/' out.png`.
+  To screenshot a checkbox panel: seed `SEED_LS` with `viewType:"2"` (Hopf) to
+  surface the Camera panel's "Reference scaffold" checkbox.
+- The randomized hero's `rollHeroVerbs()` is intentionally tier-sorted (tier-2
+  "out-there" verb lands last). Blueprint is the only skin where `--accent` ==
+  `--fg`; if a new skin does the same, give it the `--accent-2` verb override.
+- The "package drop" source files (`landing-explore/handoff/*`) were unzipped to
+  `/tmp`, **not** committed — only the ported TS/CSS landed.
+
+## Self-reflection
+
+1. **What would you do with another session?** Run the whole branch on a real
+   iOS device and Android, focused on the single-tap dismiss and the bounded
+   orbit feel; then open the PR (sync `main`, re-run build) and offer to watch CI.
+2. **What would you change about what you produced?** I'd consolidate the many
+   small commits' verification into one place earlier, and I'd have screenshotted
+   all five skins for the hero on the *first* pass instead of catching the
+   Blueprint/Phosphor regressions on a second round.
+3. **What were you not asked that you think is important?** Whether the immersive
+   full-bleed mobile mode should also apply to the layout-tab apps (Stable
+   Matching) where only one view is open at a time — I scoped it to
+   `views.length === 1`, which is defensible but a judgment call worth confirming.
+4. **What did we both overlook?** Initially, that the hero verb color is invisible
+   when a skin's accent equals its text color — a class of "token collision" that
+   could recur. A small contrast assertion across skins would catch it.
+5. **What did you find difficult?** Reproducing device-specific touch behavior in
+   a headless, GPU-less container — I could prove `onPointerDown` fires, but not
+   the actual iOS heuristic the bug came from.
+6. **What would have made this task easier?** A skin-matrix screenshot helper
+   (loop all five skins for a route in one command) and a tiny harness to open a
+   panel sheet/menu, so touch-dismiss and per-skin checks aren't one-off scripts.
+7. **Follow-up value:** MEDIUM — the code is correct and verified structurally,
+   but the two feel/touch-centric fixes (single-tap dismiss, orbit recentering)
+   are unproven on the real devices the complaints came from; a short real-device
+   pass would convert them from high-confidence to confirmed.

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -39,6 +39,20 @@ session is a separate, user-driven polish pass, not a direct continuation.
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 16:43 — Phone bottom sheet now sits above the action strip
+
+**Why:** User reported app buttons rendering on top of an open bottom menu on
+mobile. Root cause: the always-on phone action strip is at `actionbar: 130`
+while the bottom sheet/scrim were at `50/45`, so the primary verbs poked through
+an open panel sheet.
+
+Lifted `phoneScrim`/`phoneSheet` above `actionbar` (135/136) in both the
+`layers.ts` scale and its `theme.css` mirror. Verified interactively (puppeteer
+tap on a dock button) on Stable Marriage: the Preferences sheet now covers the
+Play/Step/Finish/Reset strip instead of letting it show through. Affects all
+four action-bar apps (Stable Marriage, Stable Matching, Trinary, Agentic
+Sorting). Build/lint/test green.
+
 ### 🟢 code · 16:34 — Global checkbox + immersive single-view mobile
 
 **Why:** Follow-up asks — make *every* app's checkboxes match, and on mobile

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -39,6 +39,20 @@ session is a separate, user-driven polish pass, not a direct continuation.
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 16:48 — Branded loading screen for lazy routes
+
+**Why:** User asked about the load screen — the Suspense fallback was a blank
+themed `<div>`, so switching into a code-split app (≈133 KB Three.js for the
+3D/fractal viewers) flashed an empty screen. (No, nothing was sped up — it was
+just blank.)
+
+Added `chrome/LoadingScreen.tsx`: the brand mark pulsing inside a spinning
+accent ring on the dotted stage, "Loading…" beneath, all from theme tokens so
+it matches the persisted skin. Wired it as the Suspense fallback in both
+`index.tsx` (every lazy route) and `App.tsx` (the default Complex Particles
+route has its own inner Suspense). Verified by throttling the app chunk in
+puppeteer — captured the splash in dark and Blueprint. Build/lint/test green.
+
 ### 🟢 code · 16:43 — Phone bottom sheet now sits above the action strip
 
 **Why:** User reported app buttons rendering on top of an open bottom menu on

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -5,7 +5,7 @@ date: 2026-06-12
 title: Bounded turntable orbit · full-bleed mobile views · checkbox skin bug
 branch: claude/particle-rotation-mobile-layout-nlworx
 slug: particle-rotation-mobile-layout-nlworx
-status: in-progress
+status: completed
 build: passing
 followup: null
 pr: null

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -39,6 +39,24 @@ session is a separate, user-driven polish pass, not a direct continuation.
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 16:34 — Global checkbox + immersive single-view mobile
+
+**Why:** Follow-up asks — make *every* app's checkboxes match, and on mobile
+present single-screen apps full-bleed with the toolbar overlaid (not above).
+
+- **Checkboxes globalized.** Moved the token-styled box to a single
+  `input[type="checkbox"]` rule in `chrome/theme.css` (loaded app-wide) using
+  raw theme tokens, and removed the now-redundant per-app rules (the `.cp-row`
+  block in `ControlPanel.css` and `.sm-toggle`'s `accent-color` in
+  `stableMarriage.css`). One look for current and future apps; custom pill
+  switches (`.am-switch`, a div) are unaffected.
+- **Immersive single-view phones.** `PhoneWorkspace` flags `immersive` when
+  `views.length === 1`; the lone view goes edge-to-edge (no card chrome, header
+  or grip hidden, zero scroll padding) and the floating bar + dock overlay it.
+  Multi-view apps keep the stacked-cards-below-the-bar layout. Verified on
+  Complex Particles (dark + Blueprint): canvas fills the screen, frosted bar
+  floats on top. Build/lint/test green (0 errors, 22 tests).
+
 ### 🟢 code · 16:28 — Token-styled checkbox (visible in every skin)
 
 **Why:** Root cause confirmed — the shared `ControlPanel` checkbox was a bare

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -1,0 +1,104 @@
+---
+kind: progress
+session: 2026-06-12-S01
+date: 2026-06-12
+title: Bounded turntable orbit · full-bleed mobile views · checkbox skin bug
+branch: claude/particle-rotation-mobile-layout-nlworx
+slug: particle-rotation-mobile-layout-nlworx
+status: in-progress
+build: passing
+followup: null
+pr: null
+app: complex-particles, chrome
+---
+
+# Bounded turntable orbit · full-bleed mobile views · checkbox skin bug
+
+## Session purpose
+
+Two user-reported regressions/asks on Complex Particles + the workspace chrome:
+
+1. The camera orbit was changed to a free (unbounded) trackball, which made the
+   view too hard to recenter by hand. Restore the **bounded** orbit as the
+   default and keep the unbounded one as an opt-in mode.
+2. On mobile, the view windows were small fixed-height cards that hid most of
+   the visualization. Make the views **fill the screen** with the toolbar
+   floating above.
+
+Then, mid-session: a follow-up bug — **checkboxes don't render their box in
+some skins (e.g. Blueprint)**.
+
+## Previous session
+
+First tracked session on this branch. For continuity, the most recent
+particle-app work is the three-hats review under
+`../three-hats-particle-app-rill2c/` (lifecycle leak fix + branch gating); this
+session is a separate, user-driven polish pass, not a direct continuation.
+
+## Working notes
+
+<!-- Newest entry first. -->
+
+### 🟢 code · 16:28 — Token-styled checkbox (visible in every skin)
+
+**Why:** Root cause confirmed — the shared `ControlPanel` checkbox was a bare
+native `<input type="checkbox">` styled only with `accent-color`. Native
+checkboxes paint from the page `color-scheme` (which is unset), so in Blueprint
+(accent ≈ white `#f2f6ff`) the box read as a featureless block.
+
+Replaced the native box with a custom one drawn from theme tokens in
+`ControlPanel.css`: `appearance: none`, a `--cp-fg-dim` border on a panel-solid
+fill when unchecked, an accent fill + `--accent-fg` checkmark (`::after`) when
+checked, plus hover/focus-visible states. Verified via `scripts/shoot.mjs` in
+Blueprint (checked: white box + dark-blue check; unchecked: outlined empty box)
+and the default dark skin (gold box + dark check). Build green.
+
+### 🔵 finding · 16:16 — Checkbox box missing in some skins (reported)
+
+**Why:** User reports the checkmark boxes don't show in some modes, e.g.
+Blueprint. Opening an investigation; not yet root-caused.
+
+Suspect the `Checkbox` control in `components/ControlPanel` and the skin token
+values in `chrome/theme.css` (Blueprint `[data-theme]` block) — likely a
+`border`/`background` that collapses to the panel color, or a box-shadow-based
+border that a skin overrides. To confirm next.
+
+### 🟡 milestone · 16:10 — Both asks shipped and pushed
+
+**Why:** Build/test/lint green and screenshots confirm the behavior; pushed to
+the feature branch.
+
+`npm run build` ✓, `npm test` ✓ (22), `npm run lint` ✓ (0 errors, 60 baseline
+warnings). Mobile + desktop screenshots verified via `scripts/shoot.mjs`.
+Commit `2afe887`.
+
+### 🟢 code · 16:05 — Full-bleed mobile views + floating top bar
+
+**Why:** Fixed 56vw cards hid most of the visualization on phones.
+
+Phone top bar (`.am-phone-app > .am-bar`) now floats as a translucent pill;
+view cards flex-fill the stage between it and the floating dock (one open view
+fills the screen, several split it). The bottom grip now resizes the whole card
+via flex-basis (`PhoneWorkspace.tsx`). Touched `theme.css` phone block only —
+desktop layout untouched (selectors are phone-scoped).
+
+### 🟢 code · 16:00 — Bounded "turntable" orbit restored as default
+
+**Why:** The free trackball tumbled past the poles and could roll, so a drifted
+view was hard to recenter.
+
+Added an `orbitMode` setting (`turntable` default | `free`), persisted, with a
+new Camera-panel **Orbit** toggle. Turntable accumulates azimuth/elevation in
+refs and writes `camQuat`, so camera placement, pan, reset, and the Hopf/Torus
+ambient orbit are all unchanged; a turntable drag re-syncs az/el from the
+current orientation on pointer-down. Files: `useParticleState`,
+`useGestureRotation`, `useViewControls`, `ParticleViewerShell`, `CLAUDE.md`.
+
+### 🔵 finding · 15:58 — The "full rotation" was the free trackball
+
+**Why:** Locating what to revert.
+
+`useGestureRotation.ts` 1-finger drag composed incremental quaternions about the
+camera's own axes (no pole limit). Git history shows the prior bounded version
+(commit `3689d85`) used clamped azimuth/elevation. Decided to reimplement
+bounded-on-`camQuat` rather than revert the state model, so both modes coexist.

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -39,6 +39,23 @@ session is a separate, user-driven polish pass, not a direct continuation.
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 20:40 — Randomized landing hero (package drop)
+
+**Why:** User supplied a "package drop" (handoff + `hero-verbs.js`) to make the
+gallery hero nicer: a headline that draws three verbs at random per load, the
+strangest last, click-to-reroll.
+
+The handoff targeted the redesign *prototype* (`redesign/journey.jsx`, global
+`React`/`window`); ported it idiomatically to production: typed
+`chrome/heroVerbs.ts` module (`rollHeroVerbs()`), and rewrote the `Gallery.tsx`
+hero — kicker removed (per approved design), accented `<b>` verbs, click-to-
+reroll with a soft cross-fade that respects `prefers-reduced-motion`, new
+subline. Three `theme.css` lines for the accent/cursor/fade. Verified by
+screenshot (two loads differ) and a puppeteer click test (9 distinct headlines,
+tier-2 verb always last). Build green; the raw package files were not committed.
+
+User decisions: remove kicker · soft cross-fade · silent egg (no tooltip).
+
 ### 🟢 code · 17:50 — Radar sweep: skins, first paint, immersive toggle, single-tap dismiss
 
 **Why:** User said "fix everything on your list" + a new ask: a single tap off a

--- a/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
+++ b/docs/sessions/progress/particle-rotation-mobile-layout-nlworx/2026-06-12-S01-rotation-mobile-checkbox.md
@@ -39,6 +39,31 @@ session is a separate, user-driven polish pass, not a direct continuation.
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 17:50 — Radar sweep: skins, first paint, immersive toggle, single-tap dismiss
+
+**Why:** User said "fix everything on your list" + a new ask: a single tap off a
+menu should dismiss it on mobile.
+
+- **Single-tap dismiss.** Scrims dismissed on `onClick` on bare `<div>`s, which
+  Safari needs two taps for (it only synthesizes taps on "clickable" elements).
+  Switched the menu, sheet and modal scrims to `onPointerDown` (+ `cursor:
+  pointer; touch-action: manipulation`), and stopped pointer-down propagation on
+  the modal content. Verified in puppeteer: one tap on the scrim closes the
+  sheet.
+- **Native controls per skin.** Added `color-scheme` to each `[data-theme]`
+  block (light → light, the rest → dark) so native selects/scrollbars/spinners
+  match the skin. ControlPanel's range/select were already custom-styled.
+- **First-paint flash.** `index.html` now seeds `<html data-theme>` from the
+  persisted skin via an inline boot script + per-skin body background, so the
+  first paint matches the skin instead of flashing dark before theme.css loads.
+- **Immersive chrome escape.** The full-bleed single-view phone layout hid the
+  header; added a floating full-screen button that lifts the view above the
+  bar+dock (reusing the existing fullscreen layer), and the fullscreen header
+  returns so you can exit/reach help.
+- **Verified the other action-bar apps on mobile** (Stable Matching, Agentic
+  Sorting, Trinary) and the **ComplexParticles EXPLAINER** now documents the
+  Orbit toggle. Build/lint/test green.
+
 ### 🟢 code · 16:48 — Branded loading screen for lazy routes
 
 **Why:** User asked about the load screen — the Suspense fallback was a blank

--- a/index.html
+++ b/index.html
@@ -21,9 +21,17 @@
       body {
         overflow: hidden;
         font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, sans-serif;
-        background: #0c0c10;
-        color: #f0f0f3;
+        background: #0a0c12;
+        color: #eef1f7;
       }
+      /* Boot background per skin — applied by the inline script below via
+         <html data-theme>, so the first paint matches the persisted skin
+         instead of flashing dark before the bundled theme.css loads. */
+      html[data-theme='light']     body { background: #f0ede4; color: #1d1c18; }
+      html[data-theme='blueprint'] body { background: #0e2148; color: #f2f6ff; }
+      html[data-theme='phosphor']  body { background: #03100a; color: #d4ffe0; }
+      html[data-theme='neon']      body { background: #05060f; color: #e9f0ff; }
+      html[data-theme='dark']      body { background: #0a0c12; color: #eef1f7; }
       #root { height: 100%; }
 
       button {
@@ -41,6 +49,18 @@
         }
       }
     </style>
+    <script>
+      /* Set <html data-theme> from the persisted skin at parse time, before the
+         bundle loads, so the boot background (above) matches — no skin flash.
+         applyPersistedSkin() in the bundle re-applies the same value. */
+      (function () {
+        try {
+          var s = localStorage.getItem('animath:v1:chrome:skin');
+          var ok = ['dark', 'light', 'blueprint', 'phosphor', 'neon'];
+          document.documentElement.setAttribute('data-theme', ok.indexOf(s) >= 0 ? s : 'dark');
+        } catch (e) { /* private mode — fall back to the default skin */ }
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
+import { LoadingScreen } from './chrome/LoadingScreen';
 
 const ComplexParticles = React.lazy(() => import('./animations/ComplexParticles/ComplexParticles'));
 
 export default function App() {
   return (
-    <React.Suspense fallback={<div style={{ background: 'var(--bg, #000)', width: '100%', height: '100%' }} />}>
+    <React.Suspense fallback={<LoadingScreen />}>
       <ComplexParticles />
     </React.Suspense>
   );

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -55,6 +55,12 @@ picture is a morph to help your eye track points, not a mathematical map in
 its own right. The 4-D axis cross belongs to the linear views and fades out
 toward the Torus, where the scaffold takes over as the reference frame.
 
+The **Orbit** toggle (Camera panel) sets how a drag moves the camera:
+**Turntable** (default) keeps "up" pointing up and stops at the poles, so the
+view is easy to recenter by hand; **Free** is an unbounded trackball that
+tumbles past the poles and can roll. Either way a drag only moves the *camera* —
+the 4-D rotation lives on the buttons.
+
 - **Drop axis** (4D Rotation panel) — the bluntest projection: just forget
   one of the four coordinates and keep the other three (an orthographic
   slice). Picking one returns the slider to Perspective so the two controls

--- a/src/animations/StableMarriage/stableMarriage.css
+++ b/src/animations/StableMarriage/stableMarriage.css
@@ -180,11 +180,7 @@
   gap: 8px;
 }
 
-.sm-toggle input[type='checkbox'] {
-  accent-color: var(--accent);
-  width: 16px;
-  height: 16px;
-}
+/* the checkbox itself is token-styled globally (chrome/theme.css) */
 
 /* playback transport: 2×2 button grid */
 .sm-actions {

--- a/src/chrome/ExplainerModal.tsx
+++ b/src/chrome/ExplainerModal.tsx
@@ -25,13 +25,13 @@ export function ExplainerModal({ title, markdown, onClose }: {
 }) {
   useEscLayer(true, onClose);
   return createPortal(
-    <div className="am-modal-scrim" onClick={onClose} role="presentation">
+    <div className="am-modal-scrim" onPointerDown={onClose} role="presentation">
       <div
         className="am-modal"
         role="dialog"
         aria-modal="true"
         aria-label={`${title} — explainer`}
-        onClick={e => e.stopPropagation()}
+        onPointerDown={e => e.stopPropagation()}
       >
         <div className="am-modal-head">
           <h2>{title}</h2>

--- a/src/chrome/Gallery.tsx
+++ b/src/chrome/Gallery.tsx
@@ -4,6 +4,7 @@ import { useSkin } from './skins';
 import { TopBar } from './TopBar';
 import { Preview } from './previews';
 import { CARDS, CATEGORIES } from './catalog';
+import { rollHeroVerbs } from './heroVerbs';
 
 /**
  * The landing gallery (DESIGN-SPEC §1): hero, category filter chips, one
@@ -15,6 +16,19 @@ export default function Gallery() {
   const [cat, setCat] = useState<(typeof CATEGORIES)[number]>('All');
   const [skin] = useSkin();
   const cards = CARDS.filter(c => cat === 'All' || c.cat === cat);
+  // Randomized hero verbs — three drawn per load, the strangest one last.
+  // Clicking the headline rerolls them (a quiet easter egg), cross-fading
+  // unless the visitor prefers reduced motion.
+  const [verbs, setVerbs] = useState(rollHeroVerbs);
+  const [swapping, setSwapping] = useState(false);
+  const reroll = () => {
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      setVerbs(rollHeroVerbs());
+      return;
+    }
+    setSwapping(true);
+    window.setTimeout(() => { setVerbs(rollHeroVerbs()); setSwapping(false); }, 180);
+  };
   return (
     <div className="am-app am-gallery-app">
       <TopBar
@@ -24,11 +38,14 @@ export default function Gallery() {
       />
       <div className="am-gal-scroll">
         <div className="am-gal-hero">
-          <div className="am-gal-kicker">Animated mathematics</div>
-          <h1 className="am-gal-title">See the math move.</h1>
+          <h1
+            className={`am-gal-title am-gal-title-roll${swapping ? ' is-swapping' : ''}`}
+            onClick={reroll}
+          >
+            Small worlds you can <b>{verbs[0]}</b>, <b>{verbs[1]}</b>, and <b>{verbs[2]}</b>.
+          </h1>
           <p className="am-gal-tag">
-            Each tool turns an idea — complex functions, fractals, chaotic orbits —
-            into something you can steer. Pick one to open its workspace.
+            Move a slider, change a rule, and watch how the world responds.
           </p>
         </div>
         <div className="am-gal-filters">

--- a/src/chrome/LoadingScreen.tsx
+++ b/src/chrome/LoadingScreen.tsx
@@ -1,0 +1,18 @@
+/**
+ * The Suspense fallback for lazy-loaded routes (src/index.tsx). A code-split
+ * app chunk — plus Three.js for the 3D/fractal viewers — can take a beat to
+ * download; this shows a skinned splash (the brand mark pulsing inside a
+ * spinning accent ring) on the dotted stage instead of a blank flash. It reads
+ * the active `data-theme`, so it matches whatever skin is persisted.
+ */
+export function LoadingScreen() {
+  return (
+    <div className="am-loading" role="status" aria-live="polite" aria-label="Loading">
+      <div className="am-loading-mark">
+        <span className="am-loading-ring" aria-hidden="true" />
+        <span className="am-brand-mark">a</span>
+      </div>
+      <span className="am-loading-text">Loading…</span>
+    </div>
+  );
+}

--- a/src/chrome/heroVerbs.ts
+++ b/src/chrome/heroVerbs.ts
@@ -1,0 +1,47 @@
+/**
+ * Landing-hero verb pool + selector (used by src/chrome/Gallery.tsx).
+ *
+ * The hero headline reads "Small worlds you can <A>, <B>, and <C>." where
+ * A/B/C are drawn fresh on each page load (and on each headline click). Tiers:
+ * 0 = plain, 1 = lively, 2 = out-there. {@link rollHeroVerbs} guarantees at
+ * least one tier-2 word and sorts the three by tier, so the strangest verb
+ * always lands last as the punchline.
+ *
+ * To tune the voice: add/remove words, or move a word between tiers by changing
+ * its tier number. The only rule — each word must read true in "Small worlds
+ * you can ___." Keep a few tier-2 words so the punchline slot always has
+ * something strange to draw. American spelling throughout (see CLAUDE.md).
+ */
+type HeroVerb = readonly [word: string, tier: 0 | 1 | 2];
+
+const HERO_VERBS: readonly HeroVerb[] = [
+  // tier 0 — plain
+  ['adjust', 0], ['explore', 0], ['steer', 0], ['tune', 0], ['shift', 0], ['nudge', 0], ['open', 0], ['drag', 0],
+  ['probe', 0], ['trace', 0], ['shape', 0], ['mold', 0], ['guide', 0], ['arrange', 0], ['rearrange', 0],
+  ['reshape', 0], ['sample', 0], ['navigate', 0],
+  // tier 1 — lively
+  ['poke', 1], ['prod', 1], ['tilt', 1], ['jostle', 1], ['wobble', 1], ['ruffle', 1], ['stir', 1], ['shake', 1],
+  ['twist', 1], ['bend', 1], ['warp', 1], ['coax', 1], ['spin', 1], ['pinch', 1], ['flick', 1], ['sway', 1],
+  ['tease', 1], ['tickle', 1], ['jiggle', 1], ['knead', 1], ['squeeze', 1], ['stretch', 1], ['fold', 1],
+  ['crumple', 1], ['swirl', 1], ['whirl', 1], ['rock', 1], ['tap', 1], ['tug', 1], ['yank', 1], ['jab', 1],
+  ['churn', 1], ['wiggle', 1], ['waggle', 1], ['slosh', 1], ['swish', 1], ['bounce', 1], ['jolt', 1],
+  // tier 2 — out there
+  ['disturb', 2], ['unsettle', 2], ['perturb', 2], ['provoke', 2], ['rattle', 2], ['pester', 2], ['needle', 2],
+  ['goad', 2], ['agitate', 2], ['rouse', 2], ['badger', 2], ['spook', 2], ['derange', 2], ['vex', 2], ['nettle', 2],
+  ['discombobulate', 2], ['befuddle', 2], ['harass', 2], ['bamboozle', 2], ['flummox', 2], ['bewilder', 2],
+  ['confound', 2], ['fluster', 2], ['nag', 2], ['taunt', 2], ['torment', 2], ['harry', 2], ['plague', 2],
+  ['rile', 2], ['irk', 2], ['antagonize', 2], ['bedevil', 2], ['hector', 2], ['perplex', 2], ['frazzle', 2],
+  ['unnerve', 2],
+];
+
+/** Draw three distinct verbs — at least one tier-2, sorted so it lands last. */
+export function rollHeroVerbs(): [string, string, string] {
+  const wild = HERO_VERBS.filter(v => v[1] === 2);
+  const seed = wild[(Math.random() * wild.length) | 0];
+  const chosen = new Set<number>([HERO_VERBS.indexOf(seed)]);
+  while (chosen.size < 3) chosen.add((Math.random() * HERO_VERBS.length) | 0);
+  return [...chosen]
+    .map(i => HERO_VERBS[i])
+    .sort((a, b) => a[1] - b[1]) // weird one (tier 2) lands last
+    .map(v => v[0]) as [string, string, string];
+}

--- a/src/chrome/skins.tsx
+++ b/src/chrome/skins.tsx
@@ -70,7 +70,7 @@ export function SkinPicker({ skin, onSetSkin, compact }: {
       </button>
       {open && (
         <>
-          <div className="am-menu-scrim" onClick={() => setOpen(false)} />
+          <div className="am-menu-scrim" onPointerDown={() => setOpen(false)} />
           <div className="am-skin-menu">
             <div className="am-lay-group">Skins</div>
             {SKINS.map(s => (

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -370,6 +370,12 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-gal-title-roll { cursor: pointer; }
 .am-gal-title b { color: var(--accent); font-weight: inherit; transition: opacity .18s ease; }
 .am-gal-title.is-swapping b { opacity: 0; }
+/* Blueprint's accent equals its text color (chalk-white on blue), so the verbs
+   wouldn't stand out — use the counter-accent (blue) there instead. */
+[data-theme="blueprint"] .am-gal-title b { color: var(--accent-2); }
+/* Phosphor sets the title in a monospace display face, which runs much wider —
+   pull the size down so the longer randomized headline doesn't blow out. */
+[data-theme="phosphor"] .am-gal-title { font-size: 30px; letter-spacing: -0.01em; }
 @media (prefers-reduced-motion: reduce) {
   .am-gal-title b { transition: none; }
 }

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -379,6 +379,32 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 @keyframes am-fade { from { opacity: 0; } to { opacity: 1; } }
 @keyframes am-pop { from { opacity: 0; transform: scale(.97); } to { opacity: 1; transform: none; } }
 @keyframes am-slideup { from { transform: translateY(100%); } to { transform: none; } }
+@keyframes am-spin { to { transform: rotate(360deg); } }
+@keyframes am-loading-pulse { 0%, 100% { transform: scale(1); opacity: 1; } 50% { transform: scale(.9); opacity: .8; } }
+
+/* ============ Loading screen (lazy-route Suspense fallback) ============
+   A skinned splash on the dotted stage — the brand mark pulsing inside a
+   spinning accent ring — while a route's code-split chunk (and Three.js)
+   downloads, instead of a blank flash. */
+.am-loading {
+  position: absolute; inset: 0; z-index: var(--z-modal);
+  display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 20px;
+  background-color: var(--bg);
+  background-image: radial-gradient(circle at 1px 1px, var(--dot-color, rgba(132,132,156,0.13)) 1px, transparent 1.5px);
+  background-size: 24px 24px;
+  color: var(--dim); animation: am-fade .2s var(--ease);
+}
+.am-loading-mark { position: relative; width: 58px; height: 58px; display: grid; place-items: center; }
+.am-loading-ring {
+  position: absolute; inset: 0; border-radius: 50%;
+  border: 2.5px solid var(--border); border-top-color: var(--accent);
+  animation: am-spin .85s linear infinite;
+}
+.am-loading-mark .am-brand-mark {
+  width: 36px; height: 36px; border-radius: 10px; font-size: 21px;
+  animation: am-loading-pulse 1.5s var(--ease) infinite;
+}
+.am-loading-text { font-family: var(--font-ui); font-size: 13px; font-weight: 600; letter-spacing: .03em; }
 
 /* ============ Workspace — left icon rail + windows on a void stage ============ */
 .am-ws-railwrap { position: absolute; top: 14px; left: 14px; bottom: 14px; z-index: var(--z-rail); }

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -45,6 +45,7 @@
 /* ---------------- Observatory · dark (default) ----------------
    Cool blue-black ink, warm refined gold, faint cyan structure. */
 [data-theme="dark"] {
+  color-scheme: dark;
   --bg: #0a0c12;
   --viz-bg: #04060c;
   --panel: rgba(18,21,30,0.84);
@@ -68,6 +69,7 @@
 /* ---------------- Paper · light ----------------
    Warm paper, deep ink, deepened amber for contrast. */
 [data-theme="light"] {
+  color-scheme: light;
   --bg: #f0ede4;
   --viz-bg: #f6f3ec;
   --panel: rgba(255,255,255,0.92);
@@ -91,6 +93,7 @@
 /* ---------------- Blueprint · drafting board ----------------
    Deep drafting blue, chalk-white line work, technical and crisp. */
 [data-theme="blueprint"] {
+  color-scheme: dark;
   --bg: #0e2148;
   --viz-bg: #0a1838;
   --panel: rgba(18,42,90,0.88);
@@ -115,6 +118,7 @@
 /* ---------------- Phosphor · CRT terminal ----------------
    Near-black green glass, phosphor trace, everything mono. */
 [data-theme="phosphor"] {
+  color-scheme: dark;
   --bg: #03100a;
   --viz-bg: #020c07;
   --panel: rgba(8,28,17,0.88);
@@ -141,6 +145,7 @@
 /* ---------------- Spectrum · neon ----------------
    Deep space black, cyan primary, magenta counter-accent. */
 [data-theme="neon"] {
+  color-scheme: dark;
   --bg: #05060f;
   --viz-bg: #04050d;
   --panel: rgba(13,17,33,0.62);
@@ -340,10 +345,12 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-num::-webkit-outer-spin-button, .am-num::-webkit-inner-spin-button { opacity: 0.4; }
 
 /* ============ Generic scrim (menus, modals) ============ */
-.am-menu-scrim { position: fixed; inset: 0; z-index: var(--z-menu-scrim); }
+/* cursor:pointer + touch-action keep these bare dismiss layers tappable in one
+   touch (Safari only synthesizes taps on elements it deems clickable). */
+.am-menu-scrim { position: fixed; inset: 0; z-index: var(--z-menu-scrim); cursor: pointer; touch-action: manipulation; }
 
 /* ============ Explainer modal ============ */
-.am-modal-scrim { position: fixed; inset: 0; z-index: var(--z-modal); background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; }
+.am-modal-scrim { position: fixed; inset: 0; z-index: var(--z-modal); background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; cursor: pointer; touch-action: manipulation; }
 .am-modal { width: min(560px, 92%); max-height: 86%; overflow-y: auto; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow); padding: 22px 24px; animation: am-pop .2s var(--ease); }
 .am-modal h2 { margin: 0 0 12px; font-size: 19px; }
 .am-modal-head { display: flex; align-items: center; gap: 10px; }
@@ -611,11 +618,23 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-phone-view-body > * { position: absolute; inset: 0; }
 
 /* Immersive single-view apps: the lone view fills the screen edge-to-edge and
-   the floating bar + dock overlay it (no reserved strip, no card chrome). */
+   the floating bar + dock overlay it (no reserved strip, no card chrome). The
+   header (and its full-screen/help buttons) is hidden until the view is taken
+   full screen — there the chrome-free fullscreen header returns so you can
+   exit and reach help. */
 .am-phone-immersive .am-phone-scroll { padding: 0; gap: 0; }
 .am-phone-immersive .am-phone-view-solo { border: none; border-radius: 0; min-height: 0; box-shadow: none; }
-.am-phone-immersive .am-phone-view-solo > .am-ws-vhead,
+.am-phone-immersive .am-phone-view-solo:not(.am-ws-full) > .am-ws-vhead,
 .am-phone-immersive .am-phone-view-solo > .am-phone-vresize { display: none; }
+/* The lone affordance overlaid on an immersive view: take it full screen,
+   which lifts it above the floating bar + dock for a chrome-free canvas. */
+.am-phone-immersive-expand {
+  position: absolute; top: 64px; right: 12px; z-index: var(--z-actionbar);
+  width: 38px; height: 38px; display: grid; place-items: center;
+  border-radius: 11px; border: 1px solid var(--border-strong);
+  background: var(--panel); backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+  color: var(--fg); box-shadow: var(--shadow); cursor: pointer;
+}
 /* chip switcher for layout-modeled exclusive views (matrix/welfare/lattice …) */
 .am-phone-layouts { display: flex; gap: 6px; overflow-x: auto; flex-shrink: 0; padding-bottom: 2px; scrollbar-width: none; }
 .am-phone-layouts::-webkit-scrollbar { display: none; }
@@ -640,7 +659,7 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-phone-sheet-head .am-sec-tier { margin-left: auto; }
 .am-phone-sheet-title { font-size: 14.5px; font-weight: 700; }
 .am-phone-sheet-body { overflow-y: auto; padding: 10px 16px 22px; }
-.am-phone-scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.35); z-index: var(--z-sheet-scrim); }
+.am-phone-scrim { position: absolute; inset: 0; background: rgba(0,0,0,0.35); z-index: var(--z-sheet-scrim); cursor: pointer; touch-action: manipulation; }
 .am-sheet-grip { width: 36px; height: 4px; border-radius: 2px; background: var(--track); position: absolute; top: 7px; left: 50%; transform: translateX(-50%); }
 .am-sec-tier { font-family: var(--font-mono); font-size: 9px; font-weight: 700; letter-spacing: .09em; text-transform: uppercase; color: var(--accent); border: 1px solid var(--border); border-radius: 999px; padding: 3px 8px; }
 

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -365,6 +365,14 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-gal-hero { padding: 40px 40px 8px; }
 .am-gal-kicker { font-family: var(--font-mono); font-size: 12px; letter-spacing: .14em; text-transform: uppercase; color: var(--accent); }
 .am-gal-title { font-size: 40px; font-weight: 850; letter-spacing: -0.03em; margin: 8px 0 6px; }
+/* Randomized hero verbs: accented, at the title's own weight, cross-fading on
+   reroll. The headline itself is the (silent) reroll target — just a pointer. */
+.am-gal-title-roll { cursor: pointer; }
+.am-gal-title b { color: var(--accent); font-weight: inherit; transition: opacity .18s ease; }
+.am-gal-title.is-swapping b { opacity: 0; }
+@media (prefers-reduced-motion: reduce) {
+  .am-gal-title b { transition: none; }
+}
 .am-gal-tag { font-size: 15px; color: var(--dim); max-width: 52ch; line-height: 1.5; }
 .am-gal-filters { display: flex; gap: 8px; padding: 18px 40px 0; flex-wrap: wrap; }
 .am-chip { padding: 7px 14px; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--dim); font: inherit; font-size: 12.5px; font-weight: 700; cursor: pointer; }

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -28,14 +28,16 @@
   --z-window: 30;
   --z-topbar: 30;
   --z-dock: 40;
-  --z-sheet-scrim: 45;
-  --z-sheet: 50;
   --z-tip: 60;
   --z-menu-scrim: 70;
   --z-menu: 71;
   --z-full: 100;
   --z-over-full: 110;
   --z-actionbar: 130;
+  /* the phone bottom sheet + scrim sit above the always-on action strip, so an
+     open panel covers the primary verbs instead of letting them poke through */
+  --z-sheet-scrim: 135;
+  --z-sheet: 136;
   --z-modal: 150;
   --z-rail: 200;
 }

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -278,6 +278,41 @@ body {
 .am-toggle.am-on .am-switch { background: var(--accent); }
 .am-toggle.am-on .am-switch::after { transform: translateX(16px); }
 
+/* Checkboxes — one token-styled box for every app. Native checkboxes paint
+   from the page color-scheme (which the app never sets), so in skins whose
+   accent is near-white (e.g. Blueprint) the native box vanished into the
+   panel. This draws our own box from theme tokens so the affordance reads in
+   every skin. Custom pill switches (.am-switch) are divs, so they opt out. */
+input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  flex-shrink: 0;
+  margin: 0;
+  border: 1.5px solid var(--dim, #9b9ba3);
+  border-radius: 4px;
+  background: var(--panel-solid, #16161c);
+  cursor: pointer;
+  display: inline-grid;
+  place-content: center;
+  vertical-align: middle;
+}
+input[type="checkbox"]:hover { border-color: var(--fg, #f0f0f3); }
+input[type="checkbox"]:checked { background: var(--accent); border-color: var(--accent); }
+input[type="checkbox"]::after {
+  content: "";
+  width: 4px;
+  height: 8px;
+  margin-top: -1px;
+  border: solid var(--accent-fg, #0c0c10);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  opacity: 0;
+}
+input[type="checkbox"]:checked::after { opacity: 1; }
+input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
 .am-num { width: 100%; background: var(--panel-2); border: 1px solid var(--border); color: var(--fg); font: inherit; font-size: 13px; padding: 8px 10px; border-radius: 7px; }
 
 /* segmented mini buttons (turn pads, playback rows) */
@@ -546,6 +581,13 @@ body {
 .am-phone-view .am-ws-vhead { cursor: default; flex-shrink: 0; }
 .am-phone-view-body { position: relative; flex: 1; min-height: 0; background: var(--viz-bg); }
 .am-phone-view-body > * { position: absolute; inset: 0; }
+
+/* Immersive single-view apps: the lone view fills the screen edge-to-edge and
+   the floating bar + dock overlay it (no reserved strip, no card chrome). */
+.am-phone-immersive .am-phone-scroll { padding: 0; gap: 0; }
+.am-phone-immersive .am-phone-view-solo { border: none; border-radius: 0; min-height: 0; box-shadow: none; }
+.am-phone-immersive .am-phone-view-solo > .am-ws-vhead,
+.am-phone-immersive .am-phone-view-solo > .am-phone-vresize { display: none; }
 /* chip switcher for layout-modeled exclusive views (matrix/welfare/lattice …) */
 .am-phone-layouts { display: flex; gap: 6px; overflow-x: auto; flex-shrink: 0; padding-bottom: 2px; scrollbar-width: none; }
 .am-phone-layouts::-webkit-scrollbar { display: none; }

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -531,10 +531,20 @@ body {
 
 /* ============ Phone workspace (≤740px) ============ */
 .am-phone-app { display: flex; flex-direction: column; }
-.am-phone-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 14px 14px 90px; display: flex; flex-direction: column; gap: 12px; background-color: var(--bg); background-image: radial-gradient(circle at 1px 1px, var(--dot-color, rgba(132,132,156,0.13)) 1px, transparent 1.5px); background-size: 24px 24px; }
-.am-phone-view { border: 1px solid var(--border-strong); border-radius: 13px; overflow: hidden; background: var(--panel-solid); box-shadow: var(--shadow); flex-shrink: 0; }
-.am-phone-view .am-ws-vhead { cursor: default; }
-.am-phone-view-body { position: relative; height: 56vw; max-height: 340px; background: var(--viz-bg); }
+/* The top bar floats over the stage as a translucent pill, so the view cards
+   reclaim its strip and fill the screen (the dock floats the same way below). */
+.am-phone-app > .am-bar {
+  position: absolute; top: 8px; left: 8px; right: 8px;
+  height: 48px; padding: 0 8px;
+  border: 1px solid var(--border-strong); border-bottom: 1px solid var(--border-strong);
+  border-radius: 15px; box-shadow: var(--shadow); z-index: var(--z-dock);
+}
+/* View cards fill the space between the floating bar and the floating dock;
+   with one open view it fills the screen, with several they split it. */
+.am-phone-scroll { flex: 1; min-height: 0; overflow-y: auto; padding: 64px 10px 92px; display: flex; flex-direction: column; gap: 10px; background-color: var(--bg); background-image: radial-gradient(circle at 1px 1px, var(--dot-color, rgba(132,132,156,0.13)) 1px, transparent 1.5px); background-size: 24px 24px; }
+.am-phone-view { display: flex; flex-direction: column; flex: 1 1 0; min-height: 200px; border: 1px solid var(--border-strong); border-radius: 13px; overflow: hidden; background: var(--panel-solid); box-shadow: var(--shadow); }
+.am-phone-view .am-ws-vhead { cursor: default; flex-shrink: 0; }
+.am-phone-view-body { position: relative; flex: 1; min-height: 0; background: var(--viz-bg); }
 .am-phone-view-body > * { position: absolute; inset: 0; }
 /* chip switcher for layout-modeled exclusive views (matrix/welfare/lattice …) */
 .am-phone-layouts { display: flex; gap: 6px; overflow-x: auto; flex-shrink: 0; padding-bottom: 2px; scrollbar-width: none; }

--- a/src/chrome/workspace/LayoutsMenu.tsx
+++ b/src/chrome/workspace/LayoutsMenu.tsx
@@ -58,7 +58,7 @@ export function LayoutsControl({ current, builtin, saved, onPick, onSave, onDele
       </button>
       {open && (
         <>
-          <div className="am-menu-scrim" onClick={() => setOpen(false)} />
+          <div className="am-menu-scrim" onPointerDown={() => setOpen(false)} />
           <div className="am-layouts-menu" role="menu">
             <div className="am-lay-group">Workspaces</div>
             {builtin.map(Item)}

--- a/src/chrome/workspace/PhoneWorkspace.tsx
+++ b/src/chrome/workspace/PhoneWorkspace.tsx
@@ -58,12 +58,13 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
   const dockRef = useRef<HTMLElement>(null);
   const dockHint = useScrollHints(dockRef, 'x');
 
-  /* drag the bottom grip to resize a card; fullscreen restyles the same DOM
-     node (CSS-only), so WebGL engines keep their context either way */
+  /* Cards fill the screen by default (flex), so the bottom grip resizes the
+     whole card by pinning its flex-basis; fullscreen restyles the same DOM
+     node (CSS-only), so WebGL engines keep their context either way. */
   const onResizeDown = (id: string) => (e: React.PointerEvent) => {
     e.preventDefault();
-    const body = (e.currentTarget as HTMLElement).previousElementSibling as HTMLElement | null;
-    const oh = body?.offsetHeight ?? 240;
+    const card = (e.currentTarget as HTMLElement).parentElement as HTMLElement | null;
+    const oh = card?.offsetHeight ?? 280;
     beginPointerDrag(e, (_dx, dy) => {
       const h = Math.round(Math.min(Math.max(oh + dy, MIN_CARD_H), maxCardH()));
       setCardH(prev => ({ ...prev, [id]: h }));
@@ -106,11 +107,18 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
         {views.map(v => {
           const isFull = full === v.id;
           const h = cardH[v.id];
+          // A manually-resized card pins its flex-basis (and stops growing);
+          // otherwise it flex-fills the stage. Fullscreen ignores both.
+          const cardStyle: React.CSSProperties | undefined = !viewOpen(v.id)
+            ? { display: 'none' }
+            : !isFull && h
+              ? { flex: `0 0 ${h}px` }
+              : undefined;
           return (
             <div
               className={`am-phone-view${isFull ? ' am-ws-full' : ''}`}
               key={v.id}
-              style={!viewOpen(v.id) ? { display: 'none' } : undefined}
+              style={cardStyle}
             >
               <div className="am-ws-vhead">
                 <span className="am-ws-vico"><Icon name="window" size={13} /></span>
@@ -136,7 +144,6 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
               </div>
               <div
                 className="am-phone-view-body"
-                style={!isFull && h ? { height: h, maxHeight: 'none' } : undefined}
                 onPointerDownCapture={
                   v.hint && !hintSeen[v.id]
                     ? () => setHintSeen(s => ({ ...s, [v.id]: true }))

--- a/src/chrome/workspace/PhoneWorkspace.tsx
+++ b/src/chrome/workspace/PhoneWorkspace.tsx
@@ -25,6 +25,10 @@ const maxCardH = () => Math.round(window.innerHeight * 0.8);
 export default function PhoneWorkspace(props: WorkspaceProps) {
   const { appId, title, subtitle, views, layouts: appLayouts, defaultLayoutId, explainer, titlePanel, topExtra, actions, modes, activeMode, onModeChange } = props;
   const sections = useMemo(() => sortByTier(props.sections), [props.sections]);
+  // Single-view apps go full-bleed: the lone view fills the whole screen and
+  // the top bar floats over it (overlaid), rather than sitting above it. Multi-
+  // view apps keep the stacked cards below the bar.
+  const immersive = views.length === 1;
   const [sheet, setSheet] = useState<string | null>(null);
   /* per-view card heights are layout state (like desktop view rects) — persisted */
   const [cardH, setCardH] = usePersistentState<Record<string, number>>(`wsphone:${appId}`, {});
@@ -72,7 +76,7 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
   };
 
   return (
-    <div className={`am-app am-phone-app${actions?.length ? ' am-has-actions' : ''}`}>
+    <div className={`am-app am-phone-app${actions?.length ? ' am-has-actions' : ''}${immersive ? ' am-phone-immersive' : ''}`}>
       <TopBar
         title={title}
         subtitle={subtitle}
@@ -116,7 +120,7 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
               : undefined;
           return (
             <div
-              className={`am-phone-view${isFull ? ' am-ws-full' : ''}`}
+              className={`am-phone-view${isFull ? ' am-ws-full' : ''}${immersive ? ' am-phone-view-solo' : ''}`}
               key={v.id}
               style={cardStyle}
             >

--- a/src/chrome/workspace/PhoneWorkspace.tsx
+++ b/src/chrome/workspace/PhoneWorkspace.tsx
@@ -166,6 +166,19 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
                   <i />
                 </div>
               )}
+              {/* Immersive apps hide the card header, so this floating button is
+                  the way into (chrome-free) full screen; the fullscreen header
+                  brings back exit + help. */}
+              {immersive && !isFull && (
+                <button
+                  className="am-phone-immersive-expand"
+                  title="Full screen"
+                  aria-label={`Full screen ${v.title}`}
+                  onClick={() => setFull(v.id)}
+                >
+                  <Icon name="expand" size={15} />
+                </button>
+              )}
             </div>
           );
         })}
@@ -204,7 +217,7 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
       </div>
       {active && (
         <>
-          <div className="am-phone-scrim" onClick={() => setSheet(null)} role="presentation" />
+          <div className="am-phone-scrim" onPointerDown={() => setSheet(null)} role="presentation" />
           <div className="am-phone-sheet" role="dialog" aria-label={active.title}>
             <div className="am-sheet-grip" />
             <div className="am-phone-sheet-head">

--- a/src/chrome/workspace/layers.ts
+++ b/src/chrome/workspace/layers.ts
@@ -14,8 +14,6 @@ export const LAYER = {
   window: 30,
   topbar: 30,
   phoneDock: 40,
-  phoneScrim: 45,
-  phoneSheet: 50,
   railTip: 60,
   menuScrim: 70,
   menu: 71,
@@ -25,6 +23,11 @@ export const LAYER = {
   overFull: 110,
   /** The always-on action strip — above every window, even in fullscreen. */
   actionbar: 130,
+  /** The phone bottom sheet (an open panel) + its scrim sit above the action
+   *  strip, so opening a control panel covers the always-on verbs instead of
+   *  letting them poke through. */
+  phoneScrim: 135,
+  phoneSheet: 136,
   /** Modals (explainer) — above fullscreen, portaled to <body>. */
   modal: 150,
   rail: 200,

--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -144,10 +144,43 @@
 }
 .cp-stop:hover { color: var(--cp-fg); }
 .cp-stop-on { color: var(--cp-accent); }
+/* Custom box (not the native control): native checkboxes render from the
+   page color-scheme, which is unset, so in skins whose accent is near-white
+   (e.g. Blueprint) the box vanished into the panel. Draw our own from theme
+   tokens so the affordance reads in every skin. */
 .cp-row input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
   width: 16px;
   height: 16px;
-  accent-color: var(--cp-accent);
+  flex-shrink: 0;
+  margin: 0;
+  border: 1.5px solid var(--cp-fg-dim, #9b9ba3);
+  border-radius: 4px;
+  background: var(--cp-bg-solid, #16161c);
+  cursor: pointer;
+  display: inline-grid;
+  place-content: center;
+}
+.cp-row input[type="checkbox"]:hover { border-color: var(--cp-fg, #f0f0f3); }
+.cp-row input[type="checkbox"]:checked {
+  background: var(--cp-accent);
+  border-color: var(--cp-accent);
+}
+.cp-row input[type="checkbox"]::after {
+  content: "";
+  width: 4px;
+  height: 8px;
+  margin-top: -1px;
+  border: solid var(--accent-fg, #0c0c10);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg);
+  opacity: 0;
+}
+.cp-row input[type="checkbox"]:checked::after { opacity: 1; }
+.cp-row input[type="checkbox"]:focus-visible {
+  outline: 2px solid var(--cp-accent);
+  outline-offset: 2px;
 }
 
 /* Two-thumb range slider (RangeSlider) — two overlapping native range inputs

--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -144,44 +144,8 @@
 }
 .cp-stop:hover { color: var(--cp-fg); }
 .cp-stop-on { color: var(--cp-accent); }
-/* Custom box (not the native control): native checkboxes render from the
-   page color-scheme, which is unset, so in skins whose accent is near-white
-   (e.g. Blueprint) the box vanished into the panel. Draw our own from theme
-   tokens so the affordance reads in every skin. */
-.cp-row input[type="checkbox"] {
-  appearance: none;
-  -webkit-appearance: none;
-  width: 16px;
-  height: 16px;
-  flex-shrink: 0;
-  margin: 0;
-  border: 1.5px solid var(--cp-fg-dim, #9b9ba3);
-  border-radius: 4px;
-  background: var(--cp-bg-solid, #16161c);
-  cursor: pointer;
-  display: inline-grid;
-  place-content: center;
-}
-.cp-row input[type="checkbox"]:hover { border-color: var(--cp-fg, #f0f0f3); }
-.cp-row input[type="checkbox"]:checked {
-  background: var(--cp-accent);
-  border-color: var(--cp-accent);
-}
-.cp-row input[type="checkbox"]::after {
-  content: "";
-  width: 4px;
-  height: 8px;
-  margin-top: -1px;
-  border: solid var(--accent-fg, #0c0c10);
-  border-width: 0 2px 2px 0;
-  transform: rotate(45deg);
-  opacity: 0;
-}
-.cp-row input[type="checkbox"]:checked::after { opacity: 1; }
-.cp-row input[type="checkbox"]:focus-visible {
-  outline: 2px solid var(--cp-accent);
-  outline-offset: 2px;
-}
+/* Checkboxes are styled globally (token-styled box) in chrome/theme.css, so
+   every app shares one look — nothing to override here. */
 
 /* Two-thumb range slider (RangeSlider) — two overlapping native range inputs
    over a shared rail + fill. The inputs' tracks ignore pointer events so both

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -298,9 +298,22 @@ export default function ParticleViewerShell({
         value={state.viewMotion}
         onChange={controls.handleMotion}
       />
+      {/* How a drag tumbles the camera. Turntable (default) is the bounded
+          orbit — up stays up, elevation clamps at the poles — so the scene is
+          easy to recenter by hand; Free is the unbounded trackball that tumbles
+          past the poles and can roll. */}
+      <Pills
+        label="Orbit"
+        options={[
+          { value: 'turntable', label: 'Turntable' },
+          { value: 'free', label: 'Free' },
+        ]}
+        value={state.orbitMode}
+        onChange={state.setOrbitMode}
+      />
       {/* Desktop pans with modifiers (right-drag, held Space, Shift), so the
-          mode toggle only exists on phone, where one-finger drag must choose
-          (two-finger drag always pans there). */}
+          drag-mode toggle only exists on phone, where one-finger drag must
+          choose (two-finger drag always pans there). */}
       {phone ? (
         <Pills
           label="Drag"

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import Gallery from './chrome/Gallery';
+import { LoadingScreen } from './chrome/LoadingScreen';
 import './chrome/theme.css';
 import { applyPersistedSkin } from './chrome/skins';
 
@@ -68,7 +69,7 @@ function Router(): JSX.Element {
   if (path === '/' || !Component) return <Gallery />;
 
   return (
-    <React.Suspense fallback={<div style={{ background: 'var(--bg, #000)', width: '100%', height: '100%' }} />}>
+    <React.Suspense fallback={<LoadingScreen />}>
       <Component />
     </React.Suspense>
   );

--- a/src/lib/particles/useGestureRotation.ts
+++ b/src/lib/particles/useGestureRotation.ts
@@ -5,20 +5,34 @@ import type { ParticleState } from './useParticleState';
 
 const ORBIT_SENSITIVITY = 0.006;     // radians of camera orbit per pixel
 const WHEEL_ZOOM_SENSITIVITY = 0.01; // cameraZ delta per wheel deltaY
+const ELEV_LIMIT = Math.PI / 2 - 0.01; // turntable elevation clamp (just shy of the poles)
 
 interface Pt { x: number; y: number; }
 
 const X_AXIS = new THREE.Vector3(1, 0, 0);
 const Y_AXIS = new THREE.Vector3(0, 1, 0);
+const Z_AXIS = new THREE.Vector3(0, 0, 1);
+
+/** The bounded "turntable" orientation: azimuth around world-up, then
+ *  elevation about the camera's right axis. Keeps the horizon level (no roll),
+ *  so identity (az=el=0) is the straight-back default and recentering is easy. */
+function turntableQuat(az: number, el: number) {
+  return new THREE.Quaternion()
+    .setFromAxisAngle(Y_AXIS, az)
+    .multiply(new THREE.Quaternion().setFromAxisAngle(X_AXIS, -el));
+}
 
 /**
  * Pointer-driven CAMERA controls for a particle viewer. Gestures never touch
  * the 4D quaternion rotation — plane rotations live on the on-screen
  * quarter-turn buttons.
  *
- *   1-pointer drag             → free orbit (trackball tumble around the
- *                                look-at target, no pole limits) — or pan,
- *                                when the (phone) Drag mode is Pan.
+ *   1-pointer drag             → orbit the camera around the look-at target.
+ *                                Bounded "turntable" by default (up stays up,
+ *                                elevation clamps at the poles); the Camera
+ *                                panel's Orbit toggle switches to a free
+ *                                trackball that tumbles without limits. Drags
+ *                                pan instead when the (phone) Drag mode is Pan.
  *   right-button drag          → pan (desktop; the canvas context menu is
  *                                suppressed so the drag reads cleanly).
  *   Space (held) / Shift +drag → pan (momentary modifiers — translate the
@@ -87,10 +101,20 @@ export function useGestureRotation(state: ParticleState) {
     state.setPanZ(p => p + right.z * sx + up.z * sy);
   }
 
+  /** Re-derive the turntable's azimuth/elevation from the current camera
+   *  orientation, so a turntable drag continues smoothly from wherever the
+   *  camera is (after a reset, a free-mode tumble, or the ambient orbit). */
+  function syncTurntableFromQuat() {
+    const p = Z_AXIS.clone().applyQuaternion(state.camQuat);
+    state.elevationRef.current = Math.asin(Math.max(-1, Math.min(1, p.y)));
+    state.azimuthRef.current = Math.atan2(p.x, p.z);
+  }
+
   const onPointerDown = (e: React.PointerEvent) => {
     (e.currentTarget as Element).setPointerCapture(e.pointerId);
     pointers.current.set(e.pointerId, { x: e.clientX, y: e.clientY });
     if (e.button === 2) panPointers.current.add(e.pointerId);
+    if (state.orbitMode === 'turntable') syncTurntableFromQuat();
     if (pointers.current.size === 2) {
       const [a, b] = [...pointers.current.values()];
       lastPinchDist.current = Math.hypot(a.x - b.x, a.y - b.y);
@@ -110,7 +134,7 @@ export function useGestureRotation(state: ParticleState) {
       const dy = next.y - prev.y;
       if (e.shiftKey || spaceHeld.current || panPointers.current.has(e.pointerId) || state.dragMode === 'pan') {
         applyPan(dx, dy, el);
-      } else {
+      } else if (state.orbitMode === 'free') {
         // Free trackball orbit: incremental rotations about the camera's own
         // right/up axes, so the tumble never hits a pole stop. Drag-right
         // turns the camera right; drag-up pitches over the top and keeps going.
@@ -118,6 +142,15 @@ export function useGestureRotation(state: ParticleState) {
           .multiply(new THREE.Quaternion().setFromAxisAngle(Y_AXIS, dx * ORBIT_SENSITIVITY))
           .multiply(new THREE.Quaternion().setFromAxisAngle(X_AXIS, dy * ORBIT_SENSITIVITY))
           .normalize());
+      } else {
+        // Bounded turntable: azimuth around world-up, elevation clamped at the
+        // poles. The horizon stays level, so the view is easy to recenter.
+        state.azimuthRef.current += dx * ORBIT_SENSITIVITY;
+        state.elevationRef.current = Math.max(
+          -ELEV_LIMIT,
+          Math.min(ELEV_LIMIT, state.elevationRef.current - dy * ORBIT_SENSITIVITY),
+        );
+        state.setCamQuat(turntableQuat(state.azimuthRef.current, state.elevationRef.current));
       }
     } else if (count >= 2) {
       const others = [...pointers.current.entries()].filter(([id]) => id !== e.pointerId);

--- a/src/lib/particles/useParticleState.ts
+++ b/src/lib/particles/useParticleState.ts
@@ -33,9 +33,20 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
   // Camera orbit + pan are transient "looking" state, not settings — they reset
   // each session (and the Reset orientation button clears them), so they are
   // intentionally NOT persisted.
-  // Free orbit: the camera's orientation quaternion (camera-local → world).
-  // Identity = the straight-back default, at (0, 0, cameraZ) facing the target.
+  // The camera's orientation quaternion (camera-local → world). Identity = the
+  // straight-back default, at (0, 0, cameraZ) facing the target. Both orbit
+  // modes write it; useUniformSync reads it to place the camera.
   const [camQuat, setCamQuat] = useState(() => new THREE.Quaternion());
+  // How a drag tumbles the camera. 'turntable' (default) is the bounded orbit:
+  // horizontal = azimuth around world-up, vertical = elevation clamped to the
+  // poles, so "up" stays up and the scene is easy to recenter by hand.
+  // 'free' is the unbounded trackball — it tumbles past the poles and can roll,
+  // which is powerful but easy to get lost in. This is a setting (persisted).
+  const [orbitMode, setOrbitMode] = usePersistentState<'turntable' | 'free'>(pk('orbitMode'), 'turntable');
+  // Turntable accumulator (azimuth/elevation, radians). Refs, not state, so a
+  // continuous drag never races React renders; camQuat is the rendered output.
+  const azimuthRef = useRef(0);
+  const elevationRef = useRef(0);
   /** What a one-finger drag does: orbit the camera or pan the target. */
   const [dragMode, setDragMode] = useState<'orbit' | 'pan'>('orbit');
   const [panX, setPanX] = useState(0);
@@ -239,6 +250,8 @@ export function useParticleState(options: UseParticleStateOptions = {}) {
     particleCount, setParticleCount,
     cameraZ, setCameraZ,
     camQuat, setCamQuat,
+    orbitMode, setOrbitMode,
+    azimuthRef, elevationRef,
     dragMode, setDragMode,
     panX, setPanX,
     panY, setPanY,

--- a/src/lib/particles/useViewControls.ts
+++ b/src/lib/particles/useViewControls.ts
@@ -102,8 +102,11 @@ export function useViewControls(state: ParticleState) {
     });
     viewPointRef.current = { L: qL.clone(), R: qR.clone() };
     onViewPointChangeRef.current?.(viewPointRef.current);
-    // Camera also returns to its default vantage point.
+    // Camera also returns to its default vantage point. Zero the turntable
+    // accumulator too, so the bounded orbit restarts from the straight-back pose.
     state.setCamQuat(new THREE.Quaternion());
+    state.azimuthRef.current = 0;
+    state.elevationRef.current = 0;
     state.setPanX(0);
     state.setPanY(0);
     state.setPanZ(0);


### PR DESCRIPTION
Camera orbit
- Restore the bounded "turntable" orbit (azimuth around world-up, elevation
  clamped at the poles) as the default, so "up" stays up and the view is easy
  to recenter by hand. The unbounded free trackball is now an opt-in mode via
  a new Camera-panel Orbit toggle (Turntable | Free). Mode is persisted.
- Turntable accumulates az/el in refs and writes camQuat, so the existing
  camera placement (and pan/reset/ambient-orbit) is unchanged; a turntable
  drag re-syncs from the current orientation on pointer-down.

Mobile layout
- The phone top bar now floats as a translucent pill, and view cards flex-fill
  the stage between it and the floating dock: one open view fills the screen,
  several split it. Replaces the small fixed-height (56vw) cards that hid most
  of the visualization. The bottom grip now resizes the whole card (flex-basis).