### PR TITLE
Fix mobile workspace not filling the screen height

### DIFF
--- a/index.html
+++ b/index.html
@@ -32,7 +32,11 @@
       html[data-theme='phosphor']  body { background: #03100a; color: #d4ffe0; }
       html[data-theme='neon']      body { background: #05060f; color: #e9f0ff; }
       html[data-theme='dark']      body { background: #0a0c12; color: #eef1f7; }
-      #root { height: 100%; }
+      /* dvh tracks the *visible* viewport as the mobile URL bar shows/retracts;
+         a plain height:100% chain resolves against the initial containing block
+         and leaves the phone workspace short (dead strip at the bottom). The
+         100% line is the fallback for browsers without dvh. */
+      #root { height: 100%; height: 100dvh; }
 
       button {
         touch-action: manipulation;

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -504,6 +504,9 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
   position: fixed; inset: 0; width: auto; height: auto; max-height: none;
   border: none; border-radius: 0; z-index: var(--z-full); animation: none;
 }
+/* On mobile the dynamic toolbar makes a fixed inset:0 box unreliable; pin it
+   to the visible viewport explicitly so full screen truly fills the screen. */
+.am-phone-view.am-ws-full { height: 100dvh; }
 .am-phone-view.am-ws-full { display: flex; flex-direction: column; }
 .am-phone-view.am-ws-full .am-phone-view-body { height: auto; max-height: none; flex: 1; min-height: 0; }
 


### PR DESCRIPTION
The full-height layout chained height:100% from html down through #root and
.am-app to the flex view card. On mobile that percentage chain resolves
against the initial containing block, which does not track the visible
viewport as the browser's dynamic toolbar shows/retracts, so the phone
workspace ended up shorter than the screen and the view fell through to the
dotted stage background at the bottom.

Give #root a dvh-based height (with a 100% fallback) so the layout tracks the
visible viewport, and pin the explicit fullscreen card to 100dvh since fixed
inset:0 is unreliable under the mobile toolbar.

https://claude.ai/code/session_0187AbVtGeNBFY5Bfqam6YKV