### PR TITLE
Fix mobile crash switching to Torus projection (perspective singularity)

### DIFF
--- a/docs/sessions/handoff/complex-particles-torus-crash-tile/2026-06-14-S02-domain-region.md
+++ b/docs/sessions/handoff/complex-particles-torus-crash-tile/2026-06-14-S02-domain-region.md
@@ -1,0 +1,88 @@
+---
+kind: handoff
+session: 2026-06-14-S02
+date: 2026-06-14
+title: Continuous perspective floor + a polar domain-region band
+branch: claude/complex-particles-torus-crash-tile
+slug: complex-particles-torus-crash-tile
+status: completed
+build: passed
+followup: low
+pr: https://github.com/piyarsquare/animath/pull/216
+app: complex-particles
+---
+
+# Continuous perspective floor + a polar domain-region band
+
+## Summary
+
+Branch `claude/complex-particles-torus-crash-tile` (PR #216) carries two arcs.
+**S01** fixed a mobile context-loss crash when switching to the Torus projection
+(NaN-guarded tile normal + a floored perspective denominator) and preserved the
+projection across a sheet-count rebuild. **S02 (this session)** smoothed that
+perspective floor to be continuous, then added a **Domain region** control to
+Complex Particles. The region feature briefly included quadrants, an
+inside/outside-the-unit-circle filter, and a region tint, but was trimmed back to
+**just a polar Radius `|z|` band** at the user's request. Build and lint are
+clean; the viewer renders headless with no shader error.
+
+## What changed
+
+- **Continuous perspective floor** (`86e6eff`): the S01 fix floored `|3 + p.w|`
+  with a sign flip across the eye plane; reworked so singular points slide off to
+  a finite far field continuously. Mirrored in shader `project()` and JS
+  `viewpoint.ts`.
+- **Domain region — final state** (`a73f870`): the Domain panel gains one control,
+  a **Radius `|z|`** `RangeSlider` (top thumb = ∞ = no upper limit). Implemented
+  as a shader gate `regionMask(z)` that returns 0 outside the band, multiplied
+  into every render mode's alpha — live, no geometry rebuild. Driven by a single
+  `uRegionRadius` vec2 uniform synced from `radiusRange` state.
+- **Removed before merge** (added in `34f0e79`/`8ee9cc6`, removed in `a73f870`):
+  the quadrant chips, the inside/outside filter, and the region tint, plus their
+  `uRegionQuad` / `uSideFilter` / `uTintSides` / `uTintQuad` uniforms and the
+  `divergentTint` / `quadrantTint` GLSL helpers. The pre-existing **Polar**
+  sampling mode was never touched.
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`src/animations/ComplexParticles/shaders/index.ts`](https://github.com/piyarsquare/animath/blob/a73f870/src/animations/ComplexParticles/shaders/index.ts) | `regionMask` gate + `uRegionRadius`; the floored mode-0 `project()` |
+| [`src/animations/ComplexParticles/ComplexParticles.tsx`](https://github.com/piyarsquare/animath/blob/a73f870/src/animations/ComplexParticles/ComplexParticles.tsx) | `radiusRange` state, the Radius `|z|` RangeSlider, uniform sync effect |
+| [`src/lib/viewpoint.ts`](https://github.com/piyarsquare/animath/blob/a73f870/src/lib/viewpoint.ts) | JS mirror of the continuous perspective floor (axis cross) |
+| [`src/animations/ComplexParticles/EXPLAINER.md`](https://github.com/piyarsquare/animath/blob/a73f870/src/animations/ComplexParticles/EXPLAINER.md) | "Domain region" section trimmed to the radius band |
+
+## Open / not done
+
+- **S01 crash fix is still unconfirmed on a real Android device.** That is the
+  branch's only live risk. The fix is reasoned + headless-sanity-checked but the
+  Adreno context loss cannot be reproduced in SwiftShader — recommended next step
+  is to put the PR #216 Cloudflare preview in front of the user's phone running
+  the exact repro (exp · Tiles · Drop X · XY spin · slide Perspective → Torus). See
+  the [S01 report](../../progress/complex-particles-torus-crash-tile/2026-06-13-S01-torus-crash-and-sheet-projection.md).
+- Domain region is intentionally minimal (radius band only). The quadrant / filter
+  / tint variants are recoverable from git at `8ee9cc6` if ever wanted.
+
+## Context
+
+- The branch the task harness named (`claude/mobile-fullscreen-panel-height-*`) is
+  not the one checked out; all work has been on and pushed to
+  `claude/complex-particles-torus-crash-tile`, which is PR #216. Continue there.
+- The radius band is a *render* mask, independent of the **Polar** sampling mode
+  (which changes how points are placed). They compose but don't interact.
+
+## Self-reflection
+
+1. **What would you do with another session?** Drive the PR #216 preview on the
+   user's Android device to close the S01 crash question — the one unverified item.
+2. **What would you change about what you produced?** I built the full
+   quadrant/filter/tint feature before confirming scope, then removed it a commit
+   later. A scope check up front would have avoided the churn.
+3. **What were you not asked that you think is important?** Whether the radius band
+   should also drive Polar sampling density, not just mask the render.
+4. **What did we both overlook?** Nothing material; the trim left no dead uniforms
+   or unused imports (lint clean).
+5. **What did you find difficult?** Nothing notable — clean shader seams.
+6. **What would have made this task easier?** Scoping the region feature up front.
+7. **Follow-up value:** LOW — the shipped radius-band change is complete and
+   verified; the only HIGH item (S01 real-device crash check) is tracked in S01.

--- a/docs/sessions/progress/complex-particles-torus-crash-tile/2026-06-13-S01-torus-crash-and-sheet-projection.md
+++ b/docs/sessions/progress/complex-particles-torus-crash-tile/2026-06-13-S01-torus-crash-and-sheet-projection.md
@@ -1,0 +1,108 @@
+---
+kind: progress
+session: 2026-06-13-S01
+date: 2026-06-13
+title: Torus-switch mobile crash + sheet-count projection reset
+branch: claude/complex-particles-torus-crash-tile
+slug: complex-particles-torus-crash-tile
+status: in-progress
+build: passed
+followup: high
+pr: https://github.com/piyarsquare/animath/pull/216
+app: complex-particles, engine
+---
+
+# Torus-switch mobile crash + sheet-count projection reset
+
+## Session purpose
+
+Two Complex Particles bugs reported from mobile:
+1. With **exp · Drop X · XY spin · Tiles**, sliding the projection
+   **Perspective → Torus** crashes the app (canvas goes black on Android Brave).
+2. Changing the number of Riemann sheets silently resets the camera to the
+   Perspective view; the current viewport should be preserved.
+
+## Previous session
+
+First tracked session on this branch (no `/start-session` was run; report
+written mid-session at the user's request).
+
+## Working notes
+
+<!-- Newest entry first. -->
+
+### 🟢 code · 17:35 — Preserve the projection across a sheet-count rebuild
+**Why:** rebuilt materials reset the projection cross-fade, snapping to Perspective.
+
+Changing the sheet range runs `rebuildBranchObjects`, which disposes and
+recreates every per-branch material. Fresh materials start at `makeUniforms`'
+projection defaults (`uProjMode = uProjTarget = projRef`, `uProjAlpha = 0`),
+collapsing any active cross-fade. The render loop re-pushes **rotation** each
+frame (orientation survived) but never the **projection**, so a Torus/Sphere/
+mid-morph view snapped back to Perspective. Fix: snapshot `uProjMode/uProjTarget/
+uProjAlpha` from the first old material before disposal and restore them onto the
+rebuilt set. **Verified** headless: a sqrt Torus view stays Torus after 1 → 2
+sheets. Commit `521c72c`.
+
+### 🟢 code · 17:20 — Guard the tile face-normal against NaN (likely the real crash fix)
+**Why:** Adreno (Android) faults the GPU on NaN shader output; desktop/SwiftShader don't.
+
+User confirmed the crash is **WebGL context loss** (canvas black, chrome intact)
+on **Android Brave**. In `tileVertexShader`, near a projection fold `cross(du, dv)
+→ 0` and `normalize(0) = NaN`; the NaN reaches `gl_FragColor` via
+`vFacing`/`vNormalView`. Replaced it with a guarded normal (screen-facing
+fallback when the cross product vanishes). Commit `f910ca0`. Drop X never folds
+(no division) — consistent with it being the only stable mode.
+
+### 🟢 code · 17:06 — Stop continuous spins when the projection knob is touched
+**Why:** user's stabilization idea — don't morph while a spin re-sweeps the singularity.
+
+Wrapped the projection slider's `onChange` so it clears all running spins first
+(`handleProjMix` already releases any drop axis). Commit `d4223b4`.
+
+### 🟢 code · 15:40 — Floor the perspective projection denominator
+**Why:** `exp`'s `Im(f)` sweeps through −3, the eye plane, sending `p.xyz/(3+p.w)` to ∞.
+
+Soft-floored `|3 + p.w|` (sign-preserving) in the shader's mode-0 `project()` and
+mirrored it in JS `viewpoint.ts` (axis cross); floored the legacy Stereo pole
+too. Singular points now land far off-screen but finite. Non-singular pixels
+unchanged. Commit `8601da1`. (Necessary but, per the user's later report, **not
+sufficient** on its own — see the NaN guard above.)
+
+### 🔵 finding · 15:30 — The crash is a real mobile-GPU fault, unreproducible headless
+**Why:** software WebGL (SwiftShader) tolerates the degenerate geometry that crashes Adreno.
+
+Drove the exact sequence headlessly (exp · Tiles · Drop X · XY spin · slider
+0→1): no JS error, no context loss, bounded geometry. So the failure is
+GPU-driver-specific. This is the central limitation of this session — every fix
+is reasoned + headless-sanity-checked, but the actual crash can only be confirmed
+on the user's phone via the Cloudflare PR preview.
+
+### 🟣 decision · 14:45 — Diagnose before changing GPU-territory code
+**Why:** a context-loss "fix" guessed blind is likely wrong; reproduce/understand first.
+
+Traced the projection control path: `handleProjMix` releases Drop X and
+reactivates Perspective as the cross-fade source — pinpointing the singular term
+that distinguishes the crashing path from the stable Drop X state.
+
+## Open questions / next steps
+
+- **Unverified:** does the NaN-normal guard (`f910ca0`) actually stop the Android
+  Brave context loss? Needs a real-device check on the rebuilt PR preview.
+- If it still crashes: ask whether plain **Points** mode also crashes. Points-yes
+  ⇒ NaN-in-fragment isn't the whole story (look at raw GPU load / the morph's
+  double `project()` per `surfacePos`); Points-no ⇒ the tile fragment path is it.
+- Consider sanitizing all shader outputs (clamp/finite-guard `gl_FragColor`) as a
+  blanket Adreno safeguard if the targeted guard proves insufficient.
+
+## Self-reflection
+
+**Follow-up value:** HIGH
+
+My first diagnosis (perspective singularity) was correct but **incomplete** — I
+shipped it as "the fix" and made a PR before the user could confirm, then learned
+it still crashed. The lesson: for GPU-context-loss bugs I cannot reproduce, frame
+fixes as *hypotheses to verify on hardware*, not solutions, and front-load the
+"what does the crash look like / which GPU" questions — the answer (Adreno + NaN
+intolerance) reshaped the diagnosis entirely. High follow-up because the headline
+crash fix remains **unconfirmed on a real device**.

--- a/docs/sessions/progress/complex-particles-torus-crash-tile/2026-06-13-S01-torus-crash-and-sheet-projection.md
+++ b/docs/sessions/progress/complex-particles-torus-crash-tile/2026-06-13-S01-torus-crash-and-sheet-projection.md
@@ -5,9 +5,9 @@ date: 2026-06-13
 title: Torus-switch mobile crash + sheet-count projection reset
 branch: claude/complex-particles-torus-crash-tile
 slug: complex-particles-torus-crash-tile
-status: in-progress
+status: completed
 build: passed
-followup: high
+followup: low
 pr: https://github.com/piyarsquare/animath/pull/216
 app: complex-particles, engine
 ---
@@ -30,6 +30,15 @@ written mid-session at the user's request).
 ## Working notes
 
 <!-- Newest entry first. -->
+
+### 🟡 milestone · 2026-06-14 — Crash confirmed fixed on the real device
+**Why:** the headline fix could only ever be verified on Adreno hardware, not headless.
+
+User verified on the actual Android device: the **exp · Drop X · XY spin · Tiles**
+sequence sliding **Perspective → Torus** no longer loses the WebGL context. The
+NaN-guarded tile normal (`f910ca0`) + the floored/continuous perspective
+denominator (`8601da1` → `86e6eff`) hold up on hardware. This was the branch's one
+open risk — now closed. Follow-up downgraded HIGH → LOW.
 
 ### 🟢 code · 17:35 — Preserve the projection across a sheet-count rebuild
 **Why:** rebuilt materials reset the projection cross-fade, snapping to Perspective.
@@ -97,7 +106,7 @@ that distinguishes the crashing path from the stable Drop X state.
 
 ## Self-reflection
 
-**Follow-up value:** HIGH
+**Follow-up value:** LOW _(updated 2026-06-14: crash confirmed fixed on the real device; was HIGH pending that check)_
 
 My first diagnosis (perspective singularity) was correct but **incomplete** — I
 shipped it as "the fix" and made a PR before the user could confirm, then learned

--- a/docs/sessions/progress/complex-particles-torus-crash-tile/2026-06-14-S02-domain-region.md
+++ b/docs/sessions/progress/complex-particles-torus-crash-tile/2026-06-14-S02-domain-region.md
@@ -1,0 +1,99 @@
+---
+kind: progress
+session: 2026-06-14-S02
+date: 2026-06-14
+title: Continuous perspective floor + a polar domain-region band
+branch: claude/complex-particles-torus-crash-tile
+slug: complex-particles-torus-crash-tile
+status: completed
+build: passed
+followup: low
+pr: https://github.com/piyarsquare/animath/pull/216
+app: complex-particles
+---
+
+# Continuous perspective floor + a polar domain-region band
+
+## Session purpose
+
+Continuation on the Complex Particles branch. Two threads:
+1. Smooth the mobile-crash perspective fix from S01 — the sign-preserving floor
+   on `|3 + p.w|` had a discontinuity at the eye plane.
+2. Add a **Domain region** control so the user can restrict the sampled plane.
+   This grew into a full polar feature (radius band · quadrants · inside/outside
+   filter · region tint), then was **trimmed back to just the radius band** at
+   the user's request.
+
+## Previous session
+
+[2026-06-13-S01](2026-06-13-S01-torus-crash-and-sheet-projection.md): fixed the
+Torus-switch mobile context-loss crash (NaN tile normal + perspective floor) and
+preserved the projection across a sheet-count rebuild. Headline crash fix still
+awaiting real-device confirmation.
+
+## Working notes
+
+<!-- Newest entry first. -->
+
+### 🟢 code · ~02:05 — Trim the domain region down to the radius band
+**Why:** user decided the quadrants / filter / tint were more than the feature needed.
+
+Removed the **Quadrants** chips (+ swatches), the **Unit circle** inside/outside
+filter, and the entire **Region tint** control (both the divergent log-`|z|`
+inside/outside shade and the per-quadrant hue tags). The Domain panel keeps only
+the polar **Radius `|z|`** band. Dropped the `uRegionQuad` / `uSideFilter` /
+`uTintSides` / `uTintQuad` uniforms and the `divergentTint` / `quadrantTint` GLSL
+helpers; `regionMask` is now just the radial band test. Build + lint clean;
+headless render confirms no shader error. Commit `a73f870`.
+
+### 🟢 code · earlier — Region tint to mark structure
+**Why:** make the unit circle and the four quadrants legible in the masked plane.
+
+Added a **Region tint** pill (Off · Quadrants · In/out · Both): a per-quadrant
+hue multiplier and a divergent log-`|z|` shade neutral at `|z|=1`, applied in all
+four render modes. **Superseded by the trim above.** Commit `8ee9cc6`.
+
+### 🟢 code · earlier — Polar domain-region controls
+**Why:** let the user carve the sampled plane (annulus / quadrants / unit-circle side).
+
+Added the `regionMask` shader gate (radius band ∩ quadrants ∩ inside/outside),
+fed by `uRegionRadius` / `uRegionQuad` / `uSideFilter`, multiplied into each
+render mode's alpha — live masking with no geometry rebuild. The radius band is
+the only part that survived the later trim. Commit `34f0e79`.
+
+### 🟢 code · earlier — Make the perspective singularity floor continuous
+**Why:** S01's sign-preserving floor still flipped sign across the eye plane (a jump).
+
+Reworked the mode-0 `project()` denominator floor (shader + `viewpoint.ts`) so
+`|3 + p.w|` is floored without the sign flip — singular points now slide off to a
+finite far field continuously instead of snapping between +∞-ish and −∞-ish sides.
+Commit `86e6eff`.
+
+## Open questions / next steps
+
+- The **S01 headline crash fix remains unconfirmed on a real Android device** —
+  that is the branch's one live risk (see the S01 report). This session's work is
+  orthogonal (a new feature + a continuity refinement) and builds/renders clean.
+- Domain region is now intentionally minimal (radius band only). If the quadrant /
+  filter / tint ideas are wanted later, they live in git history at `8ee9cc6`.
+
+## Self-reflection
+
+1. **What would you do with another session?** Get the PR preview in front of the
+   user's Android device to finally close the S01 crash question — it's the only
+   unverified thing on the branch.
+2. **What would you change about what you produced?** I built the full
+   quadrant/filter/tint feature before checking how much the user actually wanted;
+   it shipped in two commits and was then removed in one. A quick "how far should
+   this go?" up front would have saved the round trip.
+3. **What were you not asked that you think is important?** Whether the radius band
+   should also gate the **Polar** sampling rings/spokes density — right now it's a
+   pure render mask, independent of how the plane is sampled.
+4. **What did we both overlook?** Nothing material; the trim left no dead uniforms
+   or unused imports (verified by lint).
+5. **What did you find difficult?** Nothing notable — the shader had clean seams
+   for both adding and removing the mask.
+6. **What would have made this task easier?** Scoping the region feature up front.
+7. **Follow-up value:** LOW — the shipped change (radius band) is complete and
+   verified; the only HIGH item belongs to S01 (real-device crash check), tracked
+   there.

--- a/docs/sessions/progress/mobile-fullscreen-panel-height-7014r5/2026-06-13-S01-mobile-fullscreen-dvh.md
+++ b/docs/sessions/progress/mobile-fullscreen-panel-height-7014r5/2026-06-13-S01-mobile-fullscreen-dvh.md
@@ -1,0 +1,70 @@
+---
+kind: progress
+session: 2026-06-13-S01
+date: 2026-06-13
+title: Mobile workspace full-height fix (dvh)
+branch: claude/mobile-fullscreen-panel-height-7014r5
+slug: mobile-fullscreen-panel-height-7014r5
+status: completed
+build: passed
+followup: low
+pr: https://github.com/piyarsquare/animath/pull/215
+app: chrome
+---
+
+# Mobile workspace full-height fix (dvh)
+
+## Session purpose
+
+On mobile, a fullscreen panel (and the default immersive view) did not extend
+the full screen — a dotted dead band showed at the bottom. Find why and fix it.
+
+## Previous session
+
+First tracked session on this branch (no `/start-session` was run; report
+written retroactively).
+
+## Working notes
+
+<!-- Newest entry first. -->
+
+### 🟢 code · 13:55 — Switch the root height chain to dynamic viewport units
+**Why:** `height: 100%` doesn't track the mobile visible viewport; `dvh` does.
+
+- `index.html`: `#root { height: 100%; height: 100dvh; }` (the `100%` line is the
+  fallback for browsers without `dvh`). Everything below inherits from it.
+- `src/chrome/theme.css`: pinned the explicit fullscreen card to `height: 100dvh`
+  (`.am-phone-view.am-ws-full`), since `position: fixed; inset: 0` is unreliable
+  under iOS's dynamic toolbar.
+
+Build passed; lint at baseline. Merged as #215.
+
+### 🔵 finding · 13:50 — Root cause: a pure `height: 100%` chain
+**Why:** the dead band is the `.am-phone-scroll` stage background showing through.
+
+The full-height layout chains percentage heights `html → body → #root → .am-app
+→ .am-phone-scroll → .am-phone-view` (the view is `flex: 1 1 0`). On a real
+mobile browser `height: 100%` resolves against the initial containing block,
+which does **not** follow the visible viewport as the address bar shows/retracts
+— so the content box ends up shorter than the screen and the bottom strip falls
+through to the dotted stage. No `transform`/`filter`/`contain` on any ancestor
+(ruled out the containing-block theory).
+
+### 🔵 finding · 13:42 — Reproduces only on real mobile, not headless
+**Why:** narrows the cause to the dynamic-toolbar viewport, not the CSS itself.
+
+Headless Chromium at a phone viewport (390×844) fills correctly in both the
+immersive and explicit-fullscreen states (`getBoundingClientRect` → full 844),
+because software Chromium has no dynamic toolbar. So the bug is the
+`100%`-vs-`dvh` mismatch that only a real mobile browser exhibits.
+
+## Self-reflection
+
+**Follow-up value:** LOW
+
+The fix is the canonical `dvh` remedy and is verified not to regress in headless,
+but I could **not reproduce the actual failure** here (no dynamic toolbar in
+SwiftShader/headless), so real-device confirmation was deferred to the user. The
+pattern worth remembering: any future full-bleed mobile surface should start from
+`dvh`, never a `height: 100%` chain. Low follow-up because the change is small,
+isolated to two lines, and already merged.

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -405,6 +405,20 @@ export default function ComplexParticles({
     const tileGeom = tileGeomRef.current;
     const netGeom = netGeomRef.current;
     if (!pointsGeom || !fillGeom || !wireGeom || !tileGeom || !netGeom) return;
+    // Preserve the live projection across the rebuild. Fresh materials start at
+    // makeUniforms' defaults (uProjMode = uProjTarget = projRef, alpha 0), which
+    // collapses any active cross-fade — so a Torus/Sphere/mid-morph view would
+    // snap back to Perspective when the sheet count changes. The animation loop
+    // re-pushes rotation every frame (orientation self-heals) but never touches
+    // the projection cross-fade, so capture it here and restore it after rebuild.
+    const prevMat = state.materialsRef.current[0];
+    const projSnap = prevMat
+      ? {
+          mode: prevMat.uniforms.uProjMode.value as number,
+          target: prevMat.uniforms.uProjTarget.value as number,
+          alpha: prevMat.uniforms.uProjAlpha.value as number,
+        }
+      : null;
     pointsRef.current.forEach(o => scene.remove(o));
     fillMeshRef.current.forEach(o => scene.remove(o));
     wireMeshRef.current.forEach(o => scene.remove(o));
@@ -443,6 +457,13 @@ export default function ComplexParticles({
       tileMeshRef.current.push(tiles);
       netMeshRef.current.push(net);
       scene.add(pts, fill, wire, tiles, net);
+    }
+    if (projSnap) {
+      state.materialsRef.current.forEach(m => {
+        m.uniforms.uProjMode.value = projSnap.mode;
+        m.uniforms.uProjTarget.value = projSnap.target;
+        m.uniforms.uProjAlpha.value = projSnap.alpha;
+      });
     }
     applyRenderVisibility();
   };

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import ParticleViewerShell from '../../components/ParticleViewerShell';
-import { Select, NumberInput, ComplexInput, Checkbox, RangeSlider, Pills } from '../../components/ControlPanel';
+import { Select, NumberInput, ComplexInput, Checkbox, RangeSlider } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
@@ -110,24 +110,11 @@ export default function ComplexParticles({
   const [quadB, setQuadB] = usePersistentState<Complex2>(ek('quadB'), [0, 0]);
   const [quadC, setQuadC] = usePersistentState<Complex2>(ek('quadC'), [0, 0]);
 
-  // Domain region (Domain panel): restrict and/or recolor the sampled plane by
-  // polar criteria, applied live in the shaders (no geometry rebuild). A radius
-  // band on |z| (max thumb = no limit), a union of the four quadrants (by sign
-  // of z), and an inside/outside-the-unit-circle filter; `regionTint` recolors to
-  // mark structure: 'sides' is a divergent log|z| map neutral at |z|=1 (so the unit
-  // circle reads and inside/outside differ), 'quadrants' hue-tags the four quadrants,
-  // 'both' overlays the two. The tint is independent of the on/off quadrant chips.
+  // Domain region (Domain panel): restrict the sampled plane to a polar radius
+  // band on |z| (max thumb = no limit), applied live in the shaders (no geometry
+  // rebuild). rMax at the ceiling means "no upper limit".
   const [radiusRange, setRadiusRange] = usePersistentState<[number, number]>(ek('radiusRange'), [0, REGION_RMAX]);
-  const [quadrants, setQuadrants] = usePersistentState<boolean[]>(ek('quadrants'), [true, true, true, true]);
-  const [sideFilter, setSideFilter] = usePersistentState<'both' | 'inside' | 'outside'>(ek('sideFilter'), 'both');
-  const [regionTint, setRegionTint] = usePersistentState<'off' | 'quadrants' | 'sides' | 'both'>(ek('regionTint'), 'off');
-  // Pack the region state into the shader's uniform shapes (one place, reused by
-  // makeUniforms and the sync effect). rMax at the ceiling means "no upper limit".
   const regionRMax = () => (radiusRange[1] >= REGION_RMAX ? 1e9 : radiusRange[1]);
-  const sideFilterCode = () => (sideFilter === 'inside' ? 1 : sideFilter === 'outside' ? 2 : 0);
-  const quadFlag = (i: number) => (quadrants[i] ? 1 : 0);
-  const tintSidesFlag = () => (regionTint === 'sides' || regionTint === 'both' ? 1 : 0);
-  const tintQuadFlag = () => (regionTint === 'quadrants' || regionTint === 'both' ? 1 : 0);
 
   // Effective sampling box (× axisScale). Locked → symmetric ±extent; unlocked →
   // the independent min/max window.
@@ -264,10 +251,6 @@ export default function ComplexParticles({
     branchIndex: { value: branchMin + b },
     uBranchHue: { value: branchHue(b) },
     uRegionRadius: { value: new THREE.Vector2(radiusRange[0], regionRMax()) },
-    uRegionQuad: { value: new THREE.Vector4(quadFlag(0), quadFlag(1), quadFlag(2), quadFlag(3)) },
-    uSideFilter: { value: sideFilterCode() },
-    uTintSides: { value: tintSidesFlag() },
-    uTintQuad: { value: tintQuadFlag() },
   });
 
   // Adaptive fade only applies while the sheet is on screen — in plain Points
@@ -601,20 +584,15 @@ export default function ComplexParticles({
     });
   }, [state.tileSize]);
 
-  // Push the domain-region controls (radius band, quadrants, side filter, tint)
-  // to every material — live masking/recoloring, no geometry rebuild.
+  // Push the domain-region radius band to every material — live masking, no
+  // geometry rebuild.
   useEffect(() => {
     const rMax = regionRMax();
-    const sf = sideFilterCode();
     state.materialsRef.current.forEach(m => {
       if (m.uniforms.uRegionRadius) (m.uniforms.uRegionRadius.value as THREE.Vector2).set(radiusRange[0], rMax);
-      if (m.uniforms.uRegionQuad) (m.uniforms.uRegionQuad.value as THREE.Vector4).set(quadFlag(0), quadFlag(1), quadFlag(2), quadFlag(3));
-      if (m.uniforms.uSideFilter) m.uniforms.uSideFilter.value = sf;
-      if (m.uniforms.uTintSides) m.uniforms.uTintSides.value = tintSidesFlag();
-      if (m.uniforms.uTintQuad) m.uniforms.uTintQuad.value = tintQuadFlag();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [radiusRange, quadrants, sideFilter, regionTint]);
+  }, [radiusRange]);
 
   // Show the sphere scaffold in the Hopf view (or once the Torus → Hopf collapse
   // is past halfway) and the donut scaffold in the Torus view; hide both in the
@@ -892,73 +870,19 @@ export default function ComplexParticles({
     </>
   );
 
-  // Domain-region controls (polar bounds · quadrant subset · inside/outside the
-  // unit circle). A shader mask, so these toggle live in every render mode.
-  // Quadrants are laid out 2×2 to match the plane (Q2 Q1 / Q3 Q4).
-  // Swatch ≈ the shader's quadrantTint multiplier applied to a neutral gray, so the
-  // chips read as a legend once quadrant tinting is on (laid out 2×2 = Q2 Q1 / Q3 Q4).
-  const quadCells: Array<{ i: number; label: string; title: string; swatch: string }> = [
-    { i: 1, label: 'Q2', title: 'Re z < 0, Im z > 0', swatch: '#7fd09a' },
-    { i: 0, label: 'Q1', title: 'Re z > 0, Im z > 0', swatch: '#d8b96e' },
-    { i: 2, label: 'Q3', title: 'Re z < 0, Im z < 0', swatch: '#8fbdf2' },
-    { i: 3, label: 'Q4', title: 'Re z > 0, Im z < 0', swatch: '#e29acc' },
-  ];
-  const showQuadSwatch = regionTint === 'quadrants' || regionTint === 'both';
+  // Domain-region control: a polar radius band on |z|. A shader mask, so it
+  // applies live in every render mode (max thumb = ∞ = no upper limit).
   const regionControls = (
-    <>
-      <RangeSlider
-        label="Radius |z|"
-        min={0}
-        max={REGION_RMAX}
-        step={0.05}
-        valueMin={radiusRange[0]}
-        valueMax={radiusRange[1]}
-        onChange={(lo, hi) => setRadiusRange([lo, hi])}
-        format={v => (v >= REGION_RMAX ? '∞' : v.toFixed(2))}
-      />
-      <Pills
-        label="Unit circle"
-        options={[
-          { value: 'both', label: 'Both' },
-          { value: 'inside', label: '|z|<1' },
-          { value: 'outside', label: '|z|>1' },
-        ]}
-        value={sideFilter}
-        onChange={setSideFilter}
-      />
-      <div className="cp-row">
-        <div className="cp-row-label"><span>Quadrants</span></div>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 4, maxWidth: 140 }}>
-          {quadCells.map(({ i, label, title, swatch }) => (
-            <button
-              key={label}
-              type="button"
-              className={`am-chip ${quadrants[i] ? 'am-on' : ''}`}
-              aria-pressed={quadrants[i]}
-              title={title}
-              onClick={() => setQuadrants(q => { const n = [...q]; n[i] = !n[i]; return n; })}
-              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5 }}
-            >
-              {showQuadSwatch && (
-                <span style={{ width: 8, height: 8, borderRadius: 2, background: swatch, flex: '0 0 auto' }} />
-              )}
-              {label}
-            </button>
-          ))}
-        </div>
-      </div>
-      <Pills
-        label="Region tint"
-        options={[
-          { value: 'off', label: 'Off' },
-          { value: 'quadrants', label: 'Quadrants' },
-          { value: 'sides', label: 'In/out' },
-          { value: 'both', label: 'Both' },
-        ]}
-        value={regionTint}
-        onChange={setRegionTint}
-      />
-    </>
+    <RangeSlider
+      label="Radius |z|"
+      min={0}
+      max={REGION_RMAX}
+      step={0.05}
+      valueMin={radiusRange[0]}
+      valueMax={radiusRange[1]}
+      onChange={(lo, hi) => setRadiusRange([lo, hi])}
+      format={v => (v >= REGION_RMAX ? '∞' : v.toFixed(2))}
+    />
   );
 
   return (

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -113,17 +113,21 @@ export default function ComplexParticles({
   // Domain region (Domain panel): restrict and/or recolor the sampled plane by
   // polar criteria, applied live in the shaders (no geometry rebuild). A radius
   // band on |z| (max thumb = no limit), a union of the four quadrants (by sign
-  // of z), and an inside/outside-the-unit-circle filter; `tintSides` recolors by
-  // log|z| with a divergent map neutral at |z|=1, so the unit circle reads.
+  // of z), and an inside/outside-the-unit-circle filter; `regionTint` recolors to
+  // mark structure: 'sides' is a divergent log|z| map neutral at |z|=1 (so the unit
+  // circle reads and inside/outside differ), 'quadrants' hue-tags the four quadrants,
+  // 'both' overlays the two. The tint is independent of the on/off quadrant chips.
   const [radiusRange, setRadiusRange] = usePersistentState<[number, number]>(ek('radiusRange'), [0, REGION_RMAX]);
   const [quadrants, setQuadrants] = usePersistentState<boolean[]>(ek('quadrants'), [true, true, true, true]);
   const [sideFilter, setSideFilter] = usePersistentState<'both' | 'inside' | 'outside'>(ek('sideFilter'), 'both');
-  const [tintSides, setTintSides] = usePersistentState(ek('tintSides'), false);
+  const [regionTint, setRegionTint] = usePersistentState<'off' | 'quadrants' | 'sides' | 'both'>(ek('regionTint'), 'off');
   // Pack the region state into the shader's uniform shapes (one place, reused by
   // makeUniforms and the sync effect). rMax at the ceiling means "no upper limit".
   const regionRMax = () => (radiusRange[1] >= REGION_RMAX ? 1e9 : radiusRange[1]);
   const sideFilterCode = () => (sideFilter === 'inside' ? 1 : sideFilter === 'outside' ? 2 : 0);
   const quadFlag = (i: number) => (quadrants[i] ? 1 : 0);
+  const tintSidesFlag = () => (regionTint === 'sides' || regionTint === 'both' ? 1 : 0);
+  const tintQuadFlag = () => (regionTint === 'quadrants' || regionTint === 'both' ? 1 : 0);
 
   // Effective sampling box (× axisScale). Locked → symmetric ±extent; unlocked →
   // the independent min/max window.
@@ -262,7 +266,8 @@ export default function ComplexParticles({
     uRegionRadius: { value: new THREE.Vector2(radiusRange[0], regionRMax()) },
     uRegionQuad: { value: new THREE.Vector4(quadFlag(0), quadFlag(1), quadFlag(2), quadFlag(3)) },
     uSideFilter: { value: sideFilterCode() },
-    uTintSides: { value: tintSides ? 1 : 0 },
+    uTintSides: { value: tintSidesFlag() },
+    uTintQuad: { value: tintQuadFlag() },
   });
 
   // Adaptive fade only applies while the sheet is on screen — in plain Points
@@ -605,10 +610,11 @@ export default function ComplexParticles({
       if (m.uniforms.uRegionRadius) (m.uniforms.uRegionRadius.value as THREE.Vector2).set(radiusRange[0], rMax);
       if (m.uniforms.uRegionQuad) (m.uniforms.uRegionQuad.value as THREE.Vector4).set(quadFlag(0), quadFlag(1), quadFlag(2), quadFlag(3));
       if (m.uniforms.uSideFilter) m.uniforms.uSideFilter.value = sf;
-      if (m.uniforms.uTintSides) m.uniforms.uTintSides.value = tintSides ? 1 : 0;
+      if (m.uniforms.uTintSides) m.uniforms.uTintSides.value = tintSidesFlag();
+      if (m.uniforms.uTintQuad) m.uniforms.uTintQuad.value = tintQuadFlag();
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [radiusRange, quadrants, sideFilter, tintSides]);
+  }, [radiusRange, quadrants, sideFilter, regionTint]);
 
   // Show the sphere scaffold in the Hopf view (or once the Torus → Hopf collapse
   // is past halfway) and the donut scaffold in the Torus view; hide both in the
@@ -889,12 +895,15 @@ export default function ComplexParticles({
   // Domain-region controls (polar bounds · quadrant subset · inside/outside the
   // unit circle). A shader mask, so these toggle live in every render mode.
   // Quadrants are laid out 2×2 to match the plane (Q2 Q1 / Q3 Q4).
-  const quadCells: Array<{ i: number; label: string; title: string }> = [
-    { i: 1, label: 'Q2', title: 'Re z < 0, Im z > 0' },
-    { i: 0, label: 'Q1', title: 'Re z > 0, Im z > 0' },
-    { i: 2, label: 'Q3', title: 'Re z < 0, Im z < 0' },
-    { i: 3, label: 'Q4', title: 'Re z > 0, Im z < 0' },
+  // Swatch ≈ the shader's quadrantTint multiplier applied to a neutral gray, so the
+  // chips read as a legend once quadrant tinting is on (laid out 2×2 = Q2 Q1 / Q3 Q4).
+  const quadCells: Array<{ i: number; label: string; title: string; swatch: string }> = [
+    { i: 1, label: 'Q2', title: 'Re z < 0, Im z > 0', swatch: '#7fd09a' },
+    { i: 0, label: 'Q1', title: 'Re z > 0, Im z > 0', swatch: '#d8b96e' },
+    { i: 2, label: 'Q3', title: 'Re z < 0, Im z < 0', swatch: '#8fbdf2' },
+    { i: 3, label: 'Q4', title: 'Re z > 0, Im z < 0', swatch: '#e29acc' },
   ];
+  const showQuadSwatch = regionTint === 'quadrants' || regionTint === 'both';
   const regionControls = (
     <>
       <RangeSlider
@@ -920,7 +929,7 @@ export default function ComplexParticles({
       <div className="cp-row">
         <div className="cp-row-label"><span>Quadrants</span></div>
         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 4, maxWidth: 140 }}>
-          {quadCells.map(({ i, label, title }) => (
+          {quadCells.map(({ i, label, title, swatch }) => (
             <button
               key={label}
               type="button"
@@ -928,14 +937,26 @@ export default function ComplexParticles({
               aria-pressed={quadrants[i]}
               title={title}
               onClick={() => setQuadrants(q => { const n = [...q]; n[i] = !n[i]; return n; })}
-            >{label}</button>
+              style={{ display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 5 }}
+            >
+              {showQuadSwatch && (
+                <span style={{ width: 8, height: 8, borderRadius: 2, background: swatch, flex: '0 0 auto' }} />
+              )}
+              {label}
+            </button>
           ))}
         </div>
       </div>
-      <Checkbox
-        label="Tint by |z| (divergent, log — neutral at |z|=1)"
-        checked={tintSides}
-        onChange={setTintSides}
+      <Pills
+        label="Region tint"
+        options={[
+          { value: 'off', label: 'Off' },
+          { value: 'quadrants', label: 'Quadrants' },
+          { value: 'sides', label: 'In/out' },
+          { value: 'both', label: 'Both' },
+        ]}
+        value={regionTint}
+        onChange={setRegionTint}
       />
     </>
   );

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef } from 'react';
 import * as THREE from 'three';
 import ParticleViewerShell from '../../components/ParticleViewerShell';
-import { Select, NumberInput, ComplexInput, Checkbox } from '../../components/ControlPanel';
+import { Select, NumberInput, ComplexInput, Checkbox, RangeSlider, Pills } from '../../components/ControlPanel';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { COMPLEX_PARTICLES_DEFAULTS } from '../../config/defaults';
@@ -24,6 +24,8 @@ import type { ViewPoint, HopfScaffold } from '../../lib/particles';
 const STORAGE_KEY = 'complex-particles';
 /** Cap on how many Riemann sheets (particle sets) can be drawn at once. */
 const MAX_SHEETS = 12;
+/** Radius-band slider ceiling; the max thumb here means "no upper |z| limit". */
+const REGION_RMAX = 12;
 import {
   applyComplex, complexPowRational, complexQuadratic,
   functionNames, functionFormulas, functionCategories, POW_PQ_INDEX, QUADRATIC_INDEX,
@@ -107,6 +109,21 @@ export default function ComplexParticles({
   const [quadA, setQuadA] = usePersistentState<Complex2>(ek('quadA'), [1, 0]);
   const [quadB, setQuadB] = usePersistentState<Complex2>(ek('quadB'), [0, 0]);
   const [quadC, setQuadC] = usePersistentState<Complex2>(ek('quadC'), [0, 0]);
+
+  // Domain region (Domain panel): restrict and/or recolor the sampled plane by
+  // polar criteria, applied live in the shaders (no geometry rebuild). A radius
+  // band on |z| (max thumb = no limit), a union of the four quadrants (by sign
+  // of z), and an inside/outside-the-unit-circle filter; `tintSides` recolors by
+  // log|z| with a divergent map neutral at |z|=1, so the unit circle reads.
+  const [radiusRange, setRadiusRange] = usePersistentState<[number, number]>(ek('radiusRange'), [0, REGION_RMAX]);
+  const [quadrants, setQuadrants] = usePersistentState<boolean[]>(ek('quadrants'), [true, true, true, true]);
+  const [sideFilter, setSideFilter] = usePersistentState<'both' | 'inside' | 'outside'>(ek('sideFilter'), 'both');
+  const [tintSides, setTintSides] = usePersistentState(ek('tintSides'), false);
+  // Pack the region state into the shader's uniform shapes (one place, reused by
+  // makeUniforms and the sync effect). rMax at the ceiling means "no upper limit".
+  const regionRMax = () => (radiusRange[1] >= REGION_RMAX ? 1e9 : radiusRange[1]);
+  const sideFilterCode = () => (sideFilter === 'inside' ? 1 : sideFilter === 'outside' ? 2 : 0);
+  const quadFlag = (i: number) => (quadrants[i] ? 1 : 0);
 
   // Effective sampling box (× axisScale). Locked → symmetric ±extent; unlocked →
   // the independent min/max window.
@@ -242,6 +259,10 @@ export default function ComplexParticles({
     uProjAlpha: { value: 0 },
     branchIndex: { value: branchMin + b },
     uBranchHue: { value: branchHue(b) },
+    uRegionRadius: { value: new THREE.Vector2(radiusRange[0], regionRMax()) },
+    uRegionQuad: { value: new THREE.Vector4(quadFlag(0), quadFlag(1), quadFlag(2), quadFlag(3)) },
+    uSideFilter: { value: sideFilterCode() },
+    uTintSides: { value: tintSides ? 1 : 0 },
   });
 
   // Adaptive fade only applies while the sheet is on screen — in plain Points
@@ -575,6 +596,20 @@ export default function ComplexParticles({
     });
   }, [state.tileSize]);
 
+  // Push the domain-region controls (radius band, quadrants, side filter, tint)
+  // to every material — live masking/recoloring, no geometry rebuild.
+  useEffect(() => {
+    const rMax = regionRMax();
+    const sf = sideFilterCode();
+    state.materialsRef.current.forEach(m => {
+      if (m.uniforms.uRegionRadius) (m.uniforms.uRegionRadius.value as THREE.Vector2).set(radiusRange[0], rMax);
+      if (m.uniforms.uRegionQuad) (m.uniforms.uRegionQuad.value as THREE.Vector4).set(quadFlag(0), quadFlag(1), quadFlag(2), quadFlag(3));
+      if (m.uniforms.uSideFilter) m.uniforms.uSideFilter.value = sf;
+      if (m.uniforms.uTintSides) m.uniforms.uTintSides.value = tintSides ? 1 : 0;
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [radiusRange, quadrants, sideFilter, tintSides]);
+
   // Show the sphere scaffold in the Hopf view (or once the Torus → Hopf collapse
   // is past halfway) and the donut scaffold in the Torus view; hide both in the
   // flat/perspective projections.
@@ -851,6 +886,60 @@ export default function ComplexParticles({
     </>
   );
 
+  // Domain-region controls (polar bounds · quadrant subset · inside/outside the
+  // unit circle). A shader mask, so these toggle live in every render mode.
+  // Quadrants are laid out 2×2 to match the plane (Q2 Q1 / Q3 Q4).
+  const quadCells: Array<{ i: number; label: string; title: string }> = [
+    { i: 1, label: 'Q2', title: 'Re z < 0, Im z > 0' },
+    { i: 0, label: 'Q1', title: 'Re z > 0, Im z > 0' },
+    { i: 2, label: 'Q3', title: 'Re z < 0, Im z < 0' },
+    { i: 3, label: 'Q4', title: 'Re z > 0, Im z < 0' },
+  ];
+  const regionControls = (
+    <>
+      <RangeSlider
+        label="Radius |z|"
+        min={0}
+        max={REGION_RMAX}
+        step={0.05}
+        valueMin={radiusRange[0]}
+        valueMax={radiusRange[1]}
+        onChange={(lo, hi) => setRadiusRange([lo, hi])}
+        format={v => (v >= REGION_RMAX ? '∞' : v.toFixed(2))}
+      />
+      <Pills
+        label="Unit circle"
+        options={[
+          { value: 'both', label: 'Both' },
+          { value: 'inside', label: '|z|<1' },
+          { value: 'outside', label: '|z|>1' },
+        ]}
+        value={sideFilter}
+        onChange={setSideFilter}
+      />
+      <div className="cp-row">
+        <div className="cp-row-label"><span>Quadrants</span></div>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 4, maxWidth: 140 }}>
+          {quadCells.map(({ i, label, title }) => (
+            <button
+              key={label}
+              type="button"
+              className={`am-chip ${quadrants[i] ? 'am-on' : ''}`}
+              aria-pressed={quadrants[i]}
+              title={title}
+              onClick={() => setQuadrants(q => { const n = [...q]; n[i] = !n[i]; return n; })}
+            >{label}</button>
+          ))}
+        </div>
+      </div>
+      <Checkbox
+        label="Tint by |z| (divergent, log — neutral at |z|=1)"
+        checked={tintSides}
+        onChange={setTintSides}
+      />
+    </>
+  );
+
   return (
     <ParticleViewerShell
       appId="complex-particles"
@@ -861,7 +950,7 @@ export default function ComplexParticles({
       functionFormula={displayFormula}
       functionPicker={functionPicker}
       topExtra={functionTopSelect}
-      domainExtras={isMultivalued ? branchControls : undefined}
+      domainExtras={<>{regionControls}{isMultivalued ? branchControls : null}</>}
       readme={readmeText}
       explainer={explainerText}
       settingsStorageKey={embed ? undefined : STORAGE_KEY}

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -104,6 +104,20 @@ projection can still evert the sheet where it stretches past the camera divide
 non-folding surface. It's the clearest way to see folds, branch sheets, and how
 the surface drapes through each projection.
 
+### Domain region
+
+You can carve down and mark the sampled plane by polar criteria — applied live
+in the shader, so every render mode and projection updates instantly with no
+rebuild. **Radius `|z|`** keeps an annulus (drag the top thumb to ∞ for no upper
+limit); the **Unit circle** pills keep only `|z|<1` or `|z|>1`; the **Quadrants**
+chips toggle the four sign regions of `z` on and off. **Region tint** then recolors
+what's left to expose its structure: **Quadrants** hue-tags the four regions
+(amber `Q1`, green `Q2`, blue `Q3`, rose `Q4` — the chips show the legend),
+**In/out** applies a divergent log-`|z|` shade that's neutral exactly on the unit
+circle and cools inward / warms outward so inside and outside read apart, and
+**Both** overlays the two. The tint is independent of the on/off chips, so you can
+color all four quadrants while keeping only some of them visible.
+
 ## Branches and Riemann sheets (Domain panel)
 
 Multivalued functions (`√z`, `∛z`, `ln z`, `z^(p/q)`, `√(z(z−1)(z+1))`, the

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -106,17 +106,9 @@ the surface drapes through each projection.
 
 ### Domain region
 
-You can carve down and mark the sampled plane by polar criteria — applied live
-in the shader, so every render mode and projection updates instantly with no
-rebuild. **Radius `|z|`** keeps an annulus (drag the top thumb to ∞ for no upper
-limit); the **Unit circle** pills keep only `|z|<1` or `|z|>1`; the **Quadrants**
-chips toggle the four sign regions of `z` on and off. **Region tint** then recolors
-what's left to expose its structure: **Quadrants** hue-tags the four regions
-(amber `Q1`, green `Q2`, blue `Q3`, rose `Q4` — the chips show the legend),
-**In/out** applies a divergent log-`|z|` shade that's neutral exactly on the unit
-circle and cools inward / warms outward so inside and outside read apart, and
-**Both** overlays the two. The tint is independent of the on/off chips, so you can
-color all four quadrants while keeping only some of them visible.
+**Radius `|z|`** restricts the sampled plane to a polar band — keep only an
+annulus, or drag the top thumb to ∞ for no upper limit. It's a shader mask, so
+every render mode and projection updates instantly with no rebuild.
 
 ## Branches and Riemann sheets (Domain panel)
 

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -55,13 +55,9 @@ uniform int   uColorQty;
 uniform int   uBrightnessQty;
 uniform int   uInCoord;
 uniform int   uOutCoord;
-// Domain region controls (Domain panel). The mask gates which samples render;
-// the tint recolors by |z| so the unit circle reads as a boundary.
+// Domain region control (Domain panel): a polar radius band that gates which
+// samples render. Applied live in every render mode (no geometry rebuild).
 uniform vec2  uRegionRadius;   // keep |z| in [x, y]
-uniform vec4  uRegionQuad;     // per-quadrant keep flag (Q1,Q2,Q3,Q4), by sign of z
-uniform int   uSideFilter;     // 0 both · 1 inside |z|<1 · 2 outside |z|>1
-uniform int   uTintSides;      // 1 → divergent log-|z| tint centered on |z|=1
-uniform int   uTintQuad;       // 1 → per-quadrant hue tint (mark the four quadrants)
 attribute float size;
 attribute vec4 seed;
 varying vec3 vColor;
@@ -425,38 +421,13 @@ vec2 domainWarp(vec2 z){
   return z * (rNew / r);
 }
 // Domain region gate: 1.0 if the domain point z (post-warp, the value fed to f)
-// is inside the active region — the radius band ∩ the selected quadrants ∩ the
-// inside/outside filter — else 0.0. Axes (z.x or z.y == 0) fall into a quadrant
-// by the >= tests, so they never gap. Each render mode multiplies its alpha by
-// this (or discards on it) so masking is live and needs no geometry rebuild.
+// falls inside the polar radius band [uRegionRadius.x, uRegionRadius.y], else 0.0.
+// Each render mode multiplies its alpha by this (or discards on it) so the band is
+// live and needs no geometry rebuild.
 float regionMask(vec2 z){
   float r = length(z);
   if(r < uRegionRadius.x || r > uRegionRadius.y) return 0.0;
-  float quad = (z.x >= 0.0) ? ((z.y >= 0.0) ? uRegionQuad.x : uRegionQuad.w)
-                            : ((z.y >= 0.0) ? uRegionQuad.y : uRegionQuad.z);
-  if(quad < 0.5) return 0.0;
-  if(uSideFilter == 1 && r > 1.0) return 0.0;
-  if(uSideFilter == 2 && r < 1.0) return 0.0;
   return 1.0;
-}
-// Divergent tint by log|z|, neutral (×1) at |z|=1 so the unit circle is the
-// pivot: cools toward the inside (|z|<1), warms toward the outside (|z|>1). The
-// log scale spreads decades evenly; tanh softens the far field. Multiplied onto
-// the base color so the domain-coloring structure still shows through.
-vec3 divergentTint(float r){
-  float u = clamp(0.5 + 0.5*tanh(log(r + 1e-6) / 1.5), 0.0, 1.0);
-  vec3 cool = vec3(0.45, 0.65, 1.35);
-  vec3 warm = vec3(1.35, 0.60, 0.40);
-  return (u < 0.5) ? mix(cool, vec3(1.0), u * 2.0) : mix(vec3(1.0), warm, (u - 0.5) * 2.0);
-}
-// Per-quadrant hue tint: four distinct, roughly equal-luminance multipliers (each
-// averages ≈1 so it marks the region without darkening) keyed by the sign of z, in
-// the same Q1..Q4 order as regionMask/the chips: Q1 amber, Q2 green, Q3 blue, Q4 rose.
-vec3 quadrantTint(vec2 z){
-  if(z.x >= 0.0) return (z.y >= 0.0) ? vec3(1.28, 1.04, 0.66)   // Q1 (+,+) amber
-                                     : vec3(1.30, 0.78, 1.08);  // Q4 (+,−) rose
-  return            (z.y >= 0.0) ? vec3(0.70, 1.26, 0.84)       // Q2 (−,+) green
-                                 : vec3(0.72, 0.96, 1.32);      // Q3 (−,−) blue
 }
 // Full surface placement of a domain point (no jitter): warp → chart → 4-vector →
 // 4D rotation → projection → scale. The sheet shaders use this both to place
@@ -506,7 +477,7 @@ varying float vPointKeep;
 // clean z, then add the full independent 4D offset to (x, y, Re f, Im f), pushing
 // the point off the surface on all four axes. Color uses the effective z/f, so
 // it stays consistent in both modes.
-void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vPointKeep *= regionMask(zc);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColor(zc,f);if(uTintSides==1) vColor *= divergentTint(length(zc));if(uTintQuad==1) vColor *= quadrantTint(zc);}`;
+void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vPointKeep *= regionMask(zc);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColor(zc,f);}`;
 
 export const fragmentShader = `
 uniform float opacity;
@@ -577,8 +548,6 @@ void main(){
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
   vColor = calcColor(zc, f);
-  if(uTintSides==1) vColor *= divergentTint(length(zc));
-  if(uTintQuad==1) vColor *= quadrantTint(zc);
 }`;
 
 // Sheet FILL vertex shader: same surface placement, but each rectangle gets a
@@ -626,8 +595,6 @@ void main(){
          + cornerColor(cellBase + vec2(0.0, uCellSize.y))
          + cornerColor(cellBase + uCellSize);
   vColor = c * 0.25;
-  if(uTintSides==1) vColor *= divergentTint(length(zCenter));
-  if(uTintQuad==1) vColor *= quadrantTint(zCenter);
 }`;
 
 // Shared external-light snippet: a single directional light that shades whichever
@@ -730,8 +697,6 @@ void main(){
   vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vColor = calcColor(zc, f);                // one flat color per tile (shared node)
-  if(uTintSides==1) vColor *= divergentTint(length(zc));
-  if(uTintQuad==1) vColor *= quadrantTint(zc);
 }`;
 
 // Tiles fragment: flat per-tile color with a facing-ratio shade so the faceted
@@ -780,8 +745,6 @@ void main(){
   vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vColor = calcColor(zc, f);
-  if(uTintSides==1) vColor *= divergentTint(length(zc));
-  if(uTintQuad==1) vColor *= quadrantTint(zc);
 }`;
 
 // Fiber-net fragment: the line color, a touch brighter/opaquer so the threads

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -296,8 +296,15 @@ vec2 applyComplex(vec2 z, int t){
 }
 
 vec3 project(vec4 p, int mode){
-  if(mode==0){ return p.xyz / (3.0 + p.w); }
-  if(mode==1){ vec4 n = normalize(p); return n.xyz / (1.0 - n.w); }
+  // Perspective from the eye at w = -3. The denominator 3 + p.w vanishes on the
+  // eye plane (p.w = -3), sending vertices to infinity — for steep functions
+  // (exp) that locus is inside the sampled box, and an infinite/NaN vertex makes
+  // a Tiles quad anchored there rasterize as garbage and hang mobile GPUs. Floor
+  // the denominator's magnitude (sign-preserving) so such points land far off
+  // screen but finite, mirroring the Torus pole's soft floor. Non-singular
+  // points (|3 + p.w| ≥ floor) are unchanged.
+  if(mode==0){ float den = 3.0 + p.w; float s = den < 0.0 ? -1.0 : 1.0; return p.xyz / (s * max(abs(den), 0.35)); }
+  if(mode==1){ vec4 n = normalize(p); return n.xyz / max(1.0 - n.w, 0.04); }
   if(mode==2){ float d = max(dot(p,p), 1e-6); return vec3(2.0*(p.x*p.z + p.y*p.w), 2.0*(p.y*p.z - p.x*p.w), p.x*p.x + p.y*p.y - p.z*p.z - p.w*p.w) / d; }
   if(mode==3) return vec3(p.y, p.z, p.w);
   if(mode==4) return vec3(p.x, p.z, p.w);

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -300,10 +300,11 @@ vec3 project(vec4 p, int mode){
   // eye plane (p.w = -3), sending vertices to infinity — for steep functions
   // (exp) that locus is inside the sampled box, and an infinite/NaN vertex makes
   // a Tiles quad anchored there rasterize as garbage and hang mobile GPUs. Floor
-  // the denominator's magnitude (sign-preserving) so such points land far off
-  // screen but finite, mirroring the Torus pole's soft floor. Non-singular
-  // points (|3 + p.w| ≥ floor) are unchanged.
-  if(mode==0){ float den = 3.0 + p.w; float s = den < 0.0 ? -1.0 : 1.0; return p.xyz / (s * max(abs(den), 0.35)); }
+  // the denominator to a positive minimum (no sign flip): the projection stays
+  // continuous as p.w sweeps through the eye plane (a spin would otherwise pop a
+  // crossing vertex from +X/floor to -X/floor), front-facing points (3 + p.w >=
+  // floor) are unchanged, and everything stays finite.
+  if(mode==0){ return p.xyz / max(3.0 + p.w, 0.35); }
   if(mode==1){ vec4 n = normalize(p); return n.xyz / max(1.0 - n.w, 0.04); }
   if(mode==2){ float d = max(dot(p,p), 1e-6); return vec3(2.0*(p.x*p.z + p.y*p.w), 2.0*(p.y*p.z - p.x*p.w), p.x*p.x + p.y*p.y - p.z*p.z - p.w*p.w) / d; }
   if(mode==3) return vec3(p.y, p.z, p.w);

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -659,7 +659,13 @@ void main(){
   vec3 duC = du * min(1.0, uMaxTile / lu);   // clamp edge length → tiles cap, then detach
   vec3 dvC = dv * min(1.0, uMaxTile / lv);
   vec3 pos3 = c0 + corner.x * duC + corner.y * dvC;
-  vec3 nrm = normalize(cross(du, dv));
+  // Guard the face normal: near a projection singularity du and dv can go
+  // parallel or vanish, so cross(du,dv) -> 0 and normalize() would emit NaN.
+  // A NaN here poisons the varying and can hard-crash real mobile GL drivers
+  // (software renderers tolerate it), so fall back to a screen-facing normal.
+  vec3 cr = cross(du, dv);
+  float crl = length(cr);
+  vec3 nrm = (crl > 1e-9) ? cr / crl : vec3(0.0, 0.0, 1.0);
   vNormalView = normalize(normalMatrix * nrm);
   vFacing = abs(vNormalView.z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -61,6 +61,7 @@ uniform vec2  uRegionRadius;   // keep |z| in [x, y]
 uniform vec4  uRegionQuad;     // per-quadrant keep flag (Q1,Q2,Q3,Q4), by sign of z
 uniform int   uSideFilter;     // 0 both · 1 inside |z|<1 · 2 outside |z|>1
 uniform int   uTintSides;      // 1 → divergent log-|z| tint centered on |z|=1
+uniform int   uTintQuad;       // 1 → per-quadrant hue tint (mark the four quadrants)
 attribute float size;
 attribute vec4 seed;
 varying vec3 vColor;
@@ -448,6 +449,15 @@ vec3 divergentTint(float r){
   vec3 warm = vec3(1.35, 0.60, 0.40);
   return (u < 0.5) ? mix(cool, vec3(1.0), u * 2.0) : mix(vec3(1.0), warm, (u - 0.5) * 2.0);
 }
+// Per-quadrant hue tint: four distinct, roughly equal-luminance multipliers (each
+// averages ≈1 so it marks the region without darkening) keyed by the sign of z, in
+// the same Q1..Q4 order as regionMask/the chips: Q1 amber, Q2 green, Q3 blue, Q4 rose.
+vec3 quadrantTint(vec2 z){
+  if(z.x >= 0.0) return (z.y >= 0.0) ? vec3(1.28, 1.04, 0.66)   // Q1 (+,+) amber
+                                     : vec3(1.30, 0.78, 1.08);  // Q4 (+,−) rose
+  return            (z.y >= 0.0) ? vec3(0.70, 1.26, 0.84)       // Q2 (−,+) green
+                                 : vec3(0.72, 0.96, 1.32);      // Q3 (−,−) blue
+}
 // Full surface placement of a domain point (no jitter): warp → chart → 4-vector →
 // 4D rotation → projection → scale. The sheet shaders use this both to place
 // each vertex and to sample a cell's four corners so they can measure how far
@@ -496,7 +506,7 @@ varying float vPointKeep;
 // clean z, then add the full independent 4D offset to (x, y, Re f, Im f), pushing
 // the point off the surface on all four axes. Color uses the effective z/f, so
 // it stays consistent in both modes.
-void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vPointKeep *= regionMask(zc);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColor(zc,f);if(uTintSides==1) vColor *= divergentTint(length(zc));}`;
+void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vPointKeep *= regionMask(zc);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColor(zc,f);if(uTintSides==1) vColor *= divergentTint(length(zc));if(uTintQuad==1) vColor *= quadrantTint(zc);}`;
 
 export const fragmentShader = `
 uniform float opacity;
@@ -568,6 +578,7 @@ void main(){
   gl_Position = projectionMatrix * mv;
   vColor = calcColor(zc, f);
   if(uTintSides==1) vColor *= divergentTint(length(zc));
+  if(uTintQuad==1) vColor *= quadrantTint(zc);
 }`;
 
 // Sheet FILL vertex shader: same surface placement, but each rectangle gets a
@@ -604,7 +615,8 @@ void main(){
   // How far the function has stretched this cell in 3D (per-cell, uniform across
   // its six verts since they share cellBase) → drives the adaptive fade.
   vStretch = cellStretch(cellBase, uCellSize);
-  vRegion = regionMask(domainWarp(cellBase + 0.5 * uCellSize));
+  vec2 zCenter = domainWarp(cellBase + 0.5 * uCellSize);
+  vRegion = regionMask(zCenter);
   vec3 pos3 = surfacePos(z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   vViewPos = mv.xyz;
@@ -614,7 +626,8 @@ void main(){
          + cornerColor(cellBase + vec2(0.0, uCellSize.y))
          + cornerColor(cellBase + uCellSize);
   vColor = c * 0.25;
-  if(uTintSides==1) vColor *= divergentTint(length(domainWarp(cellBase + 0.5 * uCellSize)));
+  if(uTintSides==1) vColor *= divergentTint(length(zCenter));
+  if(uTintQuad==1) vColor *= quadrantTint(zCenter);
 }`;
 
 // Shared external-light snippet: a single directional light that shades whichever
@@ -718,6 +731,7 @@ void main(){
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vColor = calcColor(zc, f);                // one flat color per tile (shared node)
   if(uTintSides==1) vColor *= divergentTint(length(zc));
+  if(uTintQuad==1) vColor *= quadrantTint(zc);
 }`;
 
 // Tiles fragment: flat per-tile color with a facing-ratio shade so the faceted
@@ -767,6 +781,7 @@ void main(){
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vColor = calcColor(zc, f);
   if(uTintSides==1) vColor *= divergentTint(length(zc));
+  if(uTintQuad==1) vColor *= quadrantTint(zc);
 }`;
 
 // Fiber-net fragment: the line color, a touch brighter/opaquer so the threads

--- a/src/animations/ComplexParticles/shaders/index.ts
+++ b/src/animations/ComplexParticles/shaders/index.ts
@@ -55,6 +55,12 @@ uniform int   uColorQty;
 uniform int   uBrightnessQty;
 uniform int   uInCoord;
 uniform int   uOutCoord;
+// Domain region controls (Domain panel). The mask gates which samples render;
+// the tint recolors by |z| so the unit circle reads as a boundary.
+uniform vec2  uRegionRadius;   // keep |z| in [x, y]
+uniform vec4  uRegionQuad;     // per-quadrant keep flag (Q1,Q2,Q3,Q4), by sign of z
+uniform int   uSideFilter;     // 0 both · 1 inside |z|<1 · 2 outside |z|>1
+uniform int   uTintSides;      // 1 → divergent log-|z| tint centered on |z|=1
 attribute float size;
 attribute vec4 seed;
 varying vec3 vColor;
@@ -417,6 +423,31 @@ vec2 domainWarp(vec2 z){
   float rNew = pow(R, 2.0 * (r / R) - 1.0);
   return z * (rNew / r);
 }
+// Domain region gate: 1.0 if the domain point z (post-warp, the value fed to f)
+// is inside the active region — the radius band ∩ the selected quadrants ∩ the
+// inside/outside filter — else 0.0. Axes (z.x or z.y == 0) fall into a quadrant
+// by the >= tests, so they never gap. Each render mode multiplies its alpha by
+// this (or discards on it) so masking is live and needs no geometry rebuild.
+float regionMask(vec2 z){
+  float r = length(z);
+  if(r < uRegionRadius.x || r > uRegionRadius.y) return 0.0;
+  float quad = (z.x >= 0.0) ? ((z.y >= 0.0) ? uRegionQuad.x : uRegionQuad.w)
+                            : ((z.y >= 0.0) ? uRegionQuad.y : uRegionQuad.z);
+  if(quad < 0.5) return 0.0;
+  if(uSideFilter == 1 && r > 1.0) return 0.0;
+  if(uSideFilter == 2 && r < 1.0) return 0.0;
+  return 1.0;
+}
+// Divergent tint by log|z|, neutral (×1) at |z|=1 so the unit circle is the
+// pivot: cools toward the inside (|z|<1), warms toward the outside (|z|>1). The
+// log scale spreads decades evenly; tanh softens the far field. Multiplied onto
+// the base color so the domain-coloring structure still shows through.
+vec3 divergentTint(float r){
+  float u = clamp(0.5 + 0.5*tanh(log(r + 1e-6) / 1.5), 0.0, 1.0);
+  vec3 cool = vec3(0.45, 0.65, 1.35);
+  vec3 warm = vec3(1.35, 0.60, 0.40);
+  return (u < 0.5) ? mix(cool, vec3(1.0), u * 2.0) : mix(vec3(1.0), warm, (u - 0.5) * 2.0);
+}
 // Full surface placement of a domain point (no jitter): warp → chart → 4-vector →
 // 4D rotation → projection → scale. The sheet shaders use this both to place
 // each vertex and to sample a cell's four corners so they can measure how far
@@ -465,7 +496,7 @@ varying float vPointKeep;
 // clean z, then add the full independent 4D offset to (x, y, Re f, Im f), pushing
 // the point off the surface on all four axes. Color uses the effective z/f, so
 // it stays consistent in both modes.
-void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColor(zc,f);}`;
+void main(){vec2 z = vec2(position.x, position.z);vec4 jit = (seed*2. - 1.) * jitterAmp;if(uJitterMode==0) z += jit.xy;vPointKeep = (uAdaptive==1) ? smoothstep(uDensity, uDensity*2.0, cellStretch(z - 0.5*uCellSize, uCellSize)) : 1.0;vec2 zc = domainWarp(z);vPointKeep *= regionMask(zc);vec2 f = applyComplex(zc, functionType);if(length(f) > 1e3) f = normalize(f)*1e3;vec2 zPlot = chartCoord(zc, uInCoord);vec2 fPlot = chartCoord(f, uOutCoord);vec4 p4 = vec4(zPlot.x, zPlot.y, fPlot.x, fPlot.y);if(uJitterMode==1) p4 += jit;p4 = quatRotate4D(p4, uRotL, uRotR);vec3 Pold = project(p4, uProjMode);vec3 Pnew = project(p4, uProjTarget);vec3 pos3 = mix(Pold, Pnew, uProjAlpha) * 1.5;vec4 mv  = modelViewMatrix * vec4(pos3,1.);gl_Position = projectionMatrix * mv;gl_PointSize = size * globalSize * (80. / -mv.z);vColor = calcColor(zc,f);if(uTintSides==1) vColor *= divergentTint(length(zc));}`;
 
 export const fragmentShader = `
 uniform float opacity;
@@ -514,6 +545,7 @@ uniform vec2 uCellSize;    // domain units per cell (for the adaptive metric)
 varying vec3 vViewPos;
 varying float vFade;
 varying float vStretch;
+varying float vRegion;
 void main(){
   vec2 z = vec2(position.x, position.z);
   {
@@ -527,6 +559,7 @@ void main(){
   // fill where the function stretches the grid.
   vStretch = cellStretch(z - 0.5*uCellSize, uCellSize);
   vec2 zc = domainWarp(z);
+  vRegion = regionMask(zc);
   vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vec3 pos3 = surfacePos(z);
@@ -534,6 +567,7 @@ void main(){
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
   vColor = calcColor(zc, f);
+  if(uTintSides==1) vColor *= divergentTint(length(zc));
 }`;
 
 // Sheet FILL vertex shader: same surface placement, but each rectangle gets a
@@ -548,6 +582,7 @@ uniform vec4 uDomainBox;   // xMin, xMax, yMin, yMax
 varying vec3 vViewPos;
 varying float vFade;
 varying float vStretch;
+varying float vRegion;
 vec3 cornerColor(vec2 zc){
   zc = domainWarp(zc);
   vec2 fc = applyComplex(zc, functionType);
@@ -569,6 +604,7 @@ void main(){
   // How far the function has stretched this cell in 3D (per-cell, uniform across
   // its six verts since they share cellBase) → drives the adaptive fade.
   vStretch = cellStretch(cellBase, uCellSize);
+  vRegion = regionMask(domainWarp(cellBase + 0.5 * uCellSize));
   vec3 pos3 = surfacePos(z);
   vec4 mv = modelViewMatrix * vec4(pos3, 1.0);
   vViewPos = mv.xyz;
@@ -578,6 +614,7 @@ void main(){
          + cornerColor(cellBase + vec2(0.0, uCellSize.y))
          + cornerColor(cellBase + uCellSize);
   vColor = c * 0.25;
+  if(uTintSides==1) vColor *= divergentTint(length(domainWarp(cellBase + 0.5 * uCellSize)));
 }`;
 
 // Shared external-light snippet: a single directional light that shades whichever
@@ -614,6 +651,7 @@ varying vec3 vColor;
 varying vec3 vViewPos;
 varying float vFade;
 varying float vStretch;
+varying float vRegion;
 void main(){
   vec3 col = vColor;
   float alpha = opacity;
@@ -632,6 +670,7 @@ void main(){
     // stretched the cell past the threshold so the point cloud shows through.
     alpha *= 1.0 - smoothstep(uDensity, uDensity*2.0, vStretch);
   }
+  alpha *= vRegion;
   if(alpha < 0.003) discard;
   gl_FragColor = vec4(col, alpha);
 }`;
@@ -649,6 +688,7 @@ uniform float uMaxTile;      // max world-space half-... edge length per tile
 varying float vFacing;       // |view-space normal . z| for depth shading
 varying vec3  vNormalView;   // signed view-space normal (for external lighting)
 varying vec3  vViewPos;      // view-space position (for external lighting)
+varying float vRegion;       // domain-region keep flag (0 → masked out)
 void main(){
   vec2 z = vec2(position.x, position.z);
   vec3 c0 = surfacePos(z);
@@ -673,9 +713,11 @@ void main(){
   vViewPos = mv.xyz;
   gl_Position = projectionMatrix * mv;
   vec2 zc = domainWarp(z);
+  vRegion = regionMask(zc);
   vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vColor = calcColor(zc, f);                // one flat color per tile (shared node)
+  if(uTintSides==1) vColor *= divergentTint(length(zc));
 }`;
 
 // Tiles fragment: flat per-tile color with a facing-ratio shade so the faceted
@@ -688,7 +730,9 @@ varying vec3  vColor;
 varying float vFacing;
 varying vec3  vNormalView;
 varying vec3  vViewPos;
+varying float vRegion;
 void main(){
+  if(vRegion < 0.5) discard;
   float shade = mix(1.0, 0.45 + 0.55*vFacing, clamp(uShade, 0.0, 1.0));
   vec3 col = applyExternalLight(vColor * shade, vNormalView, vViewPos, gl_FrontFacing);
   gl_FragColor = vec4(col, opacity);
@@ -702,6 +746,7 @@ attribute vec2 aOther;       // the segment's other endpoint (domain coords)
 attribute float aSide;       // ±1 ribbon side
 uniform vec2 uResolution;    // drawing-buffer size in px (for screen-space width)
 uniform float uLineWidth;    // ribbon width in px
+varying float vRegion;
 void main(){
   vec2 z = vec2(position.x, position.z);
   vec4 clipA = projectionMatrix * modelViewMatrix * vec4(surfacePos(z), 1.0);
@@ -717,9 +762,11 @@ void main(){
   clipA.xy += offsetNdc * clipA.w;
   gl_Position = clipA;
   vec2 zc = domainWarp(z);
+  vRegion = regionMask(zc);
   vec2 f = applyComplex(zc, functionType);
   if(length(f) > 1e3) f = normalize(f)*1e3;
   vColor = calcColor(zc, f);
+  if(uTintSides==1) vColor *= divergentTint(length(zc));
 }`;
 
 // Fiber-net fragment: the line color, a touch brighter/opaquer so the threads
@@ -727,6 +774,8 @@ void main(){
 export const netFragmentShader = `
 uniform float opacity;
 varying vec3 vColor;
+varying float vRegion;
 void main(){
+  if(vRegion < 0.5) discard;
   gl_FragColor = vec4(vColor, clamp(opacity*1.3 + 0.2, 0.0, 1.0));
 }`;

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -131,6 +131,15 @@ export default function ParticleViewerShell({
     setSpins(s => ({ ...s, [key]: !s[key] }));
   };
 
+  // Touching the projection knob stabilizes the view first: stop every running
+  // spin so the morph isn't fighting a per-frame 4D rotation (which sweeps a
+  // steep function's projection singularity across the grid frame after frame —
+  // the worst case for the GPU). handleProjMix already releases any drop axis.
+  const handleProjMix = (v: number) => {
+    if (anySpin) setSpins({});
+    controls.handleProjMix(v);
+  };
+
   const handleTurn = (id: string, dir: 1 | -1) => {
     if (ambient) controls.orbitTurn(id as ViewAxis, dir);
     else controls.turn(id as Plane, dir);
@@ -277,7 +286,7 @@ export default function ParticleViewerShell({
         label="Projection"
         value={state.projMix}
         min={0} max={2} step={0.01}
-        onChange={controls.handleProjMix}
+        onChange={handleProjMix}
         format={fmtProjMix}
         stops={[
           { value: 0, label: 'Perspective' },

--- a/src/lib/viewpoint.ts
+++ b/src/lib/viewpoint.ts
@@ -68,11 +68,12 @@ export function makeUnitQuat(angle: number, axis: Axis4D): {L: THREE.Vector4, R:
 }
 
 export function project(p: THREE.Vector4, mode: ProjectionMode): THREE.Vector3{
-  // Perspective denominator (3 + p.w) is floored in magnitude so the eye-plane
-  // singularity (p.w = -3) yields a finite, far-off point instead of infinity —
-  // matches the shader's mode-0 guard (shaders/index.ts) so the 4D axis cross
-  // tracks the rendered geometry. Stereo's pole (n.w = 1) is floored likewise.
-  if(mode===ProjectionMode.Perspective){ const den=3+p.w; const s=den<0?-1:1; return new THREE.Vector3(p.x,p.y,p.z).multiplyScalar(1/(s*Math.max(Math.abs(den),0.35))); }
+  // Perspective denominator (3 + p.w) is floored to a positive minimum so the
+  // eye-plane singularity (p.w = -3) yields a finite point instead of infinity,
+  // continuously (no sign flip as p.w crosses the plane) — matches the shader's
+  // mode-0 guard (shaders/index.ts) so the 4D axis cross tracks the rendered
+  // geometry. Stereo's pole (n.w = 1) is floored likewise.
+  if(mode===ProjectionMode.Perspective){ return new THREE.Vector3(p.x,p.y,p.z).multiplyScalar(1/Math.max(3+p.w,0.35)); }
   if(mode===ProjectionMode.Stereo){ const n=p.clone().normalize(); return new THREE.Vector3(n.x,n.y,n.z).multiplyScalar(1/Math.max(1-n.w,0.04)); }
   if(mode===ProjectionMode.Hopf){
     // Faithful Hopf map of the complex pair (z1,z2) = (x+iy, u+iv) = (z, f):

--- a/src/lib/viewpoint.ts
+++ b/src/lib/viewpoint.ts
@@ -68,8 +68,12 @@ export function makeUnitQuat(angle: number, axis: Axis4D): {L: THREE.Vector4, R:
 }
 
 export function project(p: THREE.Vector4, mode: ProjectionMode): THREE.Vector3{
-  if(mode===ProjectionMode.Perspective) return new THREE.Vector3(p.x,p.y,p.z).multiplyScalar(1/(3+p.w));
-  if(mode===ProjectionMode.Stereo){ const n=p.clone().normalize(); return new THREE.Vector3(n.x,n.y,n.z).multiplyScalar(1/(1-n.w)); }
+  // Perspective denominator (3 + p.w) is floored in magnitude so the eye-plane
+  // singularity (p.w = -3) yields a finite, far-off point instead of infinity —
+  // matches the shader's mode-0 guard (shaders/index.ts) so the 4D axis cross
+  // tracks the rendered geometry. Stereo's pole (n.w = 1) is floored likewise.
+  if(mode===ProjectionMode.Perspective){ const den=3+p.w; const s=den<0?-1:1; return new THREE.Vector3(p.x,p.y,p.z).multiplyScalar(1/(s*Math.max(Math.abs(den),0.35))); }
+  if(mode===ProjectionMode.Stereo){ const n=p.clone().normalize(); return new THREE.Vector3(n.x,n.y,n.z).multiplyScalar(1/Math.max(1-n.w,0.04)); }
   if(mode===ProjectionMode.Hopf){
     // Faithful Hopf map of the complex pair (z1,z2) = (x+iy, u+iv) = (z, f):
     //   H = ( 2 Re(z1 conj z2), 2 Im(z1 conj z2), |z1|^2 - |z2|^2 ) / |(z1,z2)|^2


### PR DESCRIPTION
## What was crashing

In Complex Particles, with **function = exp**, **Drop X**, a continuous **XY spin**, and **Tiles** render mode, sliding the projection from **Perspective → Torus** crashes the app on mobile.

Drop X projects with `vec3(p.y, p.z, p.w)` — no division, so every vertex is finite. The crash is triggered by the *transition*:

1. Sliding toward Torus calls `handleProjMix`, which **releases Drop X** and reactivates the **Perspective** projection `p.xyz / (3 + p.w)` as the crossfade's source term.
2. For `exp`, `p.w = Im(exp(z))` sweeps through **−3** (the eye plane) — and the XY spin drags that locus across the sampled domain. There the denominator vanishes and the vertex projects to **infinity**.
3. In **Tiles** mode each quad is anchored at that vertex (`c0 = surfacePos(z)`). The tile-size clamp limits the quad's *edges* but not its *anchor*, so a small quad pinned at an infinite/NaN clip-space point rasterizes as garbage that hangs the mobile GPU and loses the WebGL context (the "crash"). Points mode mostly survives because a lone point at infinity just disappears.

## The fix

Soft-floor the perspective denominator's magnitude (`max(|3 + p.w|, 0.35)`, sign-preserving) in the shader's `project()`, mirroring the soft floor already used for the Torus pole. Singular points now land far off-screen but **finite**, so rasterization stays well-defined. Anything not near the eye plane (`|3 + p.w| ≥ 0.35`) renders bit-identically to before. The same guard is mirrored in the JS `project()` (used for the 4D axis cross), and the legacy Stereo pole is floored for the same latent singularity.

## Verification

- Reproduced the exact state (exp · Tiles · mid perspective→torus, 390-wide viewport): now renders finite, bounded tiles with no JS errors and no geometry blowout.
- `npm run build` passes; `npm run lint` at baseline (0 errors).

**Caveat:** the screenshot harness uses software WebGL (SwiftShader), which is robust to the degenerate geometry that crashes a real mobile GPU — so this confirms the geometry is now finite and the infinity is removed by the math, but the crash itself couldn't be reproduced here. Worth a quick check on an actual phone.

https://claude.ai/code/session_0187AbVtGeNBFY5Bfqam6YKV

---
_Generated by [Claude Code](https://claude.ai/code/session_0187AbVtGeNBFY5Bfqam6YKV)_