### PR TITLE
Polygon Worlds: declutter the phone layout

### DIFF
--- a/src/animations/PolygonWorlds/PolygonWorlds.tsx
+++ b/src/animations/PolygonWorlds/PolygonWorlds.tsx
@@ -1,7 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
 import * as THREE from 'three';
 import Canvas3D from '@/components/Canvas3D';
 import Workspace from '../../chrome/workspace/Workspace';
+import { Icon } from '../../chrome/icons';
+import { useEscLayer } from '../../chrome/useEscLayer';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef } from '../../chrome/workspace/types';
 import { usePhone } from '../../chrome/usePhone';
 import { Slider, Select, Pills } from '../../components/ControlPanel';
@@ -365,11 +368,18 @@ export default function PolygonWorlds() {
     </>
   );
 
-  // always-on verbs (bottom-center strip) — reachable without opening a panel.
+  // always-on verbs (bottom-center strip on desktop; folded into the bottom
+  // dock on phone). The two clears collapse into one verb that opens a small
+  // chooser (trail · signs · both), keeping the strip to two buttons.
+  const [clearOpen, setClearOpen] = useState(false);
+  const clearWhat = useCallback((what: 'trail' | 'signs' | 'both') => {
+    if (what === 'trail' || what === 'both') engineRef.current?.clearTrail();
+    if (what === 'signs' || what === 'both') engineRef.current?.clearSigns();
+    setClearOpen(false);
+  }, []);
   const actions: ActionDef[] = [
     { id: 'plant', icon: 'pin', label: 'Plant sign', primary: true, onClick: () => engineRef.current?.plantSign(signFront, signBack) },
-    { id: 'clear-signs', icon: 'close', label: 'Clear signs', onClick: () => engineRef.current?.clearSigns() },
-    { id: 'clear-trail', icon: 'reset', label: 'Clear trail', onClick: () => engineRef.current?.clearTrail() },
+    { id: 'clear', icon: 'reset', label: 'Clear', onClick: () => setClearOpen(true) },
   ];
 
   // drive — locomotion.
@@ -425,22 +435,85 @@ export default function PolygonWorlds() {
   ];
 
   return (
-    <Workspace
-      appId="polygon-worlds"
-      title="Polygon Worlds"
-      subtitle={spec.short}
-      titlePanel="world"
-      modes={phone ? undefined : [{ id: 'third', label: 'Third person' }, { id: 'first', label: 'First person' }]}
-      activeMode={thirdPerson ? 'third' : 'first'}
-      onModeChange={(id) => setThirdPerson(id === 'third')}
-      actions={actions}
-      immersive
-      sections={sections}
-      views={views}
-      layouts={LAYOUTS}
-      defaultLayoutId="walk"
-      explainer={explainerText}
-    />
+    <>
+      <Workspace
+        appId="polygon-worlds"
+        // On the phone bar the app name is dead weight (the subtitle is hidden
+        // there anyway), so the title names the world you're standing in — and
+        // tapping it still opens the World picker (titlePanel). Desktop keeps
+        // the app name, since it has the perspective pills and far more room.
+        title={phone ? spec.label : 'Polygon Worlds'}
+        subtitle={spec.short}
+        titlePanel="world"
+        modes={phone ? undefined : [{ id: 'third', label: 'Third person' }, { id: 'first', label: 'First person' }]}
+        activeMode={thirdPerson ? 'third' : 'first'}
+        onModeChange={(id) => setThirdPerson(id === 'third')}
+        actions={actions}
+        phoneActionsInDock
+        immersive
+        sections={sections}
+        views={views}
+        layouts={LAYOUTS}
+        defaultLayoutId="walk"
+        explainer={explainerText}
+      />
+      {clearOpen && <ClearMenu phone={phone} onClear={clearWhat} onClose={() => setClearOpen(false)} />}
+    </>
+  );
+}
+
+/** The "Clear" chooser — one verb, three targets (the trail, the signs, or
+ *  both). Portaled to <body> so it floats above the dock/action strip on either
+ *  layout: a bottom sheet on phone, a small centered card on desktop. */
+function ClearMenu({ phone, onClear, onClose }: {
+  phone: boolean;
+  onClear: (what: 'trail' | 'signs' | 'both') => void;
+  onClose: () => void;
+}) {
+  useEscLayer(true, onClose);
+  const items: { what: 'trail' | 'signs' | 'both'; icon: string; label: string }[] = [
+    { what: 'trail', icon: 'reset', label: 'Clear trail' },
+    { what: 'signs', icon: 'close', label: 'Clear signs' },
+    { what: 'both', icon: 'reset', label: 'Clear both' },
+  ];
+  return createPortal(
+    <div
+      className={phone ? 'am-phone-scrim' : 'am-modal-scrim'}
+      style={{ position: 'fixed' }}
+      onPointerDown={onClose}
+      role="presentation"
+    >
+      <div
+        className={phone ? 'am-phone-sheet' : 'am-modal'}
+        role="dialog"
+        aria-label="Clear"
+        onPointerDown={(e) => e.stopPropagation()}
+        style={phone
+          ? undefined
+          : { width: 240, padding: 14, display: 'flex', flexDirection: 'column', gap: 6 }}
+      >
+        {phone && <div className="am-sheet-grip" />}
+        <div className={phone ? 'am-phone-sheet-head' : undefined} style={phone ? undefined : { fontWeight: 700, marginBottom: 4 }}>
+          {phone
+            ? <span className="am-phone-sheet-title">Clear</span>
+            : 'Clear'}
+        </div>
+        <div style={phone ? { padding: '8px 12px 18px', display: 'flex', flexDirection: 'column', gap: 8 } : { display: 'flex', flexDirection: 'column', gap: 6 }}>
+          {items.map((it) => (
+            <button
+              key={it.what}
+              className="am-action-btn"
+              style={{ justifyContent: 'flex-start', width: '100%', border: '1px solid var(--border)' }}
+              onClick={() => onClear(it.what)}
+            >
+              <Icon name={it.icon} size={15} />
+              <span>{it.label}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>,
+    document.body,
   );
 }
 
@@ -465,9 +538,10 @@ function MovePad({ onSet, phone }: { onSet: (k: MoveKey, v: boolean) => void; ph
     >{label}</button>
   );
   // On phone the floating bottom dock sits at the screen's bottom edge; lift the
-  // pad above it so the back arrow stays tappable.
+  // pad just clear of that single bar (the action verbs now live inside it, so
+  // there's no second row to clear — the pad can sit low and out of the scene).
   return (
-    <div style={{ position: 'absolute', bottom: phone ? 100 : 20, right: phone ? 14 : 20, width: 150, height: 150, zIndex: 20 }}>
+    <div style={{ position: 'absolute', bottom: phone ? 84 : 20, right: phone ? 14 : 20, width: 150, height: 150, zIndex: 20 }}>
       {mv('fwd', '▲', { top: 0, left: 52 })}
       {mv('left', '◀', { top: 52, left: 0 })}
       {mv('right', '▶', { top: 52, left: 104 })}

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -693,6 +693,12 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-dock-more-right { right: 1px; justify-content: flex-end; padding-right: 5px; border-radius: 0 16px 16px 0; background: linear-gradient(270deg, var(--panel-solid) 35%, transparent); }
 .am-phone-dock-btn { display: flex; flex-direction: column; align-items: center; gap: 3px; min-width: 58px; min-height: 44px; padding: 7px 6px; border: none; background: none; border-radius: 11px; color: var(--dim); font-family: var(--font-ui); font-size: 9.5px; font-weight: 700; cursor: pointer; flex-shrink: 0; }
 .am-phone-dock-btn.am-on { color: var(--accent); background: var(--accent-soft); }
+/* Action verbs folded into the dock (phoneActionsInDock): they FIRE rather
+   than open a sheet, so they read in the bar's foreground color, and the
+   primary one is accent-filled to stand apart from the panel toggles. */
+.am-phone-dock-verb { color: var(--fg); }
+.am-phone-dock-verb.am-primary { color: var(--accent-fg); background: var(--accent); }
+.am-phone-dock-verb:disabled { color: var(--dim-2); }
 .am-phone-dock-sep { width: 1px; height: 30px; background: var(--border); flex-shrink: 0; margin: 0 3px; }
 .am-phone-sheet { position: absolute; left: 0; right: 0; bottom: 0; max-height: 72%; display: flex; flex-direction: column; background: var(--panel-solid); border-top: 1px solid var(--border-strong); border-radius: 18px 18px 0 0; box-shadow: var(--shadow); z-index: var(--z-sheet); animation: am-slideup .26s var(--ease); }
 .am-phone-sheet-head { position: relative; display: flex; align-items: center; gap: 9px; padding: 16px 12px 10px 16px; border-bottom: 1px solid var(--border); }

--- a/src/chrome/workspace/PhoneWorkspace.tsx
+++ b/src/chrome/workspace/PhoneWorkspace.tsx
@@ -23,8 +23,11 @@ const maxCardH = () => Math.round(window.innerHeight * 0.8);
  * Layouts menu is hidden on phone.
  */
 export default function PhoneWorkspace(props: WorkspaceProps) {
-  const { appId, title, subtitle, views, layouts: appLayouts, defaultLayoutId, explainer, titlePanel, topExtra, actions, modes, activeMode, onModeChange } = props;
+  const { appId, title, subtitle, views, layouts: appLayouts, defaultLayoutId, explainer, titlePanel, topExtra, actions, phoneActionsInDock, modes, activeMode, onModeChange } = props;
   const sections = useMemo(() => sortByTier(props.sections), [props.sections]);
+  // When an app opts in, the action verbs ride inside the dock as a leading
+  // cluster (one consolidated bottom bar) rather than a separate strip above it.
+  const mergeActions = !!phoneActionsInDock && !!actions?.length;
   // Single-view apps go full-bleed: the lone view fills the whole screen and
   // the top bar floats over it (overlaid), rather than sitting above it. Multi-
   // view apps keep the stacked cards below the bar.
@@ -76,7 +79,7 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
   };
 
   return (
-    <div className={`am-app am-phone-app${actions?.length ? ' am-has-actions' : ''}${immersive ? ' am-phone-immersive' : ''}`}>
+    <div className={`am-app am-phone-app${actions?.length && !mergeActions ? ' am-has-actions' : ''}${immersive ? ' am-phone-immersive' : ''}`}>
       <TopBar
         title={title}
         subtitle={subtitle}
@@ -183,9 +186,26 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
           );
         })}
       </div>
-      {actions && <ActionBar actions={actions} sections={sections} phone />}
+      {actions && !mergeActions && <ActionBar actions={actions} sections={sections} phone />}
       <div className="am-phone-dockwrap">
         <nav ref={dockRef} className="am-phone-dock" aria-label="Panels">
+          {mergeActions && (
+            <>
+              {actions!.map(a => (
+                <button
+                  key={`act-${a.id}`}
+                  className={`am-phone-dock-btn am-phone-dock-verb${a.primary ? ' am-primary' : ''}`}
+                  aria-label={a.label}
+                  disabled={a.disabled}
+                  onClick={a.onClick}
+                >
+                  <Icon name={a.icon} size={19} />
+                  <span>{a.label}</span>
+                </button>
+              ))}
+              <div className="am-phone-dock-sep" />
+            </>
+          )}
           {sections.map((s, i) => {
             const arch = ARCHETYPES[s.arch];
             const prev = i > 0 ? ARCHETYPES[sections[i - 1].arch] : null;

--- a/src/chrome/workspace/PhoneWorkspace.tsx
+++ b/src/chrome/workspace/PhoneWorkspace.tsx
@@ -186,10 +186,15 @@ export default function PhoneWorkspace(props: WorkspaceProps) {
           );
         })}
       </div>
-      {actions && !mergeActions && <ActionBar actions={actions} sections={sections} phone />}
+      {/* The action verbs normally fold into the dock (mergeActions). But a
+          fullscreen view sits at --z-full, above the --z-dock the merged
+          cluster rides — so in fullscreen we fall back to the standalone
+          ActionBar (--z-actionbar, above fullscreen), preserving the contract
+          that primary verbs stay reachable while full. */}
+      {actions && (!mergeActions || full != null) && <ActionBar actions={actions} sections={sections} phone />}
       <div className="am-phone-dockwrap">
         <nav ref={dockRef} className="am-phone-dock" aria-label="Panels">
-          {mergeActions && (
+          {mergeActions && full == null && (
             <>
               {actions!.map(a => (
                 <button

--- a/src/chrome/workspace/types.ts
+++ b/src/chrome/workspace/types.ts
@@ -147,6 +147,11 @@ export interface WorkspaceProps {
    *  panel); renders bottom-center on desktop, above the dock on phone,
    *  and persists through fullscreen. See ActionDef. */
   actions?: ActionDef[];
+  /** Phone opt-in: fold the action verbs into the bottom dock as a leading
+   *  cluster (one consolidated bar) instead of a separate strip above it.
+   *  Saves a row on cramped immersive views (Polygon Worlds). Desktop is
+   *  unaffected — the verbs stay in the floating action pill there. */
+  phoneActionsInDock?: boolean;
   /** Panel id the top-bar title opens when clicked (e.g. 'function'), so the
    *  formula in the bar doubles as a shortcut to its selector. */
   titlePanel?: string;


### PR DESCRIPTION
The ≤740px immersive view stacked two full-width bottom rows (the
Plant/Clear action strip and the World/View/… dock), which shoved the
on-screen walk pad into mid-screen, colliding with the scene props.

- Title names the world (e.g. "Klein bottle") on phone, where the app
  name is dead weight (the subtitle is hidden there anyway); tapping it
  still opens the World picker. Desktop keeps "Polygon Worlds".
- New opt-in `phoneActionsInDock` folds the action verbs into the bottom
  dock as a leading cluster (one consolidated bar) instead of a separate
  strip; desktop is unaffected. Polygon Worlds opts in.
- The two clears collapse into one "Clear" verb that opens a small
  chooser (trail · signs · both): a bottom sheet on phone, a centered
  card on desktop. Two action buttons instead of three.
- The walk pad drops low (clear of the single bar and the character).