### PR TITLE
Complex Particles: postures, presets, captions + graph↔map handoff (decomposition PR-0/1/2 + Phase-2 MVP)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -157,8 +157,8 @@ visible app catalog comes from `src/apps.ts` (+ `src/chrome/catalog.ts`).
 | Hash Route            | Component        | Description                                |
 |----------------------|------------------|--------------------------------------------|
 | `#/` (default)       | `Gallery`        | Landing gallery of all apps                 |
-| `#/complex-particles`| `App → ComplexParticles` | 4D complex-function particle viewer |
-| `#/plane-transform`  | `PlaneTransform` | f as a transformation of the plane (one split view window: domain · image) |
+| `#/complex-particles`| `App → ComplexParticles` | 4D complex-function particle viewer (top-bar **↗ plane map** link hands the function to Plane Transform — the "graph ↔ map" pair; codec in `lib/functionHandoff.ts`) |
+| `#/plane-transform`  | `PlaneTransform` | f as a transformation of the plane (one split view window: domain · image); **↗ 4D graph** link hands the function back to Complex Particles |
 | `#/fractals`         | `FractalsGPU`    | GPU Mandelbrot / Julia / Burning Ship / Tricorn |
 | `#/fractals-cpu`     | `Fractals2D`     | Legacy CPU 2D fractals (unlisted)           |
 | `#/correspondence`   | `Correspondence` | Mandelbrot ↔ Julia, two linked view windows |

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 The landing page (`#/`) is a gallery of every app; the cards below are also
 reachable directly by hash route.
 
-1. **[Complex Particles](https://piyarsquare.github.io/animath/#/complex-particles)** – 3D representation of four-dimensional complex functions. Includes the former *Complex Roots* (`z^(p/q)`) and *Complex Multibranch* (multi-sheeted maps for `sqrt`, `ln`, etc.) as built-in modes.
-2. **[Plane Transform](https://piyarsquare.github.io/animath/#/plane-transform)** – watch a complex function `f : ℂ → ℂ` warp a colored grid of the plane, input pane beside output pane.
+1. **[Complex Particles](https://piyarsquare.github.io/animath/#/complex-particles)** – 3D representation of four-dimensional complex functions. Includes the former *Complex Roots* (`z^(p/q)`) and *Complex Multibranch* (multi-sheeted maps for `sqrt`, `ln`, etc.) as built-in modes. A top-bar **↗ plane map** link opens the same function as a plane map in Plane Transform.
+2. **[Plane Transform](https://piyarsquare.github.io/animath/#/plane-transform)** – watch a complex function `f : ℂ → ℂ` warp a colored grid of the plane, input pane beside output pane. Its **↗ 4D graph** link opens the same function back in Complex Particles — the graph and the map are two views of one function.
 3. **[Fractals](https://piyarsquare.github.io/animath/#/fractals)** – GPU-accelerated Mandelbrot / Julia / Burning Ship / Tricorn viewer with optional orbit-tracing mode.
 4. **[Correspondence](https://piyarsquare.github.io/animath/#/correspondence)** – side-by-side Mandelbrot–Julia explorer; pick or draw paths through `c`.
 5. **[Topology Walk](https://piyarsquare.github.io/animath/#/topology-walk)** – first-person walk on a closed surface: a twisting / knotted corridor or a flat torus / Klein bottle, with shared footprints, avatar and third-person view.

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -61,6 +61,24 @@ informs future rounds. Delete or check off items as they land.
   `#/fractals-cpu`). If it's truly dead, follow up by deleting the folder, the route
   in `index.tsx`, the `apps.ts` entry, and the now-unused `marriage` `PreviewKind`.
 
+- [ ] [complex-particles] !med Mark inside/outside the unit circle (`|z| = 1`) in the 4D graph.
+  Dan (2026-06-17) has been "missing" a way to *see* `|z| < 1` vs `|z| ≥ 1` — the circle
+  is where Möbius/Blaschke maps swap inside↔outside, Joukowski folds it to a slit, and
+  roots of unity sit. A **shader/color change** (per-particle `|z|` is in the shader; no
+  DOM-overlay path for 80k points), deliberately kept out of #222. Design forks: (a) two
+  colormaps split at `|z|=1` (Dan's instinct); (b) a diverging palette centered on
+  `|z|=1` (circle as visible zero-crossing — most honest); (c) outside dimmed/desaturated;
+  (d) a literal drawn `|z|=1` ring. Open: domain `|z|` vs image `|f|`; new "Color by"
+  option vs a modifier on Domain/Range coloring. Honors hue-never-encodes-identity (colors
+  by a geometric region of `z`). See the plan's Phase-2 section. Pairs with the next item.
+
+- [ ] [complex-particles] !low Graph-native correspondence tie-line overlay (Step 2, Phase-2).
+  The "lift line" from the domain point `(x,y,0,0)` to its graph point `(x,y,Re f,Im f)`,
+  drawn through the same projection + 4D rotation (domain plane below, each point lifted
+  to its graph height). Engine-adjacent: new `LineSegments` geometry + projection plumbing,
+  plus undecided density/picking (sparse subset and/or tapped-point ray — never all 80k).
+  A domain-legibility twin of the unit-circle item above; could be one PR.
+
 - [x] [chrome] App-map view in the control center — per-app rollup (latest · risk · open · next).
 
 - [x] [docs] Split the two heavy complex guides into Part 1 / Part 2; cut applet weight.

--- a/docs/sessions/handoff/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/handoff/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -1,0 +1,154 @@
+---
+kind: handoff
+session: 2026-06-16-S01
+date: 2026-06-17
+title: "Complex Particles: postures, presets, captions + graph↔map handoff (PR #222)"
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: completed
+build: passing
+followup: null
+pr: 222
+app: complex-particles, plane-transform, chrome
+signals: needs-dan
+next: Decide — merge #222 now (complete + green), or build a deferred domain-legibility follow-up (tie-line overlay / unit-circle marking); each needs a short design pass.
+---
+
+# Complex Particles: postures, presets, captions + graph↔map handoff (PR #222)
+
+> [!NOTE]
+> This session **shipped code** (PR #222) on top of a prior design session. It
+> executed the [decomposition plan](https://github.com/piyarsquare/animath/blob/b834717/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md)
+> ("tame the *surface*, not the *code*"), then re-scoped Phase-2 after a three-hats
+> review. The branch is at a clean, green, mergeable checkpoint.
+
+## Summary
+
+PR #222 makes Complex Particles approachable without losing power, via **progressive
+disclosure** (not an app split). It lands a calm default posture + five task-shaped
+layout "postures" (**PR-0**), per-function recommended-view presets (**PR-1**), opt-in
+posture plot-captions (**PR-2**), and a **graph ↔ map function handoff** linking
+Complex Particles and Plane Transform (**Phase-2 MVP**). The originally-planned
+"domain|image split *inside* Complex Particles" was **dropped** after a three-hats
+review found it would duplicate Plane Transform / be mathematically false; the handoff
+(a pure, tested URL codec + a top-bar link each way) replaces it. State: build green,
+29/29 tests, lint at baseline (0 errors, 0 new warnings), both ends verified via
+headless WebGL, Cloudflare previews green. **Nothing half-built.**
+
+## What changed
+
+- **PR-0 — calm default + five postures** (shipped earlier in the branch). Default
+  layout is now `single` (Color only); the Layout menu reads as task-shaped postures
+  (Single Function · Representations · Change of Basis · Hopf & Projection · z → f(z)).
+  Mechanism is pure `LayoutDef[]` — no engine change.
+- **PR-1 — per-function presets.** Picking a *different* function auto-snaps
+  **domain/projection only** (units ×1/±2 for near-origin branch structure, Sphere/Hopf
+  for poles & Möbius, full tinted Riemann-sheet set for multivalued). Appearance (color,
+  size, render mode, motion) is never touched; the `z²` landing is byte-for-byte
+  preserved (it's the initial load, never a "change").
+- **PR-2 — posture plot-captions.** New **opt-in, off-by-default, desktop-only**
+  `WorkspaceProps.layoutCaptions` renders the active layout's `sub` as a subtle caption
+  under the plot; it fades once the user rearranges (layout → `custom`).
+- **Phase-2 MVP — graph ↔ map handoff.** New pure lib `lib/functionHandoff.ts` (URL-query
+  codec carrying **only** the function identity — name + `p`/`q` + quadratic `a`/`b`/`c`;
+  unparseable → `{}`, never crashes). Both apps read a one-time seed from the URL on mount
+  then strip the query (a reload uses the user's own saved choice; embed mode skipped). A
+  top-bar link each way: **↗ plane map** / **↗ 4D graph**. No engine/shader/persistence
+  change, no second renderer.
+- **Today's final polish (2026-06-17).** README + CLAUDE routing rows now mention the
+  handoff cross-link. The plan doc captures a new deferred follow-up: **marking
+  inside/outside the unit circle** (`|z| = 1`) — see Open / not done.
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`src/lib/functionHandoff.ts:25`](https://github.com/piyarsquare/animath/blob/b834717/src/lib/functionHandoff.ts#L25) | Pure URL-query codec — `encodeFunction` / `decodeFunction` (L45); function identity only |
+| [`src/lib/__tests__/functionHandoff.test.ts`](https://github.com/piyarsquare/animath/blob/b834717/src/lib/__tests__/functionHandoff.test.ts) | Round-trip + malformed-input tests (part of the 29 green) |
+| [`src/animations/ComplexParticles/ComplexParticles.tsx:826`](https://github.com/piyarsquare/animath/blob/b834717/src/animations/ComplexParticles/ComplexParticles.tsx#L826) | `applyFunctionPreset` (PR-1) + `selectFunction` (L844) + `topBarExtra` ↗ link (L904) |
+| [`src/animations/ComplexParticles/ComplexParticles.tsx:130`](https://github.com/piyarsquare/animath/blob/b834717/src/animations/ComplexParticles/ComplexParticles.tsx#L130) | One-time handoff seed (carries its own `eslint-disable`); preset Sets at L46/L50 |
+| [`src/animations/PlaneTransform/PlaneTransform.tsx:83`](https://github.com/piyarsquare/animath/blob/b834717/src/animations/PlaneTransform/PlaneTransform.tsx#L83) | Mirror seed-on-mount + ↗ 4D graph link (L585) |
+| [`src/chrome/workspace/types.ts:148`](https://github.com/piyarsquare/animath/blob/b834717/src/chrome/workspace/types.ts#L148) | `layoutCaptions?: boolean` (PR-2 opt-in prop) |
+| [`src/chrome/workspace/DesktopWorkspace.tsx:216`](https://github.com/piyarsquare/animath/blob/b834717/src/chrome/workspace/DesktopWorkspace.tsx#L216) | `captionSub` rendering (desktop only; fades on `custom`) |
+| [`src/chrome/theme.css:283`](https://github.com/piyarsquare/animath/blob/b834717/src/chrome/theme.css#L283) | `.am-bar-link` / `.am-bar-extra` (L279) / caption styles — themed across all 5 skins |
+| [`docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md`](https://github.com/piyarsquare/animath/blob/b834717/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md) | The plan this PR executed; now carries both deferred follow-ups in its Phase-2 section |
+
+## Open / not done
+
+The PR is **complete and mergeable as-is**. Two follow-ups are deferred (each captured in
+the plan doc's Phase-2 section, each wants its own short design pass):
+
+1. **Tie-line correspondence overlay (Step 2).** Draw the graph-native "lift line" from
+   the domain point `(x,y,0,0)` to its graph point `(x,y,Re f,Im f)`, through the same
+   projection + 4D rotation. Meaningful (the domain plane sitting below, each point lifted
+   to its graph height) but **engine-adjacent**: new `LineSegments` geometry + projection
+   plumbing, plus undecided density/picking (a sparse subset and/or a tapped-point ray —
+   never all 80k).
+2. **Unit-circle inside/outside marking (`|z| = 1`)** — *requested by Dan, 2026-06-17.*
+   Distinguish `|z| < 1` from `|z| ≥ 1` in the 4D graph (the circle is where Möbius/
+   Blaschke maps swap inside↔outside, Joukowski folds it to a slit, roots of unity sit).
+   **It's a shader/color change** — per-particle `|z|` is available in the shader, but
+   there's no DOM-overlay path for an 80k point cloud — which is why it was kept *out* of
+   #222 (scope: "no engine/shader change"). Design forks: (a) two colormaps split at
+   `|z|=1` (Dan's instinct); (b) a diverging palette centered on `|z|=1` (the circle as
+   visible zero-crossing — most mathematically honest); (c) a side treatment (outside
+   dimmed/desaturated); (d) a literal drawn `|z|=1` ring. Open: domain `|z|` vs image
+   `|f|`; new "Color by" option vs modifier on existing Domain/Range coloring.
+
+> [!IMPORTANT]
+> Both follow-ups are **domain-legibility** features and pair naturally — a future session
+> could scope them as one PR. Both need a Dan design call (which mechanism) before coding.
+> Neither blocks merging #222.
+
+## Context
+
+- **`appId` is the persistence root** — this is *why* the app wasn't split. A separate
+  app would fork every saved setting (`animath:<v>:<appId>:<field>` + `ws:<appId>`). The
+  handoff deliberately carries **only the function**, never view state: the two apps are
+  two ways of seeing one function, not two persistence roots.
+- **Returning users keep their saved arrangement** — saved `ws:complex-particles` layout
+  overrides `defaultLayoutId`, so only *fresh* profiles see the new `single` default. To
+  see PR-0's win in a screenshot, seed a fresh profile (`SEED_LS`); see the plan's note.
+- **Binding constraint honored throughout:** *hue never encodes function/mode/posture
+  identity* — color stays a function of `z` (Domain) or `f` (Range). The proposed
+  unit-circle feature colors by a *geometric region of `z`*, which is allowed.
+- **Verification harness:** headless WebGL via `node scripts/shoot.mjs '<route>' out.png`
+  (SwiftShader; the RGBELoader/cert/404 console lines are pre-existing noise — the HDR env
+  map can't decode under software WebGL). `npm run build` is the only CI gate; `npm test`
+  (29) and `npm run lint` (0 errors, ~60 baseline warnings) are green by convention.
+- **No `main` sync needed** — `origin/main` is fully contained in HEAD; `mergeable_state:
+  clean`. If `main` advances before merge, re-sync keeping every app's append-only entries.
+
+## Self-reflection
+
+1. **What would you do with another session?** Run the design pass on the two deferred
+   domain-legibility follow-ups (tie-line overlay + unit-circle marking) and, if Dan picks
+   a mechanism, build the unit-circle feature — it's the one the user explicitly said they'd
+   been "missing." I'd prototype option (b), the diverging palette centered on `|z|=1`,
+   since it makes the circle a true visible isoline, and compare it against (a) two
+   colormaps side by side in a fresh profile.
+2. **What would you change about what you produced?** PR #222 bundles PR-0/1/2 + Phase-2
+   MVP into one PR; the plan framed them as separable PRs. The single PR is well-sectioned
+   and reviewable, but a stricter reading of the plan would have shipped PR-0 alone first.
+   I judged the bundle acceptable because the later work (the "Rays"→"z → f(z)" rename, the
+   handoff) builds on the earlier postures — but a reviewer who wanted small PRs could
+   reasonably push back.
+3. **What were you not asked that you think is important?** Whether returning users should
+   ever be nudged toward the new `single` default (today they silently keep their old
+   arrangement). Deliberately not done — don't stomp a user's setup — but worth a conscious
+   decision rather than a side effect.
+4. **What did we both overlook?** Nothing structural surfaced. The three-hats review caught
+   the one real trap early (the in-app split would have duplicated Plane Transform / been
+   mathematically false), which is exactly what saved the session from building the wrong
+   thing.
+5. **What did you find difficult?** Judging whether the unit-circle request "fit" this PR.
+   The honest answer (it's a shader change that breaks the PR's "no engine change" safety
+   story) was clear once stated, but the pull to satisfy an explicit user ask in-the-moment
+   was real. Capturing it richly as a deferred follow-up was the right release valve.
+6. **What would have made this task easier?** A lightweight per-particle "domain scalar"
+   channel already plumbed into the color shader would make *both* the unit-circle marking
+   and future "color by |z|"-style features a small change instead of a shader edit — worth
+   considering as the substrate when the domain-legibility PR is scoped.
+7. **Follow-up value:** LOW — PR #222 is complete, verified, and mergeable; the two
+   follow-ups are net-new features/polish awaiting a Dan design call, not corrections to
+   anything shipped.

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-complex-particles-decomposition-review.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-complex-particles-decomposition-review.md
@@ -11,7 +11,7 @@ followup: null
 pr: null
 app: complex-particles
 signals: needs-dan
-next: Synthesize the six persona reviews into a recommended decomposition (or "don't split, do X instead") for Dan's decision.
+next: Build PR-0 from the plan (calm default + posture layouts) when Dan gives the go.
 ---
 
 # Complex Particles — should it become several sub-apps? (multi-lens review)
@@ -47,6 +47,24 @@ The [ideas-triage](../particle-viewer-ideas-priority-UDZRe/2026-06-05-S01-ideas-
 session deferred two big rocks: a **unified channel-mapping matrix** and **custom f**.
 
 ## Working notes
+
+### 🟡 milestone · 19:14 — Plan authored (`kind: plan`, proposed)
+**Why:** Distilled the synthesis into an executable, PR-sized plan:
+[Plan: tame the surface](2026-06-16-S01-plan-tame-the-surface.md). PR-0 = calm
+default + five posture layouts (the highest-leverage, ~one-array change); PR-1 =
+per-function preset-defaults keyed by target geometry (real `functionNames` indices);
+PR-2 = the posture affordance (open decision); Phase 2 = the Rays linked split-view
+(the only genuinely new capability), immersive stages, plane/particles naming. Grounded
+in the actual `LayoutDef`/`modes`/`immersive`/`panes` types and the 36-function library.
+Composes with the in-flight pair-mode plan (pair mode becomes a sixth posture).
+
+### 🟣 decision · 19:05 — Dan's call: draft the plan; "hide, keep power"
+**Why:** Dan chose (1) turn the synthesis into a committed `kind: plan` report, and
+(2) on the subtract-vs-hide dissent, **progressive disclosure** — the calm default
+hides ~80% but everything stays reachable behind an "Advanced" reveal; delete only
+genuinely dead code. So the plan adopts the Maintainer/UI position over the
+Aesthete's cut-to-the-bone, while still serving her "calm default" goal. Authoring
+the plan report next (separate `kind: plan` file, `status: proposed`).
 
 ### 🟡 milestone · 19:02 — Six reviews in; near-unanimous, with three live dissents
 **Why:** The panel returned and converged hard. All six verdicts are **"partial ·

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-complex-particles-decomposition-review.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-complex-particles-decomposition-review.md
@@ -1,0 +1,206 @@
+---
+kind: progress
+session: 2026-06-16-S01
+date: 2026-06-16
+title: Complex Particles — should it become several sub-apps? (multi-lens review)
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: in-progress
+build: unknown
+followup: null
+pr: null
+app: complex-particles
+signals: needs-dan
+next: Synthesize the six persona reviews into a recommended decomposition (or "don't split, do X instead") for Dan's decision.
+---
+
+# Complex Particles — should it become several sub-apps? (multi-lens review)
+
+## Session purpose
+
+Dan's concern: Complex Particles (the repo's most complicated app) has reached a
+complexity that makes it "too difficult to manage." He is tempted to split it into
+several distinct **sub-apps** but is unsure how to divide things. He named several
+*uses* it currently serves:
+
+1. Understanding a **specific** complex function.
+2. Understanding complex function **spaces** and different **representations** of
+   those transformations.
+3. Exploring **changes of basis**.
+4. Connecting **Hopf → Spherical → Projection**.
+5. Connecting the **X view to the Y view** as rays sweep the surface.
+
+He asked for a `/three-hats`-style review but with a **custom, larger panel** of
+personas: a UI thinker, a mathematician, a "Yelp reviewer of math-ed products," a
+deep complex-function expositor (words-with-animation), and an aesthete. This
+session runs that panel and synthesizes it into a recommendation for his decision.
+
+## Previous session
+
+First tracked session on this branch. The directly-relevant prior art lives on
+other branches: the [three-hats Complex Particles review](../three-hats-particle-app-rill2c/2026-06-10-S01-three-hats-complex-particles.md)
+(PR #205) settled a *narrower* question — "expand the app vs open a new one" for
+**multi-function** viz — with a unanimous **"expand, don't fragment"** and a
+committed 4-PR pair-mode plan. The [complex-guide series](../complex-particles-guide-tdlhk0/2026-06-14-S01-math-code-guide.md)
+session left a standing `!high` backlog item: **plane/particles unification**.
+The [ideas-triage](../particle-viewer-ideas-priority-UDZRe/2026-06-05-S01-ideas-triage-quick-wins.md)
+session deferred two big rocks: a **unified channel-mapping matrix** and **custom f**.
+
+## Working notes
+
+### 🟡 milestone · 19:02 — Six reviews in; near-unanimous, with three live dissents
+**Why:** The panel returned and converged hard. All six verdicts are **"partial ·
+high confidence"**: nobody wants separate apps (spectrum point E). The
+recommendation, the two-axis model, and the genuine open decisions for Dan are in
+the **Synthesis** section below. The single loudest signal — louder than the
+partition itself — is **fix the default landing state** (4 of 6 independently said
+the cold-open onto all 8 panels is the actual problem). The sharpest dissent is the
+Aesthete's: *subtract before you partition*.
+
+### 🟣 decision · 18:56 — Panel composition: six lenses, not three
+**Why:** Dan named five personas (UI · math · Yelp-style reviewer · expositor ·
+aesthete) and waved "you get the idea." I added a **sixth — framework maintainer /
+product architect** — because the actual decision is architectural and there is a
+*prior ruling against fragmentation* to reconcile; without that lens the synthesis
+can't be actionable (it would be poetry with no buildable mechanism). Each agent is
+briefed with the same context + the **decomposition spectrum** (presets → mode-pills
+→ layouts → hub app → separate apps) so none treats "split or don't" as binary, then
+its own lens. All six run in parallel, foreground, then I synthesize.
+
+### 🔵 finding · 18:55 — The current control surface is genuinely large
+**Why:** Grounding the brief in the real surface, not the README's idealization.
+`ParticleViewerShell` + `useParticleState` define **8 archetype panels** (Function ·
+Domain · Camera · Color · Render · Motion · 4D Rotation · System) totalling **~60
+individual controls**, over **~22 functions** (5 categories; several multivalued with
+branch/Riemann-sheet machinery + tinting), **4 render modes** (Points/Sheet/Tiles/Net,
+each with sub-controls), a **3-stop morphing projection** (Perspective⇠Torus⇢Sphere/Hopf)
+**+ 4 drop-axis slices**, two independent color channels, adaptive sampling, 7 sampling
+patterns, a |z| radius band, and quaternion 4D rotation with composable continuous
+spins. Dan's "too complex to manage" is well-founded, not a vibe.
+
+### 🔵 finding · 18:54 — Prior art partially answers an adjacent question
+**Why:** Avoid re-litigating settled ground and surface the real tension. The prior
+three-hats verdict ("expand, don't fragment") answered *multi-function viz*, not
+*total-surface decomposition*. The new question is broader and can be answered
+differently without contradicting it — especially because "sub-apps" need not mean
+code fragmentation (Trinary's Observatory/Lab modes and Stable Matching's
+matrix/welfare/lattice layouts both present as "sub-apps" while sharing one engine).
+The panel must engage this head-on.
+
+### 🟡 milestone · 18:54 — Session opened via start-session
+**Why:** Dan asked to run the skill before work. Branch `claude/sleepy-bardeen-uk0cal`
+is fresh (no prior handoff here); folders created; backlog + the three on-topic
+handoffs read.
+
+## The decomposition spectrum (shared brief to the panel)
+
+Not binary. Five points from least to most surgery:
+
+- **A · Presets on the monolith** — keep one app; add task-shaped starting points
+  ("Study one function", "Hopf view", "Domain coloring") that set defaults + open the
+  right layout. (The Hopf-study button already proves the pattern.)
+- **B · Mode pills** — top-bar modes that re-skin which panels/views exist (Trinary's
+  Observatory ↔ Lab). One app, one route, distinct postures.
+- **C · Layout "instruments"** — each task is a saved layout that hides irrelevant
+  views/panels (`LayoutDef.views[id].open=false`; Stable Matching's three instruments).
+- **D · Hub app** — a gallery-like launcher that opens focused sub-views of the same
+  engine.
+- **E · Separate apps/folders** — genuinely distinct registry entries (the
+  fragmentation the prior ruling resisted).
+
+## Synthesis
+
+### Headline (6/6, high confidence)
+
+**Don't split into separate apps. Split the *surface*, not the *code*.** Every
+reviewer landed on **"partial"**: the mathematics is *one* object (the 4D graph
+`Γ_f`) seen through many faithful views; the engine is *one* consolidated codebase;
+and `appId` is the **persistence root**, so separate apps would fork every saved
+setting and re-fragment the engine the repo's biggest cleanup just unified. "Sub-apps"
+should mean **in-app postures** (presets + layouts, optionally mode pills), not new
+registry entries. This is *compatible* with the prior "expand, don't fragment"
+ruling, not a reversal: taming the surface ≠ fragmenting the engine.
+
+| Lens | Verdict | Mechanism | One-line takeaway |
+|---|---|---|---|
+| UI (Priya) | partial · high | **B** on **C+A** | 4 postures (Inspect/Surface/Hopf/Basis); **kill the cockpit default**; per-function preset defaults |
+| Math | partial · high | **A+C** | One graph, four *lenses by target geometry* (Plane/Cylinder/Sphere/Branch); **never split projection from rotation**; keep Plane Transform as the map-vs-graph sibling |
+| Yelp (Marcus) | partial · high | **B over A** | "Meet a Function" front door; default to 1 function + morph slider + auto-tumble; Advanced holds today's surface |
+| Expositor | partial · high | **C+D**, 2 immersive | Six captioned chapters mirroring the guide ToC; *the unit of decomposition is the caption, not the control* |
+| Aesthete | partial · high | **subtract → C+D** | **Cut before you partition**; promote Hopf-collapse + X→Y to immersive quiet rooms; wall the comparative uses into a Lab |
+| Maintainer | partial · high | **C+A**, B if needed | Task-layouts + presets, one appId; mode pills must be in-component (PolygonWorlds), **never a Trinary-style hash hop** (that forks persistence) |
+
+### The four convergences
+
+1. **No separate apps (E).** Unanimous. One engine, one `appId`, one persistence root.
+2. **The default landing is the real problem** (Priya, Marcus, Expositor, Aesthete).
+   The highest-leverage change — cheap and independent of any partition — is to stop
+   cold-opening onto all 8 panels and land in one calm single-function posture.
+3. **Per-function preset defaults.** "Different functions want different
+   modes/domains" is a *defaults table keyed by function*, applied non-destructively —
+   not per-function apps (Priya, Math, Marcus).
+4. **Mechanism = C (layout instruments) + A (presets)** as the cheap, reversible
+   spine; an **in-component** posture selector (B, never a hash hop) as the visible
+   labels if salience demands; **immersive** single-view stages for the two reverent
+   views (Hopf-collapse, X→Y sweep).
+
+### The two-axis model (the synthesis insight)
+
+Two *orthogonal* decompositions, both wanted, neither a code split:
+- **Postures = "what do I want to *do*"** (task/curriculum-shaped): Single Function ·
+  Representations · Change of Basis · Hopf→Sphere · X→Y rays. → **layouts/presets**.
+- **Per-function presets = "what does this *function* want"** (target-geometry-shaped,
+  the mathematician's axis): Plane (`z²`, `sin`) · Cylinder/log-polar (`exp`, `ln`,
+  `z^n`) · Riemann sphere (Möbius/rational) · Branch sheets (multivalued). → **a
+  defaults table keyed by function index**, applied on function-change only.
+
+### The three live dissents (decisions for Dan)
+
+1. **Subtract vs. hide-by-default** (Aesthete vs. Maintainer/UI). The Aesthete wants
+   *deletion* (orientation matrix out of the default, Tiles mode, sprite textures,
+   8→3 colormaps, jitter/shimmer→0, hue-shift); the maintainer/UI want *progressive
+   disclosure* (hide, keep for power users). Independent agreement on real **dead
+   code** to delete regardless: `inputCoord`/`outputCoord` (pinned-Cartesian, unused);
+   the dual boundsLock widgets are "two ways to do one thing."
+2. **Mode pills (B) vs. ordered captioned chapters (C/immersive).** Priya & Marcus
+   want visible top-bar pills (a legible feature map); the Expositor argues *against*
+   pills ("a toggle, not a sequence; carries no caption") for ordered layout-chapters
+   with a per-view caption. Reconcilable: the selector *is* the layout chooser **and**
+   sets the per-view `hint` caption — but Dan picks the affordance.
+3. **Build the one genuinely new thing?** Use #5 (X-view ↔ Y-view as rays sweep) is
+   the only under-built use — the single-view shell can't show it; it needs a linked
+   **`panes` split view** (Plane Transform / Correspondence pattern). Everything else
+   is *re-posing existing capability*.
+
+### Notable side-findings
+
+- **Plane Transform is not redundant** with Complex Particles (Math): Particles draws
+  the *graph* `(z,f)∈ℝ⁴`; Plane Transform draws the *map* (the `(u,v)` shadow). The
+  existing two-app split is mathematically correct — which reframes the `!high`
+  "plane/particles unification" backlog item as **"name them graph vs map,"** not
+  "merge them."
+- **Composes with the pair-mode 4-PR plan** (Maintainer): the plan's PR-2 extraction
+  makes the orchestration ownable; task-layouts give the tamed surface a friendlier
+  door; pair mode then lands as one more `axesMode` field + one more task layout —
+  inside the same app. Splitting into apps now would *collide* with that plan.
+
+### Recommended path (PR-sized, reversible-first)
+
+1. **PR-0 — the cheap, high-leverage win:** a calm default posture (land in one
+   function, Color, a clean Perspective/Drop view; auto-tumble doing the 4D work) +
+   4–5 **task layouts** + a **per-function preset-defaults** table. No engine or state
+   change; append-only inside `ParticleViewerShell`/`ComplexParticles`.
+2. **PR-1 — the extraction** (= the pair-mode plan's PR-2): pull the per-branch
+   material orchestration into `lib/particles`, behavior-identical. The real
+   "manageable" win.
+3. **Later:** the X→Y linked `panes` view (#5); immersive stages for Hopf + X→Y;
+   resolve the subtract-vs-hide and pills-vs-chapters calls; let pair mode land as a
+   task layout.
+
+> [!IMPORTANT]
+> The two truly load-bearing decisions are Dan's: **(a) how aggressively to subtract**
+> (the Aesthete's cut-list vs. hide-by-default), and **(b) the affordance** for moving
+> between postures (top-bar pills vs. ordered captioned layouts). Both are reversible;
+> neither blocks PR-0.
+</content>
+</invoke>

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-complex-particles-decomposition-review.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-complex-particles-decomposition-review.md
@@ -48,6 +48,17 @@ session deferred two big rocks: a **unified channel-mapping matrix** and **custo
 
 ## Working notes
 
+### 🟢 milestone · 21:20 — PR-0 built: calm default + five posture layouts
+**What:** Recast `ParticleViewerShell`'s `layouts` into five task **postures**
+(Single Function · Representations · Change of Basis · Hopf & Projection · Rays);
+`defaultLayoutId` `essentials → single`. The default now lands **clear of the plot**
+(only the Color panel opens, left gutter — screenshot-verified in a fresh profile);
+the 470px 4D rig only appears in **Change of Basis** (also screenshot-verified). No
+engine or state-field change — pure layout data; returning users keep saved
+arrangements (the `layout` label is cosmetic, `open`/`views` hold positions).
+`npm run build` + 22 vitest tests green. Next: create the PR; review Dan's
+reversible decisions.
+
 ### 🟡 milestone · 19:14 — Plan authored (`kind: plan`, proposed)
 **Why:** Distilled the synthesis into an executable, PR-sized plan:
 [Plan: tame the surface](2026-06-16-S01-plan-tame-the-surface.md). PR-0 = calm

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-consultant.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-consultant.md
@@ -1,0 +1,337 @@
+---
+kind: three-hats
+session: 2026-06-16-S01
+date: 2026-06-16
+title: "Three Hats — Architecture Consultant: Rays split-view realization"
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: review
+build: passing
+---
+
+# Three Hats — Architecture Consultant: Rays split-view realization
+
+I am reviewing this as an external front-end architecture and quality consultant
+(React/TypeScript, Three.js, headless-UI and render-prop patterns, shared-model
+multi-view rendering). I have no attachment to the existing code; my job is to
+decide whether the proposed **Rays (X→Y) linked split view** for Complex
+Particles is structurally sound, whether it duplicates an asset the catalog
+already owns, and what the cheapest correct realization is. I read the plan
+under review, `PlaneTransform.tsx`, `SplitPanes.tsx`, `types.ts`,
+`createAnimationLoop.ts`, `ParticleViewerShell.tsx`, and `viewpoint.ts` to
+ground the claims below.
+
+## Plan under review
+
+<details><summary>Original request</summary>
+
+```
+Phase-2 of the Complex Particles decomposition: how should the "Rays (X→Y) linked split view" be realized?
+
+CONTEXT. Complex Particles renders the 4D graph Γ_f = {(z, f(z)) ⊂ ℂ²} as a particle cloud. We shipped (PR #222) a calm default + five postures: Single Function, Representations, Change of Basis, Hopf & Projection, "Rays (X→Y)". Rays today opens Render + Motion on the single 4D cloud. Phase-2 should give Rays a linked domain | image split view ("Plane Transform / Correspondence style, on the 4D engine").
+
+PIVOTAL FINDING. Plane Transform ALREADY is a domain|image linked split of the same function (panes domain z / image f(z) of the same geometry, shared coloring, linked zoom, draw-on-input; chrome-less EmbedPlaneTransform). A "Rays split" inside Complex Particles would substantially RE-IMPLEMENT Plane Transform.
+
+BINDING CONSTRAINTS: (1) no engine fragmentation/duplication ("expand don't fragment", PR #205). (2) one app, one appId, one persistence root; postures in-component, never a route hop. (3) hue never encodes identity (color = f(z) Domain or f Range). (4) append-only; z² landing untouchable.
+
+OPTION A — Embed Plane Transform's renderer as the Rays view (reuse PT panes/shaders in-component). Con: PT is a 2D-plane particle map (transform 0↔1), not the 4D cloud — a different renderer than the other four postures; two engines in one app; overlaps PT identity.
+OPTION B — Particle-native input|output split: two panes, each the 4D cloud projected to isolate INPUT (DropU/DropV → z-plane) vs OUTPUT, linked camera + tapped "ray". Pro: stays on the 4D engine; novel. Con: more build, muddier picture, new linked-projection plumbing, two live 3D scenes.
+OPTION C — Resolve by naming/linking: make Plane Transform THE map, add a cross-app handoff (shared function via URL) Complex Particles ↔ Plane Transform, redefine/drop Rays. Pro: zero duplication, cheapest. Con: cross-app context switch; Rays stops being an in-app posture.
+
+QUESTION: Which best serves (i) pedagogy, (ii) framework health/anti-duplication, (iii) clean architecture given PT exists? A/B/C/hybrid? Flag duplication risk; give a concrete recommendation + MVP scope.
+```
+
+</details>
+
+---
+
+## The pattern actually at stake
+
+Strip the three options of their app-specific framing and a single recognizable
+pattern decides the question. There are exactly two structural archetypes on the
+table:
+
+- **Shared model, multiple projections** (the good one). One source of truth —
+  a geometry, a function index, a set of orientation refs — is rendered through
+  *N* views, each a different camera/projection/transform of the same data.
+  Plane Transform is already a textbook instance: one `BufferGeometry`, two
+  panes, distinguished by a single `transform` uniform (`0` for domain, `1` for
+  image). Correspondence is a looser instance (two views linked by a shared
+  tapped point). This is the headless-UI / "lift state, fan out renderers"
+  shape, and it composes: adding a third projection is adding a uniform, not a
+  subsystem.
+
+- **Two engines in one app** (the smell). A component owns two *different*
+  rendering subsystems with different state shapes, different loops, different
+  lifecycles, glued by ad-hoc synchronization. This is the conflation-of-concerns
+  anti-pattern. It is not automatically wrong — Trinary legitimately hosts an
+  Observatory and a Lab — but it is a structural liability that must earn its
+  keep, because every future change pays the two-engine tax twice.
+
+> [!IMPORTANT]
+> **Option A is "two engines in one app" wearing the costume of "shared model,
+> multiple projections."** The Rays posture would sit beside four postures
+> driven by the 4D particle engine (`lib/particles`, single perspective camera,
+> `startAnimationLoop`, per-sheet `ShaderMaterial`s, quaternion 4D rotation
+> refs) and one posture driven by Plane Transform's 2D orthographic
+> `transform`-uniform engine. The "model" is not shared — `lib/particles`
+> samples a 4D graph and projects ℝ⁴→ℝ³; Plane Transform samples a 2D grid and
+> evaluates f in a vertex shader to relocate points in the ℝ² image plane. The
+> only thing common to both is the *function library* (`complexMath.ts`), which
+> they already share without being the same engine. Choosing A imports a second
+> WebGL subsystem, a second uniform-sync `useEffect`, a second resize model
+> (inscribed-square orthographic vs. perspective fill), and a second rAF
+> tick into a component whose other four postures know nothing about any of it.
+
+This is the crux. The request's own Option-A con ("two engines in one app")
+is not a minor drawback to weigh against novelty — it is the disqualifying
+property. The reviewer's instinct to be skeptical of conflated concerns is
+correct here.
+
+## Option comparison
+
+| Axis | A — embed PT's renderer | B — particle-native input/output split | C — name + cross-app link |
+|---|---|---|---|
+| **Pattern** | Two engines in one app (smell) | Shared model, two projections (clean) | Shared model, two *apps* (clean, but split surface) |
+| **Coupling** | High: ComplexParticles now depends on PT's shaders, pane components, resize math; bidirectional drift risk | Low: reuses the engine's own `project()` drop-axis modes; new code is linked-camera plumbing | Lowest: a URL contract (`?fn=…`) — a string, the loosest possible coupling |
+| **Cohesion** | Broken: one component owns two unrelated render pipelines | Intact: every posture is "the 4D cloud, projected differently" | Intact per app: each app does one thing |
+| **Perf (live renderers)** | **Two WebGL contexts** when Rays is open (PT's two panes are already two contexts; here they'd be a *third/fourth* alongside the 4D context if not torn down) — see callout | **Two WebGL contexts / two 4D scenes** — the expensive case (two particle clouds, two loops or one multi-viewport loop) | **One context per app**, never two at once (you're in one app at a time) |
+| **Bundle (React.lazy)** | ComplexParticles chunk swells: PT's shaders + pane code now load with *every* Complex Particles visit, even for users who never open Rays | Modest: new linked-camera code, reuses existing engine; no foreign shaders | Zero added to either chunk; a few lines of URL parse/emit |
+| **Testability (build + manual only)** | Worst: a new cross-engine seam with no unit coverage; correctness is "do two different pipelines agree?" — only checkable by eye | Medium: the seam is "do two cameras/projections of one geometry stay linked?" — still eyeball-only, but one engine | Best: the seam is a pure URL round-trip, the one thing trivially unit-testable in this repo's vitest setup |
+| **Composability across catalog** | Negative: establishes "embed another app's renderer in-component" as a precedent others will copy | Neutral/positive: a reusable "linked multi-projection of the 4D engine" capability | Positive: a reusable cross-app **function handoff** the whole catalog can adopt (Correspondence ↔ Fractals, etc.) |
+| **Duplication risk** | **Re-implements / re-hosts PT** — the exact thing the pivotal finding warns against | Low duplication of *code*, but **duplicates PT's pedagogical role** (a domain\|image map of f) in a second place | **Zero duplication** — PT stays the one map |
+| **Honors "hue ≠ identity"** | Yes (PT colors by z/Domain) | Yes (engine colors by z or f) | Yes |
+| **In-app posture preserved** | Yes | Yes | **No** — Rays becomes a cross-app jump |
+
+### The "second renderer in one app" smell vs. the "shared core, two views" ideal
+
+The ideal this codebase already reaches for — and reaches in Plane Transform —
+is *one* model, *two* cheap views. Plane Transform achieves it elegantly: the
+two panes are not two engines; they are one geometry and one shader, branched by
+a single `transform` uniform, rendered by two thin renderer instances that share
+everything upstream of the GPU. That is the shape to imitate, not to import.
+
+Option A inverts it: it would put a *whole second engine* (PT's) next to the 4D
+engine and call the result "a view." The tell is that nothing upstream is
+shared — not the geometry (4D vs 2D grid), not the camera (perspective vs
+orthographic inscribed-square), not the loop, not the resize policy. When two
+"views" share no model, they are two engines, and the abstraction boundary has
+been drawn in the wrong place.
+
+Option B is the honest "shared core, two views" play *within* the 4D engine: both
+panes are the same 4D particle cloud, one isolating the input copy (`DropU`/`DropV`
+→ the z-plane, which `viewpoint.ts` already implements: `DropV` returns
+`(x,y,z)`, i.e. drops the +v output axis) and one showing the output. That is
+structurally correct — but it is also where the real cost lives, because the
+*engine* must learn to drive two scenes.
+
+> [!CAUTION]
+> **`startAnimationLoop` is single-scene by construction.** Read
+> `createAnimationLoop.ts`: it closes over one `renderer`, one `scene`, one
+> `camera`, one `materialsRef`, one `axisRefs`, and ends with a single
+> `renderer.render(scene, camera)`. Option B needs *either* two of these loops
+> (two clocks, two quaternion compositions — they will drift unless seeded from
+> shared refs every frame) *or* a refactor of the loop to a multi-viewport model
+> (`renderer.setViewport` + N camera/scene pairs sharing the ref-driven 4D
+> state). The first duplicates the engine's heartbeat; the second is a genuine
+> engine change touching the repo's most-consolidated file. Neither is the
+> "modest" build the option's framing implies. This is the load-bearing cost B
+> hides.
+
+### Performance of two live WebGL contexts
+
+This deserves its own paragraph because it is the same hidden tax under both A
+and B, and it is real on the target (mobile, high particle counts):
+
+- **Context count.** Plane Transform already creates **two** `WebGLRenderer`s
+  (one per pane) — confirmed in `PlaneTransform.tsx` (`mount(...)` called for
+  input and output). The 4D engine creates one. Option A, naively, would have
+  the 4D context *plus* PT's two contexts alive whenever Rays is open and the
+  view isn't torn down — and recall the framework deliberately **does not
+  unmount collapsed views** (to preserve WebGL state), so "switch away from
+  Rays" does not free those contexts. Browsers cap live WebGL contexts
+  (commonly ~8–16); burning three-to-four on one app is profligate and risks the
+  oldest-context-loss eviction that manifests as a randomly blanked canvas.
+- **Fragment cost.** Two live particle clouds (Option B) means roughly **2× the
+  fill and draw** of one. The engine already pushes adaptive density up to large
+  point counts; doubling that on a phone at 60fps is the difference between
+  smooth and dropped frames. Plane Transform mitigates by being a *2D* map with
+  capped DPR and inscribed-square sizing — the 4D cloud has no such natural cap.
+- **rAF multiplicity.** Two independent loops means two `requestAnimationFrame`
+  chains. They will not stay phase-locked, and the 4D rotation refs they read
+  must be updated from one writer or the two panes will show the *same* function
+  at *different* orientations — a correctness bug that looks like a render glitch.
+
+Option C has none of this: you are only ever in one app, so only one engine's
+contexts are live.
+
+## What contract / seam keeps each option correct
+
+The discipline question: for each option, what is the single invariant that, if
+it holds, makes the picture truthful — and is it checkable with only
+`npm run build` plus manual inspection?
+
+| Option | Load-bearing invariant | Checkable how |
+|---|---|---|
+| A | The PT pane and the 4D cloud agree on *which f, which branch, which extent* every frame — across two uniform-sync effects with different schemas | Eyeball only; no shared type enforces agreement → silent drift is the failure mode |
+| B | The two panes share **one** set of 4D-rotation/orientation refs and one function/branch source; only the **projection** (drop-axis) differs per pane | Eyeball; partially structural if both panes read the *same* refs (a code-review check, not a test) |
+| C | The URL function descriptor **round-trips** (Complex Particles emits `?fn=idx&p=&q=&…`; Plane Transform parses the identical schema and lands on the same f) | **Unit-testable** — a pure encode/decode round-trip, the strongest seam of the three |
+
+Option C is the only one whose correctness seam is a pure function. In a repo
+whose sole CI gate is `npm run build` and whose tests cover "chrome pure logic,"
+the option that reduces the new risk to a testable pure function is the one that
+fits the verification reality, not fights it.
+
+## Where each option fails
+
+- **A fails on maintainability and bundle.** Six months out, a newcomer opening
+  ComplexParticles to change a render mode finds a foreign engine bolted into one
+  posture, with its own resize math and shader set, loaded eagerly into the
+  chunk. The pivotal finding's warning — "would substantially re-implement Plane
+  Transform" — is precisely realized: even "reuse PT's components" means
+  ComplexParticles now *depends on* PT's internals, so PT can no longer evolve
+  freely (it has a second consumer it can't see). This is the not-invented-here
+  inversion: instead of inventing, it *entangles*. Reject.
+
+- **B fails on cost-vs-clarity, not on pattern.** B is the architecturally
+  honest in-app answer, and if the engine were already multi-scene I would
+  endorse it. But it demands the engine change flagged in the CAUTION (two loops
+  or a viewport refactor), it doubles GPU cost on mobile, and the request itself
+  concedes "muddier picture": two 3D projections of one 4D cloud, side by side,
+  asking the viewer to mentally re-link them, is *harder* to read than PT's two
+  flat planes with a hand-drawn ray. It buys novelty at the price of pedagogy and
+  performance. Defer, don't kill — it could be a future "advanced" form once the
+  engine supports multi-viewport for other reasons.
+
+- **C fails on in-app continuity.** Rays stops being a posture you flip to and
+  becomes a "open this in Plane Transform" jump. That is a real UX cost (context
+  switch, a second app's chrome, the saved-setup question). But it is the *only*
+  cost, and it is mitigable: the handoff can carry the function so the jump feels
+  like "see this same f as a flat map," and a returning link can carry you back.
+
+## The hybrid worth naming
+
+The cleanest answer is **C as the architecture, with the in-app posture
+reframed rather than deleted** — a C/PR-0 hybrid:
+
+1. **Keep `rays` as a posture** (append-only; it already ships). But its *job*
+   is not "re-implement PT inside the cloud." Its job is the **ray idea on the
+   4D engine** that the cloud uniquely can show and PT cannot: the per-particle
+   segment from `z` to `f(z)` in the *same* 4D graph — i.e. lean on the engine's
+   existing Render (Net) + Motion, optionally adding a "connect z→f" rendering of
+   the graph's two ℂ-shadows. This is the genuinely-4D thing, and it does **not**
+   need a split view at all.
+2. **Add the cross-app function handoff** (the reusable C asset): a shared URL
+   function descriptor so Complex Particles can offer "Open as a plane map →"
+   that lands Plane Transform on the same f, and vice versa. PT already parses an
+   embed config and a `?fn=` notion via `EmbedPlaneTransform`; extending the
+   normal route to read the same descriptor is small and reuses existing code.
+3. **Do not build a second renderer** (no A) and **do not double the 4D scene
+   now** (defer B behind a real multi-viewport need).
+
+This serves all three criteria the question asks about: **(i) pedagogy** — the
+flat domain\|image map (PT) and the 4D ray-graph (the posture) become two
+*distinct* lessons that reference each other, instead of one lesson rendered
+twice; **(ii) framework health** — zero engine fork, zero duplicated renderer,
+and a new cross-app contract the rest of the catalog can reuse; **(iii) clean
+architecture given PT exists** — PT stays the single owner of "the map," its
+abstraction boundary intact, with one loose URL coupling instead of a hard
+code dependency.
+
+---
+
+## Verdict
+
+> [!IMPORTANT]
+> **Endorsed: Option C, as a hybrid that keeps the `rays` posture but redefines
+> its job and adds a cross-app function handoff.** Reject A outright (it is "two
+> engines in one app" and re-hosts Plane Transform — the precise duplication the
+> pivotal finding warns against, plus a bundle and WebGL-context cost). Defer B
+> (architecturally honest but it requires a multi-scene engine change, doubles
+> GPU cost on mobile, and yields a *muddier* picture than PT's flat planes).
+
+**Endorsed option:** **C-hybrid.** Concretely:
+
+1. **Reframe `rays`** from "domain|image split" to "the z→f(z) ray *on the 4D
+   graph*" — the thing only this engine can draw — realized with the engine's
+   existing Render/Motion (no `panes`, no second renderer). If a split is ever
+   wanted here, it is B and must wait for a multi-viewport engine.
+2. **Build the reusable cross-app function handoff:** a single shared URL
+   descriptor (`fn` index + `p/q` + quadratic coeffs + branch), encode/decode as
+   a pure function, with a round-trip **unit test** (the one new seam that can be
+   tested). Wire a "Open as plane map →" affordance in Complex Particles and the
+   return link in Plane Transform.
+
+**Concerns / changes I'd require before merge:**
+
+- The handoff descriptor must be the **single source of truth** for function
+  identity across both apps — define it once (extend the existing
+  `embedParams`/`complexMath` index space; do not invent a parallel encoding) so
+  the two apps cannot drift. This is the only place correctness can rot, so it
+  is the place to put the unit test.
+- Respect the binding constraints already in the plan: **append-only** (the
+  `rays` posture id and the z² landing are untouched), **one `appId`** (the
+  handoff is a navigation, not a persistence fork — and crossing apps *does*
+  cross persistence roots, so the link should be framed as "see it there," not
+  "continue your session there"; carry only the function, never the appearance
+  state).
+- Keep **hue = f(z)/Domain or f/Range** on both sides; the handoff carries the
+  function, not a color identity.
+- Do **not** let Option A sneak back as "just reuse PT's pane components" — that
+  is the same hard coupling with a softer name.
+
+**MVP scope (smallest correct slice):**
+
+1. A pure `encodeFunction(state) → query` / `decodeFunction(query) → state`
+   pair over the existing function index space, with a vitest round-trip test.
+   *(This is the whole architectural payload; everything else is wiring.)*
+2. Plane Transform reads that descriptor on its normal route (reuse the embed
+   parse path).
+3. A small "Open as a plane map →" link in Complex Particles' Rays posture (and
+   a reciprocal link back), carrying only the function.
+4. Leave `rays` opening Render + Motion as it does today; *optionally* add the
+   z→f ray rendering as a fast follow — it is independent of the handoff and
+   needs no split view.
+
+**Explicitly out of MVP:** any second `WebGLRenderer` in Complex Particles; any
+`panes` on a Complex Particles view; any change to `startAnimationLoop`. Those
+belong to a future Option-B effort that should be justified by a *general*
+multi-viewport need, not by Rays alone.
+
+---
+
+## Self-reflection
+
+1. **What would you do with another session?** Sketch the concrete
+   `encodeFunction`/`decodeFunction` schema against the real index space in
+   `complexMath.ts` and `embedParams.ts`, confirm Plane Transform's normal route
+   (not just `EmbedPlaneTransform`) can consume it without refactor, and write
+   the round-trip test so the "single source of truth" claim is demonstrated, not
+   asserted.
+2. **What would you change about what you produced?** I leaned on the request's
+   summary of Plane Transform's "two contexts" and confirmed the two-renderer
+   mount, but I did not measure actual GPU/context cost on a device — the
+   perf section is sound on counting principles but not on benchmarks.
+3. **What were you not asked that you think is important?** Whether the
+   *cross-app handoff* should be a one-off Rays feature or a catalog-wide
+   convention (Correspondence ↔ Fractals, etc.). I recommend the latter; that
+   decision changes how generic the URL descriptor should be and is worth Dan's
+   explicit call.
+4. **What did we both overlook?** The "collapsed views are never unmounted"
+   rule makes the multi-context cost of A/B *worse* than a naive read suggests —
+   a Rays renderer, once opened, stays live even when you switch postures. I
+   surfaced it, but it deserves emphasis: it turns "two contexts while viewing"
+   into "two contexts for the rest of the session."
+5. **What did you find difficult?** Separating B's genuine architectural honesty
+   (it *is* the right shape) from its real cost (a single-scene engine that would
+   have to change). The temptation is to endorse the clean pattern; the duty is
+   to price it.
+6. **What would have made this task easier?** A short note on whether any *other*
+   planned app wants multi-viewport from the 4D engine — that single fact decides
+   whether B's engine change is a Rays-only tax or a shared investment, which
+   would move B from "defer" toward "do now."
+7. **Follow-up value:** MEDIUM — the verdict and pattern analysis are sound and
+   the MVP is buildable as written, but the handoff schema is specified at the
+   design level only; a follow-up session that pins the exact descriptor against
+   the real index space and lands the round-trip test would convert this from a
+   correct recommendation into an executable one.

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-maintainer.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-maintainer.md
@@ -1,0 +1,427 @@
+---
+kind: three-hats
+session: 2026-06-16-S01
+date: 2026-06-16
+title: "Three Hats — Framework Maintainer: Rays split-view realization"
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: review
+build: passing
+---
+
+# Three Hats — Framework Maintainer: Rays split-view realization
+
+I am the framework maintainer / chrome + engine steward. I am reviewing **how
+the "Rays (X→Y) linked split view" should be realized** as Phase-2 of the Complex
+Particles decomposition. My lens is operational reality, history/precedent,
+parallel-branch safety, tech-debt delta, and scope boundaries. I am skeptical of
+abstractions not justified by a concrete app, I prefer working code, and I push
+back when a proposal assumes the codebase is cleaner than it is.
+
+The headline up front: **the pivotal finding is correct and load-bearing.** A
+"Rays domain|image split" inside Complex Particles would substantially
+re-implement Plane Transform, which already exists, already ships, and is already
+embeddable. My job here is to say which option respects that fact without
+abandoning the pedagogy, and to flag exactly where each option fragments the
+engine the repo spent its biggest cleanup consolidating.
+
+## Plan under review
+
+<details>
+<summary>Original request</summary>
+
+Phase-2 of the Complex Particles decomposition: how should the "Rays (X→Y) linked split view" be realized?
+
+CONTEXT. Complex Particles renders the 4D graph Γ_f = {(z, f(z)) ⊂ ℂ²} as a particle cloud projected to 3D. We just shipped (PR #222) a calm default + five task-shaped "postures": Single Function, Representations, Change of Basis, Hopf & Projection, and "Rays (X→Y)". Today the Rays posture just opens Render + Motion on the single 4D cloud. Phase-2 should give Rays "its real form" as a linked domain | image split view ("Plane Transform / Correspondence style, on the 4D engine").
+
+PIVOTAL FINDING. The repo ALREADY HAS a domain|image linked split of the same function: the separate app Plane Transform renders panes [domain z (transform=0), image f(z) (transform=1)] of the SAME geometry via SplitPanes, sharing the complex-function library + Domain coloring, linked zoom, draw-on-input curves; exposed chrome-less as EmbedPlaneTransform. So a "Rays domain|image split" inside Complex Particles would substantially RE-IMPLEMENT Plane Transform.
+
+BINDING CONSTRAINTS: (1) Do NOT fragment/duplicate the engine ("expand don't fragment", PR #205). (2) One app, one appId, one persistence root — postures are in-component state, never a route hop. (3) Hue NEVER encodes identity — color is a function of z (Domain) or f (Range). (4) Append-only / non-destructive; z² first impression untouchable.
+
+OPTION A — Embed Plane Transform's renderer as the Rays view (reuse PT's panes/shaders inside Complex Particles, in-component). Con: PT's renderer is a 2D-plane particle map (transform 0↔1), NOT the 4D cloud — a different renderer than the app's other four postures; risks two engines in one app, overlaps PT's identity.
+OPTION B — Particle-native input|output split: two panes, each the 4D cloud projected to isolate the INPUT plane (DropU/DropV → z-plane) vs OUTPUT, linked camera + tapped-point "ray" correspondence. Pro: stays on the 4D engine, novel. Con: more build; muddier picture; new linked-projection plumbing.
+OPTION C — Resolve by naming, don't duplicate: make Plane Transform THE domain|image MAP, add a lightweight cross-app handoff (shared function state via URL) linking Complex Particles ↔ Plane Transform, and redefine/drop the Rays posture so Complex Particles stays "the 4D graph" and Plane Transform stays "the map". Pro: zero duplication; cheapest. Con: cross-app jump is a context switch; Rays stops being an in-app posture.
+
+QUESTION: Which realization best serves (i) pedagogy, (ii) framework health & anti-fragmentation/duplication, (iii) clean architecture given Plane Transform exists? A, B, C, or a hybrid? Flag duplication risk explicitly; give a concrete recommendation with an MVP scope.
+
+</details>
+
+---
+
+## What the code actually says (verified, not assumed)
+
+Before I weigh options I want the shared substrate on the table, because three of
+the four binding constraints are decided by code that already exists, and the
+fourth option (A) is more expensive than the prose implies.
+
+**Complex Particles' view is hard-singular.** `ParticleViewerShell` (the turnkey
+host every particle viewer renders) declares exactly one `ViewDef`:
+
+```
+// ParticleViewerShell.tsx ~624
+const views: ViewDef[] = [
+  { id: 'plot', title: 'f(z) · particle cloud', defaultRect: {...},
+    node: <Canvas3D onMount={onMount} /> },
+];
+```
+
+Every one of the five postures shipped in PR #222 is a `LayoutDef` that
+rearranges *panels* over that single `plot` view — none adds a view. The Rays
+posture is literally `open: { render, motion }`. So "give Rays its real form as a
+split view" is **not** a layout change; it requires a *second* view (paned) and
+therefore a structural change to the shell or to ComplexParticles' wiring. That
+is the first cost no option escapes.
+
+**Plane Transform is a genuinely separate engine, not a thin reuse target.** It
+is ~573 lines that stand up *two* `THREE.WebGLRenderer`s with **orthographic**
+cameras, its own `ResizeObserver` size cache, its own rAF `tick`, its own mount /
+teardown, its own `ShaderMaterial` pair (`transform: 0|1`), and its own pointer
+handlers for draw-on-input and pinch-zoom (`PlaneTransform.tsx:139-225`). It
+shares with `lib/particles` essentially **nothing at the engine level** — only
+`lib/complexMath` (the function table) and the *idea* of Domain coloring. It is a
+2D ortho point-map; `lib/particles` is a 4D perspective particle cloud with
+quaternion rotation, projection morphs, Riemann sheets, four render modes, and a
+Hopf scaffold (`ComplexParticles.tsx` is ~950 lines orchestrating that). These
+are two different machines that happen to color the same z the same way.
+
+**The split mechanism is fixed and dumb on purpose.** `SplitPanes` is a
+22-line equal flex split with **no draggable divider and no camera linkage** —
+"equal inscribed squares are the invariant that keeps a domain/image pair
+truthful" (`SplitPanes.tsx:5-10`). Each `PaneDef` just carries a `node`; any
+linkage between panes (PT's shared `viewExtent` zoom) is wired by the *app* in
+React state, not by the chrome. So Option B's "linked camera + tapped-point ray
+correspondence" is **net-new plumbing the framework does not provide** — two 4D
+cameras kept in sync, plus a picking pipeline that does not exist anywhere in
+`lib/particles` today.
+
+**Drop-axis already exists and is already battle-tested in embeds.**
+`useViewControls.handleDropAxis('DropU'|'DropV'|…)` is real, and the
+`#/embed/complex-particles` route already drives it from a URL param
+(`ComplexParticles.tsx:752-759`). So Option B's "isolate the input z-plane via
+DropU/DropV" is the one piece of B that *is* grounded in shipped code.
+
+> [!IMPORTANT]
+> The prose frames A as "reuse PT's panes/shaders" and B as "more build." Read
+> against the code, **A is also a large build**: you cannot reuse PT's renderer
+> without lifting its entire two-renderer/two-camera/rAF/teardown apparatus and
+> its pointer handlers into ComplexParticles. "Embed PT's renderer" means
+> "run a second, different engine inside the 4D app" — which is precisely the
+> fragmentation PR #205 ruled against, just relocated from across-apps to
+> within-one-app.
+
+---
+
+## History & precedent — does any option repeat an abandoned approach?
+
+This is the lens I care most about, because the repo's largest cleanup is
+directly on point.
+
+**The consolidation that defines this codebase.** Three near-identical complex
+viewers (the old Roots `z^(p/q)` and Multibranch `sqrt/ln` viewers, plus the base
+particle viewer) were unified into **one** `lib/particles` engine +
+`ParticleViewerShell`; Roots and Multibranch became *modes of ComplexParticles*,
+not separate apps. PR #205's "expand, don't fragment" ruling is the codified
+lesson: when the math is one object, you grow one engine, you don't spawn parallel
+near-duplicates. The decomposition plan under review explicitly re-affirms this
+("Taming the wall ≠ fragmenting the engine").
+
+Now map each option onto that history:
+
+| Option | What it does to engine count *inside Complex Particles* | Precedent verdict |
+|---|---|---|
+| **A** (embed PT's renderer) | Adds a **second, different** renderer (2D ortho point-map) alongside `lib/particles` in one app | **Repeats the pre-#205 sin**, relocated inside one app. Two engines, one appId. |
+| **B** (particle-native split) | Stays on **one** engine (`lib/particles`), but instantiates it **twice** (two synced cameras) + adds picking plumbing | Does **not** fragment the engine — but forks the *render surface* and grows new shared machinery (linked cameras, picking) that only Rays uses |
+| **C** (name + handoff) | Adds **zero** engine code; Complex Particles stays the graph, Plane Transform stays the map | **Cleanest against precedent** — it is literally the "name them graph vs map" resolution the plan already lists in Phase 2 |
+
+> [!WARNING]
+> Option A is the historically dangerous one. The whole reason `lib/particles`
+> exists is that the repo learned, expensively, that two complex viewers that look
+> similar drift apart in maintenance. Putting PT's 2D engine *inside* the 4D app
+> gives Complex Particles two color pipelines, two zoom models, two teardown paths
+> — and the next person who edits Domain coloring has to remember there are now
+> two places it lives in one file. That is a regression in code health dressed up
+> as reuse.
+
+**Option B is subtler.** It does not add a *second engine* — it stays on
+`lib/particles`, which honors constraint (1) literally. But it adds a *new
+capability class* to that engine — two synchronized 4D viewports and a tapped-point
+picking/correspondence pipeline — that **no other consumer needs**. The repo's
+gesture/camera model (`useGestureRotation`, the single `cameraRef` in
+`ParticleState`) assumes one camera per state. Linking two cameras means either
+two `ParticleState`s sharing rotation refs (the "instantiate the engine twice"
+read) or one state driving two renderers (a `Canvas3D` the engine wasn't built
+for). Either way you are *generalizing the engine for one feature*. As the
+maintainer, that is the abstraction I am most skeptical of: I will not bless a
+multi-viewport generalization of `lib/particles` on the strength of a single
+posture, especially when Plane Transform already shows the X→Y map and
+**Correspondence** already shows the canonical two-linked-window pattern.
+
+---
+
+## Parallel-branch & shared-file impact
+
+The framework's parallel-safety contract: each app is a self-contained folder;
+the four shared files (`src/index.tsx`, `src/apps.ts`, `CLAUDE.md`, `README.md`)
+are append-only. How does each option sit against that?
+
+| Option | Touches shared `lib/`? | Touches shared chrome (`SplitPanes`/`types`)? | New route/registry entry? | Append-only-safe? |
+|---|---|---|---|---|
+| **A** | Pulls PT's pane components / shaders into Complex Particles (copy or import across app folders) | No (PaneDef already supports it) | No | Mostly — but **cross-app import** (Complex Particles importing PT internals) breaks the "self-contained folder" rule |
+| **B** | **Yes** — extends `lib/particles` (linked cameras, picking). High blast radius: every particle viewer shares it | Possibly `types.ts` if panes need per-pane camera hooks | No | **Risky** — `lib/particles` is the most-shared, most-contended file set; a B-shaped change there can collide with the pair-mode plan and any other in-flight particle work |
+| **C** | No (only a URL-param read on each app's mount) | No | No new route; reuses existing `#/plane-transform` + a query string | **Safest** — additive, per-app, no shared-engine edits |
+
+> [!WARNING]
+> Option B edits `lib/particles` — the single most parallel-contended code in the
+> repo. There is already a **pair-mode 4-PR plan** in flight against the same
+> engine (the decomposition plan flags it: pair mode lands "as one more posture on
+> the same engine"). A multi-viewport/linked-camera change for Rays and a
+> multi-function change for pairs both reach into the same state/camera model.
+> That is a real collision surface, and it is exactly the kind of shared-engine
+> churn the append-only discipline is meant to keep us out of.
+
+Option A's cross-app import is its own smell: today Complex Particles and Plane
+Transform are independent folders that share only `lib/` and `components/`. Having
+ComplexParticles reach into `animations/PlaneTransform/` (for its `InputPane` /
+`OutputPane` / shaders) couples two app folders that the framework deliberately
+keeps independent. If you instead *copy* PT's renderer into Complex Particles, you
+now have two copies of a 2D plane-map renderer in the tree — the literal
+duplication the pivotal finding warns about, made concrete in files.
+
+---
+
+## Operational reality under `npm run build` only
+
+The only CI gate is `npm run build` (`tsc && vite build`). That shapes what is
+*safe to merge*, not just what is *nice*.
+
+- **`tsc` will catch the cheap mistakes** (the `ViewDef` node|panes union is a
+  type error if you pass both), but it will **not** catch a stranded second rAF
+  loop, a leaked WebGLRenderer, or two cameras drifting out of sync. Those are the
+  exact failure modes A and B introduce, and **none of them are covered by any CI
+  check** (`npm test` covers chrome pure logic; there are no engine integration
+  tests).
+- **WebGL context budget is a real ceiling.** Browsers cap live WebGL contexts
+  (commonly ~16). Complex Particles already runs one heavy context with up to 12
+  Riemann-sheet material sets. Option A adds **two more** ortho contexts (PT runs
+  one renderer per pane). Option B adds **one or two more** perspective contexts.
+  On phone (`usePhone` re-chrome, DPR capped at 2 — PT already comments on phones
+  reporting DPR 3), a 4D cloud + a second linked 4D viewport is a genuine
+  performance and memory question that `npm run build` will happily green-light
+  and a low-end device will choke on. The collapsed-but-not-unmounted rule
+  (WebGL state survives collapse) means these contexts stay *live* even when the
+  Rays view is hidden in another posture — a returning user who lands in `single`
+  is still paying for Rays' second context if both views are mounted.
+- **Teardown is hand-rolled and unforgiving.** ComplexParticles' `onMount`
+  returns a ~30-line cleanup that stops the loop and disposes every geometry /
+  material / texture / axis / scaffold (`ComplexParticles.tsx:697-728`). A second
+  renderer (A or B) needs its own equally careful teardown, wired into the same
+  `Canvas3D` lifecycle, or every route visit strands resources. This is the kind
+  of thing that builds clean and leaks in production.
+
+> [!IMPORTANT]
+> Option C is the only option that adds **zero** new WebGL contexts, **zero** new
+> rAF loops, and **zero** new teardown surface. Under a "build is the only gate"
+> regime, that is not a minor convenience — it is the difference between a change
+> I can confidently merge and one I'd want manual perf verification on across
+> phone + desktop before trusting.
+
+---
+
+## Tech-debt delta
+
+What does each option leave behind for the next maintainer?
+
+| Option | New debt introduced | Duplication created | Net debt verdict |
+|---|---|---|---|
+| **A** | Second renderer + its lifecycle inside a 950-line file; two color/zoom pipelines in one app | **High** — re-implements (or imports) PT's domain|image map; PT's identity now overlaps a posture | **Worst.** Adds debt *and* duplication; the next Domain-coloring edit must be done twice |
+| **B** | Linked-camera + picking machinery in `lib/particles` used by exactly one posture; a "muddier picture" the plan itself flags | **Low engine dup, but a conceptual dup** of Correspondence's "two linked windows" idea, re-grown bespoke | **Medium-high.** No file duplication, but a single-consumer generalization of the most-shared engine is classic premature abstraction |
+| **C** | A small `?fn=…&p=…&q=…` param contract shared by two apps (must stay in sync with `embedParams`) | **None** | **Lowest.** The only debt is a tiny URL contract, and `embedParams` already proves that pattern works |
+
+The plan's own Phase-2 list already contains the C resolution almost verbatim:
+*"Plane/particles unification (`!high` backlog)… The resolution is likely 'name
+them graph vs map' in both explainers, not 'merge them.' Cheap doc/labeling
+task."* The decomposition review independently reached the maintainer-friendly
+answer. Options A and B are, from a debt standpoint, *relitigating a question the
+review already answered* — and answering it the more expensive way.
+
+---
+
+## Scope boundaries — what is the actual job?
+
+The decomposition's whole thesis was **"tame the surface, not the code."** PR-0
+through PR-2 shipped that with *zero engine changes* — they were `layouts`,
+`defaultLayoutId`, a preset table, and a caption flag. That is the spirit of the
+work. Phase-2's Rays item is the one place the plan tags as "genuinely new
+capability," and it is worth asking whether that tag is *aspirational* rather than
+*required*.
+
+Rays' job, pedagogically, is "follow the domain net into the image — watch X go
+to Y." Today's `rays` posture already does a version of this: **Net** render mode
++ **Motion**, with Domain coloring carrying each point's identity across the
+auto-tumble (`ParticleViewerShell.tsx:674-680`). That is *already* an X→Y story on
+the 4D engine — the net of the domain, animated into its image, color preserving
+identity. The split view is a *second framing* of the same story, not a missing
+capability.
+
+> [!IMPORTANT]
+> Scope check: the request asks "how should the linked split view be realized,"
+> which silently assumes the linked split view **must** be built inside Complex
+> Particles. As the maintainer I push back on that premise. The repo already has
+> the linked split (Plane Transform) and already has the canonical two-linked-
+> window pattern (Correspondence). Building a *third* instance of "domain | image
+> of the same function" inside a third app is scope creep dressed as a posture.
+
+---
+
+## The Embed/route implications
+
+Each app's chrome-less embed is a real, shipped surface (`docs/EMBEDS.md`):
+`#/embed/complex-particles` and `#/embed/plane-transform` already exist.
+
+- **Option A** would create pressure for an `#/embed/rays` or a Complex-Particles
+  embed mode that renders the PT-style split — i.e. a *third* embeddable
+  domain|image applet that does what `#/embed/plane-transform` already does. More
+  route surface, more registry append, more duplication of an existing applet.
+- **Option B**'s linked-4D-viewport view would, to be embeddable, need its own
+  embed wiring (two cameras configured by URL). That is a meaningful extension of
+  `embedParams` for one bespoke view.
+- **Option C** needs **no new embed route at all**. The cross-app handoff is just
+  a query string on the *existing* `#/plane-transform` (and symmetrically a
+  param on `#/complex-particles`). The embed story stays exactly as it is; the
+  handoff link can even point at the existing `EmbedPlaneTransform` if you want an
+  inline applet. This is the append-only dream: a feature that adds no rows to any
+  shared list.
+
+---
+
+## Where I disagree with the framing, and the hybrid I prefer
+
+I do not think the answer is a pure A, B, or C. The pivotal finding kills A. B is
+a real-but-premature engine generalization I won't sign off on for one posture. C
+is correct on framework health but the prose under-sells the *pedagogical* loss:
+"cross-app jump is a context switch" is true, and yanking a learner out to another
+app mid-thought is a genuine cost.
+
+So I endorse a **C-first hybrid** that buys back most of the pedagogy cheaply:
+
+1. **Keep Rays as an in-app posture, but as the *particle-native* X→Y story it
+   already is** — Net + Motion + Domain coloring, on the one 4D cloud. Sharpen it
+   (a tasteful caption, maybe a recommended Net+Motion preset and a gentle
+   auto-spin in a z-plane), but **do not** add a second view or a second engine.
+   This is a `layouts`/caption/preset change — the PR-0 mechanism, zero engine
+   risk.
+2. **Make Plane Transform THE domain|image map** and say so in both explainers
+   ("graph vs map"), the cheap labeling task the plan already lists.
+3. **Add a lightweight, additive cross-app handoff**: from Complex Particles' Rays
+   posture, a single "Open as a plane map →" affordance that links to
+   `#/plane-transform?fn=…&p=…&q=…` carrying the current function state (reuse the
+   `embedParams` parsing pattern; PT already reads `embed?.fn/p/q/extent`). One
+   small link, no new route, no new engine, no shared-file churn beyond an
+   append. The learner gets the split *when they want it*, in the app that was
+   built for it, with their function carried over.
+
+This is C's zero-duplication and zero-engine-risk profile, with B's "stays on the
+4D engine" honored (Rays stays particle-native), and the context-switch cost
+softened to a single deliberate click that *preserves state across the jump*. It
+does not foreclose a future true in-app split — if real usage shows the handoff
+isn't enough, B becomes a justified investment *then*, on evidence, after pair
+mode has settled the multi-instance engine questions.
+
+---
+
+## Verdict
+
+**Endorse: Option C, as a C-first hybrid (C + a sharpened particle-native Rays
+posture). Reject A outright. Defer B.**
+
+| Lens | A | B | C / hybrid |
+|---|---|---|---|
+| Pedagogy | Good (true split) but redundant with PT | Best-if-it-worked (novel, in-app) | Good — Rays stays an in-app X→Y story; the *split* is one click away with state carried |
+| Framework health / anti-fragmentation | **Fails** — second engine in one app | Passes literally, but premature engine generalization | **Best** — zero engine change |
+| Clean architecture given PT exists | **Worst** — overlaps/duplicates PT | Re-grows Correspondence's idea bespoke | **Best** — clean graph/map division of labor |
+| Parallel-branch safety | Cross-app coupling | Edits the most-contended `lib/` (collides with pair mode) | Additive, per-app, append-only |
+| Operational risk (`build`-only CI) | High (2 extra contexts, 2 lifecycles) | High (linked cameras, picking, leaks) | **Lowest** — no new contexts/loops/teardown |
+| Tech-debt delta | Worst | Medium-high | Lowest |
+
+**Duplication risk, stated plainly:** Option A *is* duplication of Plane Transform
+— the pivotal finding is exactly right and is disqualifying. Option B is not file
+duplication but is a *conceptual* duplication of Correspondence's two-linked-window
+pattern, re-implemented bespoke against a single consumer. Option C is the only
+choice with zero duplication of either kind.
+
+**What concerns me about my own recommendation:** C's honest cost is that "Rays as
+a posture" stops promising a literal side-by-side split *inside* Complex Particles.
+If Dan's mental model of Rays is specifically "two pictures, side by side, in this
+app," the handoff link will feel like a demotion. I think that's the right call —
+the repo should not host three implementations of domain|image — but it is a
+genuine narrowing of the original Rays ambition and should be named as such, not
+smuggled in.
+
+**What I'd change about the plan:** retire the Phase-2 framing that treats the
+in-app split as the default destination ("gate the `rays` posture's full form on
+it"). Re-tag the split view as *deferred / evidence-gated*, and promote the
+graph-vs-map naming + handoff to the actual Phase-2 deliverable.
+
+### MVP I'd actually merge (one small PR, zero engine risk)
+
+1. **Sharpen the existing `rays` posture** (layout + caption + optional preset):
+   Net render + Motion, Domain coloring, a one-line caption ("Follow the domain net
+   into its image — color is the point's identity, carried across"). Pure PR-0
+   mechanism (`layouts`/`layoutCaptions`/preset table). No new view, no engine
+   touch.
+2. **Graph-vs-map labeling**: one paragraph each in `ComplexParticles/EXPLAINER.md`
+   ("this is the *graph* Γ_f") and `PlaneTransform/EXPLAINER.md` ("this is the
+   *map* z↦f(z)"), cross-referencing each other. Per-app files only.
+3. **One handoff link** from the Rays posture: "Open as a plane map →" →
+   `#/plane-transform?fn={name}&p={p}&q={q}` (and, if desired, the symmetric
+   "See the 4D graph →" in PT). Reuse the `embedParams` param pattern; PT already
+   parses `fn/p/q/extent`. Append-only — no new route, no registry row.
+
+Explicitly **out of MVP scope** (and out of scope until evidence demands it): any
+second WebGLRenderer, any paned `ViewDef` in Complex Particles, any
+linked-camera/picking generalization of `lib/particles`, any new embed route.
+Those are exactly the things that build clean, leak in production, and collide
+with the pair-mode branch.
+
+This MVP ships the X→Y *pedagogy* now, on the engine we already trust, with no
+duplication and nothing for the next maintainer to clean up — and it leaves the
+door open to a real in-app split later, *if and only if* usage proves the handoff
+insufficient and pair mode has settled how the engine handles multiple instances.
+
+---
+
+## Self-reflection
+
+1. **What would you do with another session?** Prototype the handoff URL contract
+   concretely — confirm `PlaneTransform`'s `fn/p/q` param surface round-trips the
+   `POW_PQ_INDEX` and `QUADRATIC_INDEX` special cases (the quadratic carries three
+   complex coefficients that the current embed params may not cover), since that is
+   the one place the cheap option could quietly fail to preserve state across the
+   jump.
+2. **What would you change about what you produced?** I leaned hard on "B edits the
+   most-contended `lib/`"; I should have read `useGestureRotation` and `ParticleState`'s
+   camera ownership end-to-end to quantify *exactly* how much engine surface a linked
+   second viewport touches, rather than reasoning from the single-`cameraRef`
+   structure I saw. The conclusion holds, but the magnitude is asserted, not measured.
+3. **What were you not asked that you think is important?** Whether Correspondence
+   (Mandelbrot↔Julia, two linked windows) is the *real* precedent for "linked
+   split of one object" and should be where any future linked-4D work lands —
+   nobody asked whether the right home for B-if-ever-built is Correspondence's
+   pattern rather than a bespoke Complex Particles view.
+4. **What did we both overlook?** The collapsed-but-mounted rule: a second WebGL
+   context for Rays stays *live* even when the user is in another posture (views are
+   hidden, never unmounted). The cost of A/B is therefore paid continuously, not
+   only when Rays is on screen — a point neither the request nor my first pass
+   foregrounded.
+5. **What did you find difficult?** Separating "B fragments the engine" (it
+   doesn't, literally) from "B is still the wrong call" (premature single-consumer
+   generalization). The constraint language ("don't fragment the engine") gives B a
+   technical pass it doesn't deserve on judgment, and articulating that gap precisely
+   took care.
+6. **What would have made this task easier?** A short doc of `lib/particles`'
+   camera/viewport invariants (is it one-camera-per-state by contract, or
+   incidentally?). I had to infer the multi-viewport difficulty from the code shape.
+7. **Follow-up value:** MEDIUM — the verdict (C-first hybrid, reject A, defer B) is
+   sound and well-grounded in the code I read, but the handoff URL contract for the
+   quadratic/`z^(p/q)` cases is unverified and could change the MVP's step 3 if the
+   existing param surface can't carry that state.

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-pedagogy.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-pedagogy.md
@@ -1,0 +1,370 @@
+---
+kind: three-hats
+session: 2026-06-16-S01
+date: 2026-06-16
+title: "Three Hats — Math-Viz & Pedagogy: Rays split-view realization"
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: review
+build: passing
+---
+
+# Three Hats — Math-Viz & Pedagogy: Rays split-view realization
+
+I read this as someone who will stand in front of a class and use these
+animations to teach `z ↦ f(z)`. My only loyalty is to whether the picture tells
+the truth and whether the interaction *builds the right mental model*. I am
+skeptical of any split-view that looks impressive but quietly lies about which
+object is on screen.
+
+## Plan under review
+
+<details>
+<summary>Original request</summary>
+
+```
+Phase-2 of the Complex Particles decomposition: how should the "Rays (X→Y) linked split view" be realized?
+
+CONTEXT. Complex Particles renders the 4D graph Γ_f={(z,f(z))⊂ℂ²} as a particle cloud. Five postures shipped (PR #222): Single Function, Representations, Change of Basis, Hopf & Projection, "Rays (X→Y)". Rays today opens Render + Motion on the single 4D cloud. Phase-2 should give Rays a linked domain | image split view.
+
+PIVOTAL FINDING. Plane Transform ALREADY is a domain|image linked split of the same function (panes domain z / image f(z), Domain coloring, linked zoom, draw-on-input; chrome-less EmbedPlaneTransform). A "Rays split" inside Complex Particles would substantially RE-IMPLEMENT Plane Transform.
+
+BINDING CONSTRAINTS: (1) no engine fragmentation/duplication. (2) one app, one appId; postures in-component, never a route hop. (3) hue never encodes identity (color = z Domain or f Range). (4) append-only; z² landing untouchable.
+
+OPTION A — Embed Plane Transform's renderer as the Rays view (a 2D-plane particle map, transform 0↔1) inside Complex Particles. Con: a different renderer than the other four (4D) postures; overlaps PT identity.
+OPTION B — Particle-native input|output split: two panes, each the 4D cloud projected to isolate INPUT (DropU/DropV → z-plane) vs OUTPUT, linked camera + tapped "ray" correspondence. Pro: stays on the 4D engine. Con: muddier picture.
+OPTION C — Resolve by naming/linking: make Plane Transform THE map, add a cross-app handoff (shared function via URL) Complex Particles ↔ Plane Transform, redefine/drop Rays so Complex Particles stays "the 4D graph" and Plane Transform stays "the map".
+
+QUESTION: Which best serves (i) pedagogy & the learner's mental model of z→f(z), (ii) framework health/anti-duplication, (iii) clean architecture given PT exists? A/B/C/hybrid? Flag duplication risk; recommend with an MVP scope.
+```
+
+</details>
+
+---
+
+## 1. Two mental models, and why the difference is the whole ballgame
+
+A complex function admits two honest pictures, and a learner needs *both*, but
+needs to know **which one they are looking at at any moment**:
+
+| Model | Object on screen | What it makes visible | What it hides | The app that owns it |
+|---|---|---|---|---|
+| **The graph** Γ_f = {(z, f(z))} ⊂ ℂ² | a 2-surface living in ℝ⁴, projected to 3D | the *pairing* (z, f(z)) as one geometric object; folds, branch sheets, the Riemann surface; Hopf/torus structure | the plane-to-plane *motion* — you never see "the domain go to the image", you see a static draped surface | **Complex Particles** |
+| **The map** z ↦ f(z) | two flat ℂ-planes, identity vs image | the *transformation*: rotation, stretch, fold, conformality (right angles preserved), where the plane tears | the 4D ambient object; the graph is implicit, never drawn | **Plane Transform** |
+
+These are not two skins on one idea. They are two **different functors from the
+same data**:
+
+- The graph throws away nothing — it is the literal set of input-output pairs.
+  Its cost is that to see it you must project ℝ⁴ → ℝ³, and *the projection
+  itself distorts* (Perspective everts the sheet at `3+v = 0`; Hopf collapses
+  fibers). The learner's job is to learn to "see past" the projection.
+- The map throws away the ambient ℝ⁴ and shows only the **shadow** `(u,v)` of
+  the surface, but in exchange it animates the *correspondence*: you watch a
+  patch of the domain *land* somewhere. The cost is that the graph — the single
+  object that unifies domain and range — is never on screen; you infer it.
+
+> [!IMPORTANT]
+> The pedagogical north star: **the graph and the map are dual, and a learner
+> who can move between them owns `z ↦ f(z)`.** The question "where should the
+> domain|image split live" is really "which app should teach the *map*." There
+> is already a correct, working answer: **Plane Transform is the map.** The risk
+> in this Phase-2 is building a second, worse map inside the graph app and
+> teaching the learner that the graph app *is* the map — which would corrupt
+> exactly the distinction we want them to internalize.
+
+---
+
+## 2. What should "Rays (X→Y)" mean, mathematically — and is the name honest?
+
+Dan's use #5 was phrased as *"connecting the X view to the Y view as rays sweep
+the surface."* There are three distinct things "Rays" could honestly denote, and
+they are **not** interchangeable:
+
+| Reading of "Rays" | The mathematical object | Honest? | Already exists? |
+|---|---|---|---|
+| **(R1) Correspondence rays** | for a chosen domain point `z₀`, draw the literal segment `z₀ → f(z₀)` linking its position in a domain pane to its position in an image pane — the graph of the *pairing* as a tie-line | Yes — this is *the* "X view to Y view" reading | No |
+| **(R2) Polar fibers / "Net"** | the engine's existing **Net** render mode: circles `|z|=r` and **rays** `arg z = θ` of the polar grid, carried through `f` | Yes, but it is a *sampling pattern*, not a domain→image link | Yes (Render → Net) |
+| **(R3) Drawn curves through f** | Plane Transform's draw-on-input: a freehand or standard curve in `z`, mapped to its image curve | Yes — the cleanest "watch this set go to that set" | Yes (Plane Transform) |
+
+> [!NOTE]
+> The word **"Rays"** is doing two jobs in the current vocabulary and that is a
+> semantic-hygiene problem. In Plane Transform's explainer and the Net mode,
+> **"rays"** already means *radial spokes `arg z = θ`* (R2). If the new posture
+> uses "Rays" to mean *correspondence tie-lines `z → f(z)`* (R1), the same word
+> now denotes two unrelated things in one app family. A learner who has just
+> read "rays = constant-argument spokes" will be misled. **Do not ship a posture
+> named "Rays" that means R1.** If the posture is the correspondence, call it
+> **"Correspondence"** or **"z → f(z)"**; reserve "Rays" for the polar spokes.
+
+The honest interpretation of Dan's *intent* (#5) is **R1 — correspondence
+rays** — the literal "this input goes to this output" line. That is genuinely
+not built anywhere. But note what R1 actually *is*: the segment from `z₀` to
+`f(z₀)`, drawn between two copies of ℂ, **is a 2D slice of the graph Γ_f
+itself** — it is the chord projecting the ℝ⁴ point `(z₀, f(z₀))` onto its first
+and last factors and tying them. So R1 is *consistent* with "Complex Particles
+is the graph app" — it is the graph, made legible as a correspondence. That is a
+point in favor of building *something* here, against pure Option C. We return to
+this in the verdict.
+
+---
+
+## 3. Does a domain|image split belong with "the graph" app at all?
+
+This is the crux, and my answer is nuanced: **a domain|image split of two flat
+ℂ-planes does NOT belong in the graph app. A correspondence overlay (R1) might.**
+
+The reasoning:
+
+- A side-by-side **flat domain pane | flat image pane** *is the map model*. It is
+  Plane Transform's entire identity. Putting that exact thing inside Complex
+  Particles tells the learner "the graph app and the map app are the same app
+  in two costumes." That **erases the dual distinction** we most want to teach.
+  This is the deep objection to **Option A**, beyond the engineering
+  duplication: it is *pedagogically* a category error to host the map inside the
+  graph.
+- But a **correspondence** — keep the 3D graph/projection on screen as the hero,
+  and additionally light up, for a tapped or swept `z₀`, the tie `z₀ → f(z₀)` —
+  does **not** abandon the graph. It annotates it. That is legitimately a thing
+  the graph app can do that the map app cannot (the map app has no ambient ℝ⁴ in
+  which the pairing is a chord).
+
+> [!IMPORTANT]
+> Litmus test for "does this belong in the graph app": **is the 4D graph still
+> the thing on screen?** Option A fails it (the graph vanishes; two flat planes
+> replace it). A correspondence overlay passes it (the graph stays; the pairing
+> is highlighted). This litmus is the cleanest way to keep the two mental models
+> from collapsing into one.
+
+---
+
+## 4. Is Option B truthful, or does it lie? (The drop-axis trap)
+
+Option B proposes two panes, each the 4D cloud projected to "isolate INPUT
+(DropU/DropV → z-plane) vs OUTPUT." **I checked the actual projection code**
+(`src/lib/viewpoint.ts:87–90`), because the truthfulness of Option B turns
+entirely on what the drop-axis modes really do:
+
+```
+DropX → (y, u, v)     DropY → (x, u, v)
+DropU → (x, y, v)     DropV → (x, y, u)
+```
+
+| Claim in the request | What the code actually produces | Verdict |
+|---|---|---|
+| "DropU/DropV → the z-plane (x, y)" | DropU keeps `(x, y, v)` = `(Re z, Im z, **Im f**)`; DropV keeps `(x, y, u)` = `(Re z, Im z, **Re f**)` | **False.** Neither isolates the domain. Each is a **3D real-valued graph over the domain** of *one output component*. |
+| "isolate INPUT vs OUTPUT" | There is no drop-axis that yields the pure output plane `(u, v)`. DropX gives `(y, u, v)`, DropY gives `(x, u, v)` — each keeps *one input axis*. | **False.** No single drop gives the clean image plane either. |
+
+This is not a quibble; it is the heart of the matter.
+
+> [!IMPORTANT]
+> **Option B as specified is mathematically wrong.** There is no projection of
+> the 4D graph that gives you "the domain plane" in one pane and "the image
+> plane" in the other while staying on the existing engine — because *dropping
+> two axes at once is not a projection mode the engine has*, and dropping one
+> axis always leaves you with a mixed `(input, input, output)` or
+> `(input, output, output)` 3-slice. To get the flat z-plane you must discard
+> *both* `u` and `v`; to get the flat image plane you must discard *both* `x`
+> and `y`. Those are 2-axis drops, which is exactly Plane Transform's
+> `transform = 0` and `transform = 1` panes — i.e. **Option B done correctly
+> collapses into Option A.**
+
+What Option B would *actually* show, if built as the request describes (DropU |
+DropV side by side), is two **real graph surfaces** — `(x, y, Im f)` next to
+`(x, y, Re f)`. Those are honest and even useful pictures (they are the standard
+"two real surfaces over the domain" decomposition of a complex function, the one
+in Needham-style figures). But they are emphatically **not** "the domain and the
+image," and a tie-line drawn between them would not be the correspondence
+`z₀ → f(z₀)` — it would be a line between `(z₀, Im f(z₀))` and `(z₀, Re f(z₀))`,
+which is geometrically meaningless to a learner. **Option B as written would
+teach a falsehood**: it labels mixed 3-slices as "input" and "output."
+
+Could Option B be *salvaged* into truth? Only by adding genuine 2-axis-drop
+projection modes (DropUV → flat `(x,y)`; DropXY → flat `(u,v)`). But once you do
+that, each pane is a flat 2D plane rendered through the particle engine — and you
+have rebuilt Plane Transform's two panes inside Complex Particles. So the
+salvage *is* Option A. Option B is therefore either **false (as written)** or
+**Option A in disguise (if fixed)**. It has no truthful, distinct middle ground.
+
+---
+
+## 5. The role of Domain coloring (identity across the map)
+
+Whatever is built, the binding constraint **hue = z (Domain) or f (Range), never
+identity** is exactly right, and Plane Transform already uses it the load-bearing
+way: it colors **by Domain** (hue = `arg z`) so a point *keeps its color across
+the map*. That single decision is what makes the map legible — "same color = same
+point" (PT's own README) — and it is the mechanism by which a learner *reads the
+correspondence without tie-lines at all*. Color-as-identity is the cheapest,
+most truthful correspondence device there is.
+
+Implications for the options:
+
+- For any correspondence picture (R1) inside Complex Particles, **Domain
+  coloring must be the default**, for the same reason. If a tapped `z₀` is, say,
+  green, its image must be green; the tie-line is then confirmation, not the only
+  cue. Range coloring would *break* the correspondence (the image pane would
+  recolor by `f`, severing the visual link) — so a correspondence posture should
+  *force or strongly default to* Domain coloring and warn when the user flips to
+  Range.
+- This also means the correspondence is **already 80% present** in Plane
+  Transform via color alone; the tie-lines (R1) are an *enhancement of an
+  existing truthful device*, not a new one. That further argues the
+  correspondence belongs where the color-identity machinery already lives — i.e.
+  **Plane Transform**, not a fresh re-implementation.
+
+---
+
+## 6. CVD / legibility of the "aha"
+
+The phase→hue wheel is the standard domain-coloring device, and it has a real
+accessibility cost: a red-green-deficient viewer cannot reliably separate
+`arg z = 0` (red) from `arg z = ±2π/3` regions, so "same color = same point"
+partially fails for ~8% of male learners.
+
+| Concern | Status today | What the split-view should do |
+|---|---|---|
+| Phase→hue under CVD | Complex Particles already ships a **Dual-hue CVD** blue→yellow ramp and sequential maps (Viridis/Magma); PT ships HSV only | A correspondence view that *relies on color for identity* must offer the CVD ramp, or the "aha" is inaccessible to CVD learners |
+| Cyclic-quantity seam | the CVD ramp has one wrap seam (honest, documented) | acceptable; the seam should sit on the branch cut where a discontinuity is *expected* |
+| Tie-lines as a CVD backstop | n/a | **This is the strongest argument for R1 tie-lines**: an explicit `z₀ → f(z₀)` line is a *color-independent* correspondence cue, so it rescues the "aha" for CVD viewers in a way color alone cannot |
+
+> [!NOTE]
+> R1 correspondence rays are not just eye-candy: they are the **CVD-accessible
+> realization of "same color = same point."** That is a genuine pedagogical
+> value-add, and it is the one thing the existing color-identity device cannot
+> do by itself. If anything is built here, it should be tie-lines *as an overlay
+> on the graph*, defaulting to Domain color, with the CVD ramp available.
+
+---
+
+## 7. Which realization produces the "aha"?
+
+The "aha" for `z ↦ f(z)` is the moment a learner *predicts* where a point or
+curve will land and *watches it happen*. That is an **animated correspondence**,
+and the two truthful ways to deliver it are:
+
+1. **The map, with motion** (Plane Transform): draw a curve on `z`, see its
+   image; or — even better, and *not yet built* — a `transform` slider/animation
+   that morphs the domain pane *continuously* into the image (PT's shader already
+   carries `transform ∈ {0,1}`; interpolating it 0→1 would literally animate the
+   plane deforming into its image — the single highest-"aha" feature in this
+   whole family, and it lives in PT).
+2. **The graph, with a swept correspondence** (R1 in Complex Particles): sweep
+   `z₀` along a path and watch the tie-line `z₀ → f(z₀)` sweep the surface — Dan's
+   literal phrasing of #5.
+
+Both are honest. The first is *cheaper* (PT already has the renderer, the color
+identity, the draw-on-input, the linked zoom, and a `transform` uniform begging
+to be animated) and lives in the app whose **whole identity is the map**. The
+second is *distinct* (it is a property of the graph the map cannot show) but
+risks the category error if it degrades into "two flat planes."
+
+---
+
+## 8. Option-by-option scorecard (my lens only)
+
+| Criterion | A — embed PT renderer | B — particle DropU/DropV split | C — name+link, drop/redefine Rays | **Hybrid (recommended)** |
+|---|---|---|---|---|
+| Mathematical fidelity | High (it's the real map) | **Broken** (mislabels mixed 3-slices as input/output) | High (each app stays its true object) | High (graph stays; tie-lines are real chords) |
+| Builds the right mental model | **Hurts** — hosts the map inside the graph, collapsing the dual | Hurts — teaches a false "input/output" | **Best** — sharpens graph-vs-map | Good — graph app gains a graph-native correspondence |
+| Honest framing | Misleading ("this graph app is now the map") | Dishonest labels | Honest | Honest (named "Correspondence", not "Rays") |
+| Semantic hygiene ("Rays") | unresolved | unresolved | **resolves it** (drop "Rays" the posture) | resolves it (rename to Correspondence) |
+| CVD/"aha" accessibility | inherits PT (HSV only today) | n/a | depends on PT | **best** — tie-lines are color-independent |
+| Anti-duplication / framework health | **Worst** — re-implements PT | Bad — new dead-end renderer | **Best** — zero duplication | Good — overlay reuses the existing cloud, no 2nd renderer |
+
+---
+
+## Verdict
+
+**Endorsed: Option C as the spine, with a small, graph-native enhancement
+(NOT a domain|image flat split) layered on top. I reject Option A and reject
+Option B. I'll call the endorsed shape C+ (C with a correspondence overlay).**
+
+Reasoning in one breath: Plane Transform *is* the map and already does the
+domain|image split truthfully, with the load-bearing color-identity device.
+Complex Particles *is* the graph. A flat domain|image split inside the graph app
+(Option A) collapses the two mental models we most want to keep distinct, and
+duplicates a whole renderer. Option B is, on inspection of the real projection
+code, **mathematically false** — DropU/DropV keep `(x,y,Im f)` and `(x,y,Re f)`,
+not "the domain" and "the image"; fixing it turns it into Option A. So the only
+honest "new" thing the graph app can offer is a **correspondence overlay on the
+graph** (Dan's true #5): tie-lines `z₀ → f(z₀)` for a tapped/swept point, drawn
+in the existing 3D scene, defaulting to Domain color, CVD ramp available.
+
+### Concerns / required changes
+
+1. **Rename the posture.** Drop "Rays" as the posture name (it already means
+   polar spokes in Net/PT). Either call the graph-native overlay **"z → f(z)"**
+   / **"Correspondence,"** or, if Dan prefers, retire the fifth posture entirely
+   and point users to Plane Transform via the handoff (pure C). Do not ship a
+   posture named "Rays" that means tie-lines.
+2. **Force/strongly-default Domain coloring** in any correspondence view; warn
+   on Range flip (it severs the link).
+3. **Build the cross-app handoff** (C's core): a shared-function URL link
+   Complex Particles ↔ Plane Transform (the embed param plumbing already exists
+   in `lib/embedParams`/`PlaneEmbedConfig` and PT's `embed?.fn/p/q/extent`), so
+   "see this as the map" is one click from the graph and back. This is the
+   highest-value, lowest-risk deliverable and it *teaches the duality by making
+   the two apps two views of one function*.
+4. **Add the CVD ramp to Plane Transform** if the handoff makes PT the official
+   "map" destination — PT ships HSV only today, so the map is currently less
+   CVD-accessible than the graph. Cheap, high pedagogical value.
+5. **Sharpen both explainers** to name the duality explicitly: Complex Particles
+   = "the graph Γ_f"; Plane Transform = "the map z ↦ f(z)"; each links to the
+   other. (This also closes the `!high` "plane/particles unification" backlog
+   item the right way — *name them*, don't merge them.)
+
+### The MVP that best teaches z ↦ f(z)
+
+Smallest thing, biggest pedagogical return, in priority order:
+
+1. **Cross-app handoff (C).** Shared-function deep link both directions, plus the
+   one-line explainer additions naming graph vs map. *Zero new renderer, zero
+   duplication, immediately teaches the duality.* Ship this alone and the
+   Phase-2 goal is substantially met.
+2. **(Optional, if a "new capability" is still wanted) the correspondence
+   overlay** in Complex Particles: tap a domain point → draw the chord
+   `z₀ → f(z₀)` in the live 3D scene, Domain-colored, with an optional sweep
+   along a path. Reuses the existing cloud/camera — **no second renderer, no
+   `panes` split.** Name it "Correspondence," not "Rays."
+3. **Animate PT's `transform` 0→1** as a slider (the plane visibly deforming
+   into its image). This is the single highest-"aha" feature in the family and it
+   belongs in the map app, where the renderer already carries the `transform`
+   uniform.
+
+**Do not build:** Option A (PT renderer inside Complex Particles), or Option B's
+DropU|DropV "input/output" panes (false labels). If schedule forces a single
+deliverable, ship **MVP item 1 only** — it is the truthful core of Phase-2.
+
+---
+
+## Self-reflection
+
+1. **What would you do with another session?** Prototype the correspondence
+   overlay (item 2) to confirm tie-lines stay legible through the Perspective
+   eversion and the Hopf collapse — a chord whose endpoint is on a fiber that
+   collapses to a point may degenerate, and I have not verified that it reads
+   cleanly across all three projection stops.
+2. **What would you change about what you produced?** I'd quantify the "aha":
+   actually test whether a swept tie-line is more illuminating than PT's
+   draw-on-input + an animated `transform`, ideally with a real learner. My
+   ranking of the three MVP items is reasoned, not measured.
+3. **What were you not asked that you think is important?** Whether the *map*
+   app (Plane Transform) should itself get the animated `transform` morph — I
+   judge that the single biggest "aha" lever in the family, and it sits outside
+   the literal A/B/C question but is more valuable than any of them.
+4. **What did we both overlook?** That the request's premise "DropU/DropV → the
+   z-plane" is factually wrong against `viewpoint.ts`. The whole of Option B
+   rests on that false premise; catching it is the load-bearing finding here and
+   it was not flagged in the prior six-lens review.
+5. **What did you find difficult?** Separating "honest but useless" (Option B's
+   two real-surface graphs) from "honest and useful" (R1 tie-lines) — both are
+   truthful pictures, and the request conflated them under one label.
+6. **What would have made this task easier?** A one-paragraph statement of the
+   *learning objective* for posture #5 (predict-and-watch? read conformality?
+   see the Riemann surface?) — the right realization depends on which "aha" is
+   the target, and I had to infer it from Dan's #5 phrasing.
+7. **Follow-up value:** MEDIUM — the recommendation (C+ over A/B) is sound and
+   the Option-B fidelity refutation is verified against source, but the
+   correspondence-overlay legibility across projections is untested and the
+   "which aha is best" ranking is unmeasured.

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-synthesis.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-synthesis.md
@@ -1,0 +1,178 @@
+---
+kind: three-hats
+session: 2026-06-16-S01
+date: 2026-06-16
+title: "Three Hats — Synthesis: how to realize Phase-2 'Rays (X→Y)'"
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: review
+build: passing
+followup: null
+pr: 222
+app: complex-particles
+---
+
+# Three Hats — Synthesis: how to realize Phase-2 "Rays (X→Y)"
+
+Convergence analysis over the three independent reviews
+([Framework Maintainer](2026-06-16-S01-expert-maintainer.md) ·
+[Architecture Consultant](2026-06-16-S01-expert-consultant.md) ·
+[Math-Viz & Pedagogy](2026-06-16-S01-expert-pedagogy.md)).
+
+## Plan under review
+
+<details><summary>Original request</summary>
+
+Phase-2 of the Complex Particles decomposition: how should the "Rays (X→Y) linked split view" be realized?
+
+Complex Particles renders the 4D graph Γ_f = {(z, f(z)) ⊂ ℂ²} as a particle cloud. Five postures shipped (PR #222): Single Function, Representations, Change of Basis, Hopf & Projection, "Rays (X→Y)". Rays today opens Render + Motion on the single 4D cloud. Phase-2 should give Rays "its real form" as a linked domain | image split view ("Plane Transform / Correspondence style, on the 4D engine").
+
+**Pivotal finding:** Plane Transform already *is* a domain|image linked split of the same function — panes [domain z (transform=0), image f(z) (transform=1)] of the same geometry via `SplitPanes`, shared function library + Domain coloring, linked zoom, draw-on-input curves; exposed chrome-less as `EmbedPlaneTransform`. So a "Rays split" inside Complex Particles would substantially re-implement Plane Transform.
+
+Binding constraints: (1) no engine fragmentation/duplication ("expand don't fragment", PR #205); (2) one app / one appId / one persistence root, postures in-component not route hops; (3) hue never encodes identity (color = z Domain or f Range); (4) append-only, z² landing untouchable.
+
+- **Option A** — embed Plane Transform's renderer as the Rays view (a 2D-plane particle map) inside Complex Particles.
+- **Option B** — particle-native input|output split: two panes, each the 4D cloud projected to isolate INPUT (DropU/DropV → z-plane) vs OUTPUT, linked camera + tapped "ray".
+- **Option C** — resolve by naming/linking: Plane Transform = the map, Complex Particles = the graph, a cross-app handoff (shared function via URL), redefine/drop Rays.
+
+Which best serves (i) pedagogy, (ii) framework health/anti-duplication, (iii) clean architecture? Flag duplication risk; recommend with an MVP scope.
+
+</details>
+
+## The headline
+
+All three hats independently reached the **same verdict**: **reject Option A, do not
+build Option B, adopt Option C** — and all three, from different directions, arrived at
+the *same* graph-native enhancement: instead of a split, **draw the correspondence
+z → f(z) in the existing 3D scene** (the one picture only this engine can make). Call
+the result **C+**.
+
+| | Maintainer | Consultant | Pedagogy |
+|---|---|---|---|
+| **A** (embed PT) | ❌ reject — re-fragmentation inside one app | ❌ reject — "two engines in one app", swells the lazy chunk | ❌ reject — collapses the graph/map distinction; category error |
+| **B** (particle split) | ⏸ defer — premature; touches the most contended engine code | ⏸ defer — `startAnimationLoop` is single-scene; 2× GPU; muddier | ❌ reject — **mathematically false as written** |
+| **C** (name + link) | ✅ endorse (C-first hybrid) | ✅ endorse (hybrid) | ✅ endorse (the spine of "C+") |
+| **graph-native extra** | "the z→f(z) ray on the 4D graph" | "the thing only this engine can draw" | correspondence tie-lines, Domain-colored, CVD-safe |
+
+## Points of agreement (high confidence)
+
+> [!IMPORTANT]
+> **1. Building a domain|image split inside Complex Particles is duplication, full stop.**
+> A flat domain|image split *is* the map model, and the map model already ships as Plane
+> Transform (panes, shared shaders, linked zoom, even an embed). Option A re-hosts a whole
+> renderer; the only thing the two engines legitimately share — the function library
+> `lib/complexMath.ts` — they already share **without** being one engine. This is exactly
+> the pre-PR-#205 fragmentation the `lib/particles` consolidation cured, relocated from
+> across-apps to within-one-app.
+
+**2. Option B is not a safe "stay on the 4D engine" compromise.** The pedagogy hat
+checked the projection math (`src/lib/viewpoint.ts:87–90`): `DropU` keeps `(x, y, Im f)`
+and `DropV` keeps `(x, y, Re f)` — **neither isolates the z-plane**, and no single drop
+yields a clean image plane. Each pane would be a mixed `(input, input, output)` slice, so
+labeling them "INPUT"/"OUTPUT" teaches a falsehood. Making it truthful (2-axis drops →
+flat planes) collapses B *into* A. Independently, the engineering hats found B expensive:
+`startAnimationLoop` is single-scene by construction, and the "collapsed views never
+unmount" rule means a second WebGL context would stay live all session — cost `npm run
+build` cannot catch.
+
+**3. Option C honors every binding constraint and is the cheapest.** Zero engine change,
+zero new renderer/rAF loop/teardown, append-only, no shared-file churn. It is also
+literally the resolution the decomposition plan *already lists* ("name them graph vs
+map"). Its one correctness seam — a function round-trips through a URL — is a **pure,
+unit-testable** function, the ideal shape for a repo whose only CI gate is `npm run build`.
+
+**4. The MVP is the cross-app handoff, and it stands alone.** A shared-function deep link
+Complex Particles ↔ Plane Transform ("See as a plane map →" / "See the 4D graph →") plus
+explainer paragraphs naming the two mental models. If only one thing ships, ship this.
+
+## Points of tension (decisions to make)
+
+> [!WARNING]
+> **T1 — The posture name "Rays" is contested and probably wrong.** The pedagogy hat is
+> firm: "Rays" already means **polar spokes** (`arg z = θ`) in Net mode *and* in Plane
+> Transform, so reusing it for "correspondence tie-lines" is dishonest. Recommend renaming
+> the posture to **"Correspondence"** or **"z → f(z)"**. The engineering hats didn't object
+> to a rename; this is low-cost and should be adopted.
+
+**T2 — How much beyond the handoff to build now.** The hats differ on ambition:
+- *Minimal (Consultant-leaning):* ship only the handoff + reframe the existing posture's
+  caption/explainer. No new drawing at all. The architectural payload is a pure
+  `encode/decodeFunction` + a vitest round-trip test.
+- *Plus the overlay (Pedagogy-leaning, Maintainer-compatible):* also add **correspondence
+  tie-lines** — line segments z₀ → f(z₀) drawn in the live 3D scene for a *sampled subset*
+  or a *tapped point*, Domain-colored. This is the honest, graph-native replacement for a
+  "split", needs no second renderer, and doubles as the **CVD-accessible** realization of
+  "same color = same point."
+
+**T3 — Is a cross-app link a forbidden "route hop"?** The plan dislikes route hops, but
+all three agree this one is different in kind: it is an **app↔app** move (graph ↔ map) made
+explicit and deliberate, *not* a hidden posture masquerading as in-app state (the Trinary
+anti-pattern). It is acceptable precisely because it does **not** fork the `complex-particles`
+persistence root — it carries only the function across to a different app.
+
+## Blind spots (verify before building)
+
+> [!CAUTION]
+> **B1 — Does Plane Transform's URL/embed schema already round-trip the hard cases?** Both
+> engineering hats flagged this as the real gating risk: the function space includes the
+> parameterized **quadratic** `a·z² + b·z + c` (three complex coefficients) and **z^(p/q)**
+> (integer p, q). The MVP's value depends on these surviving the hop. **Action:** read
+> `src/lib/embedParams.ts` (or PT's embed config) and confirm — or extend — the param set
+> before committing to the link. This is step 0, not step 3.
+
+- **B2 — Overlay density.** If tie-lines are added, drawing them for all ~80k particles is
+  visual noise and draw cost; the design must pick *a sparse sampled subset* (e.g. a coarse
+  grid) or *only the tapped point's* ray. Unspecified so far.
+- **B3 — Where the handoff link lives in the chrome.** Top-bar affordance vs the posture's
+  caption vs an explainer link — not yet decided; should reuse existing chrome (no new
+  vocabulary).
+
+## Recommended action
+
+**Adopt Option C+ and retire the in-app split (A and B) from the roadmap.** Concretely,
+Phase-2 becomes three increments, gated by a verification step:
+
+> [!IMPORTANT]
+> **Step 0 (verification gate).** Confirm `src/lib/embedParams.ts` round-trips the full
+> function state — index, `p`/`q`, and the quadratic coefficients. Extend it if not. No
+> link ships until this is a pure, tested round-trip (vitest).
+>
+> **Step 1 (the MVP — the truthful core).** A bidirectional deep link carrying only the
+> function: "See as a plane map →" (Complex Particles → Plane Transform) and "See the 4D
+> graph →" (Plane Transform → Complex Particles), plus short explainer paragraphs that name
+> the two models — **the graph** Γ_f (this app) vs **the map** z↦f(z) (Plane Transform).
+> Rename the posture **"Rays (X→Y)" → "Correspondence (z → f(z))"** and update its caption.
+>
+> **Step 2 (optional, graph-native — the honest "Rays").** Correspondence tie-lines
+> z₀ → f(z₀) drawn in the existing 3D scene for a sampled subset and/or a tapped point,
+> Domain-colored, no second renderer. This is the picture only the 4D engine can draw, and
+> the CVD-accessible version of "same color = same point." Animating Plane Transform's
+> existing `transform` 0→1 is the complementary high-"aha" lever, and it belongs in the map
+> app.
+
+This keeps Complex Particles as **the graph**, keeps Plane Transform as **the map**, adds
+**zero** duplicated renderer, touches the engine **not at all**, and ends Phase-2 with the
+two apps reinforcing one mental model instead of two apps competing to host the same split.
+
+## Self-reflection
+
+**What was asked:** Synthesize three expert reviews into a recommendation for realizing the
+Phase-2 "Rays" split view, flagging duplication risk.
+
+**What I did:** Confirmed unanimous rejection of A, near-unanimous rejection/deferral of B
+(with the pedagogy hat supplying the decisive correctness argument from
+`viewpoint.ts:87–90`), and unanimous endorsement of C; merged the three into a single C+
+recommendation with a verification gate and a renamed posture.
+
+**What I'm unsure about / risks:**
+- The whole MVP hinges on **B1** (the URL round-trip for quadratic/`z^(p/q)`). If
+  `embedParams` can't carry that state cleanly, Step 1 grows from "a link" to "extend the
+  embed schema" — still tractable, but larger than billed. This is unverified in this pass.
+- Step 2 (tie-lines) is endorsed in principle but **undesigned** (density, picking, perf at
+  80k); it should get its own small design note before building.
+- The rename touches the shipped PR #222 posture id/caption — append-only-safe, but it does
+  mean the just-merged "Rays" label changes; worth a one-line heads-up to Dan.
+
+**Follow-up value:** MEDIUM — the recommendation is decisive and low-risk, but the embed
+round-trip (B1) genuinely needs a code check before Phase-2 is scoped as "small", and the
+tie-line overlay deserves its own design pass.

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -11,7 +11,7 @@ followup: null
 pr: 222
 app: complex-particles
 signals: on-track
-next: Phase-2 Step 2 (optional) — the graph-native correspondence tie-line overlay; needs its own design pass.
+next: Two deferred domain-legibility follow-ups, each needs its own design pass — (1) the graph-native correspondence tie-line overlay (z₀→f(z₀)); (2) unit-circle inside/outside marking (|z|<1 vs ≥1), e.g. two colormaps or a diverging palette centered on |z|=1.
 ---
 
 > [!NOTE]
@@ -235,6 +235,31 @@ already carries (panel pills vs top-bar pills) — let one resolution serve both
   not "merge them." Cheap doc/labeling task.
 - **Pair mode as a sixth posture.** When the pair-mode plan lands, `(f,g)` becomes a
   "Function Pairs" posture — same engine, same `appId`.
+- **Unit-circle inside/outside marking (`|z| = 1`) — domain legibility (Dan, 2026-06-17).**
+  Make the unit circle *visible* in the 4D graph: distinguish `|z| < 1` (inside the disk)
+  from `|z| ≥ 1` (outside). The circle is where so many of these functions hinge — the
+  Möbius/Blaschke maps swap inside↔outside, Joukowski folds it to a slit, the roots of
+  unity sit on it — so seeing the two regions is genuinely illuminating. This is a
+  **shader/color change** (per-particle `|z|` is already in the shader — it computes
+  `f(z)` from `z`; there is no DOM-overlay path for an 80k point cloud), which is exactly
+  why it was kept *out* of #222 (whose scope is "no engine/shader/persistence change").
+  Design forks for its own pass:
+  - **(a) two colormaps split at `|z|=1`** (Dan's instinct) — inside palette A, outside
+    palette B; most flexible, can read busy with two full palettes competing;
+  - **(b) a diverging palette centered on `|z|=1`** — the circle becomes the palette's
+    visible zero-crossing (cool inside / warm outside); the most *mathematically honest*
+    "see the boundary," since the unit circle is the isoline;
+  - **(c) a side treatment on one palette** — outside dimmed/desaturated, hue meaning
+    intact; the calmest, least garish option;
+  - **(d) a literal drawn `|z|=1` ring** — a `LineLoop` in the domain projected like the
+    axis cross; cheapest, marks the boundary but doesn't *fill* the two regions (could
+    ship alongside any of a–c as a reference).
+  Open decisions: domain `|z|` vs image `|f|`; a new **Color by: "Unit disk"** option vs
+  a *modifier* layered on the existing Domain/Range coloring; default palettes. Honors the
+  **hue-never-encodes-identity** veto (this colors by a *geometric region of `z`*, not
+  function/mode/posture identity). Pairs naturally with the tie-line overlay above — both
+  are "make the domain legible" — so a future session could scope them as one
+  domain-legibility PR.
 
 ## Decisions (resolved 2026-06-16, Dan)
 

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -221,15 +221,15 @@ already carries (panel pills vs top-bar pills) — let one resolution serve both
 - **Pair mode as a sixth posture.** When the pair-mode plan lands, `(f,g)` becomes a
   "Function Pairs" posture — same engine, same `appId`.
 
-## Open decisions (Dan's)
+## Decisions (resolved 2026-06-16, Dan)
 
-> [!IMPORTANT]
-> 1. **Posture affordance** (PR-2): layout-menu only · + top-bar pills · + per-view
->    captions. Recommendation: layouts now, captions cheap, pills if salience demands.
-> 2. **Preset re-apply** (PR-1): apply on change-of-function only (recommended), or
->    also a "reset to recommended view" gesture.
-> 3. **Phase-2 priority**: the Rays split-view (#5, the only new capability) vs the
->    immersive stages vs the plane/particles naming — which first.
+1. **Posture affordance → Layout menu + plot captions.** Postures stay in the Layout
+   menu (PR-0, shipped); each posture also sets a one-line caption under the plot
+   (the guided-chapter feel). **No** top-bar pills.
+2. **Presets → apply on function change** (PR-1): set domain/projection fields only,
+   never the user's appearance choices; fire on a change to a *different* function.
+3. **Phase-2 order → Rays X→Y linked split-view first** (the only genuinely new
+   capability), ahead of immersive stages and the graph-vs-map naming pass.
 
 ## Risks
 

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -1,0 +1,252 @@
+---
+kind: plan
+session: 2026-06-16-S01
+date: 2026-06-16
+title: "Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)"
+branch: claude/sleepy-bardeen-uk0cal
+slug: sleepy-bardeen-uk0cal
+status: proposed
+build: passing
+followup: null
+pr: null
+app: complex-particles
+signals: needs-dan
+next: Build PR-0 (calm default + posture layouts) — the cheap, reversible, high-leverage win.
+---
+
+# Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)
+
+A forward-looking implementation plan — the build has **not** started. It distills
+the six-lens decomposition review
+([synthesis + the six reviews](2026-06-16-S01-complex-particles-decomposition-review.md))
+into a concrete, ordered set of PRs with file-level detail, so any future session can
+pick it up cold.
+
+## The decision already made
+
+**Do not split Complex Particles into separate apps. Tame the *surface*, not the
+*code*.** Unanimous across all six reviewers (UI · math · the Yelp-style reviewer ·
+expositor · aesthete · maintainer), every verdict "partial · high confidence":
+
+- The math is **one object** — the 4D graph `Γ_f = {(z, f(z))} ⊂ ℂ²` seen through
+  faithful coordinates. Dan's five "uses" are mostly five doors into one room.
+- The engine is **one consolidated codebase** (`lib/particles` — the thing the repo's
+  biggest cleanup unified from the old Roots/Multibranch viewers).
+- **`appId` is the persistence root.** A separate app forks every saved setting
+  (`animath:<v>:<appId>:<field>` + `ws:<appId>`) *and* invites the engine to re-fork.
+  "Split the app" silently means "discard the user's setup on every context switch."
+
+This **reconciles with**, and does not reverse, the prior "expand, don't fragment"
+ruling (PR #205): that ruling protected the *engine*; this plan addresses the
+*control wall*. Taming the wall ≠ fragmenting the engine.
+
+**Aggressiveness (Dan's call): "hide, keep power."** Progressive disclosure — the
+calm default hides ~80% of the surface, but everything stays reachable behind an
+"Advanced/Everything" reveal. We do **not** adopt the Aesthete's cut-to-the-bone
+deletions; her *calm-default* goal is served by defaults + layouts instead.
+
+## The two-axis model (the synthesis insight)
+
+The reason "how do I divide it" felt unanswerable is that there are **two orthogonal
+decompositions**, and neither is a code split:
+
+| Axis | Answers | Shape | Mechanism | This plan |
+|---|---|---|---|---|
+| **Postures** | "what do I want to *do*?" | task / curriculum | `LayoutDef[]` + a selector | **PR-0** |
+| **Per-function presets** | "what does this *function* want?" | target geometry | a defaults table keyed by `functionIndex` | **PR-1** |
+
+Dan's five use-cases are the **postures**. The mathematician's deeper "target
+geometry" axis (Plane / Cylinder / Sphere / Branch sheets) is the **presets**.
+
+## Binding constraints (do not relitigate casually)
+
+- **Hue never encodes function/mode/posture identity** (standing pedagogy veto).
+  Color stays a function of `z` (Domain) or `f` (Range) on every posture.
+- **One app, one `appId` (`complex-particles`), one persistence root.** No new route,
+  no new registry entry. Any posture selector is **in-component state**
+  (PolygonWorlds-style), *never* a `window.location.hash` hop — Trinary's clean-looking
+  Observatory|Lab pills are secretly a route+namespace split (`TrinaryStars.tsx`
+  ~L1031); copying that here would shatter saved settings.
+- **Append-only / non-destructive.** New state fields default to today's behavior; no
+  existing persisted key changes meaning. Postures rearrange panels; presets set only
+  *domain/projection* fields, never the user's *appearance* choices (see PR-1).
+- **The just-shipped first impression of the function itself is untouchable**: `z²`
+  landing function, Fixed motion, flat brightness, π units / ±2π extents, reciprocal
+  sampling on. We change *which panels greet you*, not what the `z²` graph looks like.
+- **Closed 11-archetype icon vocabulary** — no new panel icons. Postures reuse the
+  existing layout `icon` field (closed chrome icon set).
+- **`immersive` is a Workspace-level prop, not per-layout** (`WorkspaceProps.immersive`,
+  `types.ts:139`) and requires *exactly one view*. So "reverent immersive stages for
+  Hopf / X→Y" is a Phase-2 framework item, not a PR-0 layout flag (see Phase 2).
+- **Composes with the pair-mode 4-PR plan**
+  ([that plan](../three-hats-particle-app-rill2c/2026-06-11-S01-plan-multi-function.md)):
+  PR-0/PR-1 here are independent of it and can ship first; pair mode eventually lands
+  as **one more posture** ("Function Pairs") on the same engine. Splitting into apps
+  now would *collide* with that plan (it strands pair mode's shared state).
+
+## PR-0 — A calm default + posture layouts (the high-leverage win)
+
+**Goal:** stop cold-opening the cockpit. Land in one quiet single-function posture;
+recast the layout menu as task-shaped postures. **No engine or state-field change** —
+this is the `layouts` array + `defaultLayoutId` in `ParticleViewerShell.tsx:638-653,724`.
+
+The single loudest finding of the whole review (4 of 6 said it independently): today
+the default `essentials` layout parks the **470px-tall 4D Rotation panel at
+`{x:800,y:56}` directly over the plot** while opening Function + Camera too. The
+first thing a newcomer sees is the sublime 4D graph with an orientation-matrix
+spreadsheet and two columns of ↻/↺ turn-pads bolted across its face.
+
+**Replace the three current layouts (Essentials / Appearance / Rotate) with five
+postures**, each a `LayoutDef`. The framework auto-appends **Compact** and
+**Everything** — *Everything is the "keep power" escape hatch* (today's full surface).
+
+| Posture (`id`) | Use | Opens (panels) | Leaves clear |
+|---|---|---|---|
+| **Single Function** `single` *(default)* | #1 | **Color** only (Domain/Range toggle); function picker is already in the top bar | the whole plot — nothing parked over it; auto-tumble does the 4D work |
+| **Representations** `represent` | #2 | **Render** + **Color** | 4D rig, projection morph |
+| **Change of Basis** `basis` | #3 | **4D Rotation** (+ orientation matrix) + **Camera** | Render exotica |
+| **Hopf & Projection** `hopf` | #4 | **Camera** (projection slider hero) + scaffold | Render variety, 4D plane rig (inert here) |
+| **Rays (X→Y)** `rays` | #5 | **Render** (Net) + **Color** | (linked split-view is Phase 2) |
+
+- `defaultLayoutId` → `'single'` (was `'essentials'`). This one line is the
+  highest-leverage change in the plan.
+- Each posture's `name` + `sub` (the `LayoutDef.sub` one-liner) names the *job*, e.g.
+  `{ id:'hopf', name:'Hopf & Projection', sub:'The fiber collapse', icon:'globe' }`
+  (icon from the closed set). The `Layout:` menu becomes a legible feature map.
+- **Mechanism = C (layout instruments)**: `LayoutDef.open` lists which panels float
+  where; `views` can hide a view but here there is one view, so all postures share it.
+  Zero new mechanism — `StableMatching.tsx` already does exactly this with
+  matrix/welfare/lattice.
+
+**Verify:** `npm run build`; headless screenshots of each posture
+(`node scripts/shoot.mjs '#/complex-particles' …` with `SEED_LS` to force a fresh
+profile — saved layouts override `defaultLayoutId`, see the prior handoff's note);
+confirm the default lands clear of the plot.
+
+> [!NOTE]
+> Saved `ws:complex-particles` layout state overrides `defaultLayoutId`, so existing
+> users keep their arrangement; only fresh profiles see `single`. That is the correct
+> behavior (don't stomp a returning user), but means the win is invisible without a
+> reset — verify in a fresh profile and mention it in the PR.
+
+## PR-1 — Per-function preset defaults ("what the function wants")
+
+**Goal:** picking a function snaps the *domain & projection* to what that function
+wants to be seen through — honoring Dan's "different functions want different
+modes/domains" — without touching the user's appearance choices.
+
+**The target-geometry axis** (the mathematician's organizing principle), mapped onto
+the real `functionNames` indices (`complexMath.ts:406-413`):
+
+| Preset | Member indices (functions) | Sets |
+|---|---|---|
+| **Plane** (entire, bounded growth) | 0 linear, 2 square, 9 cube, 22 quadratic | Perspective; units ×1; extent ±2; reciprocal **off** |
+| **Plane · periodic** (trig/hyperbolic) | 5 sin, 6 cos, 31 sinh, 32 cosh | Perspective; units **×π**; extent ±2π; reciprocal off |
+| **Cylinder / log-polar** | 4 exp, 3 ln, 18 z^(p/q) | Torus-leaning; **Polar** sampling; units ×π |
+| **Riemann sphere** (Möbius / poles) | 8 1/z, 29 1/z², 10 1/z³, 12 rational22, 17 (z−1)/(z+1), 11 Joukowski | **Sphere/Hopf**; reciprocal **on**; scaffold on; radius band |
+| **Poles / essential** | 7 tan, 19 cot, 23 sec, 24 csc, 13 e^{1/z}, 15 Γ | Perspective; reciprocal on; (Γ: units ×1, small extent) |
+| **Branch sheets** (multivalued) | the `MULTIVALUED_INDICES` set (1, 3, 14, 16, 18, 20, 21, 25–28, 33–35) | branch min/max already auto-shows; **Tint sheets on**; 2 sheets |
+
+(Indices that appear in two presets — e.g. `ln`/`z^(p/q)` are both *Cylinder* and
+*Branch sheets* — take the **more specific** preset; resolve in a single
+`PRESET_FOR[index]` lookup so every index maps to exactly one preset, the way
+`functionCategories` covers every index once.)
+
+**Schema + apply semantics:**
+
+```ts
+// lib/particles or config: keyed by functionIndex, every field optional.
+interface FunctionPreset {
+  viewType?: ProjectionMode;   // seeds projMix detent
+  axisScale?: number;          // 1 or Math.PI (units)
+  extent?: number;             // symmetric half-width
+  samplePattern?: SamplePattern;
+  reciprocal?: boolean;
+  showScaffold?: boolean;
+}
+const PRESET_FOR: Record<number, FunctionPreset>;  // or by-category seed
+```
+
+- **Apply on explicit function change only**, and only the *domain/projection* fields
+  above. **Never** touch color, render mode, size, motion, or 4D orientation — those
+  are the user's, not the function's. This is the "non-destructive" rule that keeps
+  presets from feeling like they stomp your setup.
+- Hook point: the function picker's `onChange` in `ComplexParticles.tsx` (the
+  top-bar `topExtra` selector) — apply `PRESET_FOR[idx]` after `setFunctionIndex`.
+- **Open sub-decision (flag for Dan):** should re-picking the *same* function
+  re-apply (a "reset this function's view" gesture), or only a genuine change? Default
+  recommendation: apply on change to a *different* function; offer "recommended view"
+  as a future small button if wanted.
+
+**Verify:** screenshots of `1/z` (snaps to Sphere + reciprocal + scaffold), `sin`
+(snaps to ×π), `√z` (tint on, 2 sheets), `z²` (unchanged — still the shipped landing).
+
+## PR-2 — The posture *affordance* (open decision; deferred, recommended)
+
+PR-0 ships postures as **layout-menu entries** (mechanism C) — already a real,
+legible selector. Whether to *also* surface them more prominently is the one genuine
+UI fork from the review:
+
+- **Top-bar mode pills (B)** — Priya & Marcus: a visible `Single · Hopf · Basis …`
+  feature map. Uses `WorkspaceProps.modes`/`activeMode`/`onModeChange`
+  (`types.ts:163-166`) — **but must be in-component state, never a hash hop**, and
+  `onModeChange` just calls the layout setter (pills *own* the layouts; the `Layout:`
+  menu stays as the "custom/advanced" escape hatch — one source of truth).
+- **Ordered captioned chapters (C + per-view `hint`)** — the Expositor: postures are a
+  *sequence*, not a toggle; each should set the per-view `hint` caption (one sentence
+  under the picture) and follow the guide-series chapter order. "The unit of
+  decomposition is the caption, not the control."
+
+**Recommendation:** ship PR-0 as layouts; then add pills **only if** salience demands
+it, and make each posture also set a one-line `hint` caption (cheap, satisfies the
+Expositor regardless of pills). This is the same open decision the pair-mode plan
+already carries (panel pills vs top-bar pills) — let one resolution serve both.
+
+## Phase 2 (each on its own merits)
+
+- **Rays linked split-view (#5) — the only genuinely new capability.** The single
+  `node` view can't show the X-view ↔ Y-view correspondence; it needs a
+  `panes: PaneDef[]` split (`types.ts:19-50`, Plane Transform / Correspondence
+  pattern) — domain net | image net. Heaviest item: two synchronized engine viewports
+  or one engine drawing two cameras. Scope as its own PR; gate the `rays` posture's
+  full form on it.
+- **Reverent immersive stages (Hopf, Rays).** Wanted by Expositor + Aesthete. Blocked
+  by the framework fact that `immersive` is app-wide, single-view only. Options: (a) a
+  small framework addition to allow *per-layout* immersive; (b) lean on the existing
+  per-view **fullscreen** button as the "quiet room" for now. Recommend (b) first.
+- **Plane/particles unification (`!high` backlog).** The mathematician reframed it:
+  Particles draws the *graph* `(z,f)`; Plane Transform draws the *map* (the `(u,v)`
+  shadow). The resolution is likely **"name them graph vs map"** in both explainers,
+  not "merge them." Cheap doc/labeling task.
+- **Pair mode as a sixth posture.** When the pair-mode plan lands, `(f,g)` becomes a
+  "Function Pairs" posture — same engine, same `appId`.
+
+## Open decisions (Dan's)
+
+> [!IMPORTANT]
+> 1. **Posture affordance** (PR-2): layout-menu only · + top-bar pills · + per-view
+>    captions. Recommendation: layouts now, captions cheap, pills if salience demands.
+> 2. **Preset re-apply** (PR-1): apply on change-of-function only (recommended), or
+>    also a "reset to recommended view" gesture.
+> 3. **Phase-2 priority**: the Rays split-view (#5, the only new capability) vs the
+>    immersive stages vs the plane/particles naming — which first.
+
+## Risks
+
+| Risk | Mitigation |
+|---|---|
+| Saved layouts hide the new default | verify in a fresh profile (`SEED_LS`); say so in the PR; do not force-reset returning users |
+| Presets stomp deliberate user tweaks | presets set *domain/projection only*, never appearance; apply on explicit change only |
+| Postures become a 3rd nav layer (rail + Layout menu + pills) | pills (if built) *own* the layouts; `Layout:` menu is the single advanced escape hatch |
+| "Simplify" via a hash-hop mode silently splits persistence | mode/posture selector is in-component state under one `appId`, never `location.hash` |
+| Drift from the pair-mode plan | PR-0/PR-1 are additive + independent; pair mode lands later as a posture, not a fork |
+
+## Process note
+
+`kind: plan`, `status: proposed` until a session executes it (then flip
+`proposed → in-progress → completed` and fill `pr:`). Surfaced by the control center
+like any report; the `needs-dan` signal is inferred from the proposed status. The
+two load-bearing calls (posture affordance, subtraction depth — already answered
+"hide, keep power") are reversible and do **not** block PR-0.
+</content>
+</invoke>

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -11,17 +11,23 @@ followup: null
 pr: 222
 app: complex-particles
 signals: on-track
-next: Phase-2 — the Rays X→Y linked split view (the one genuinely new capability).
+next: Phase-2 Step 2 (optional) — the graph-native correspondence tie-line overlay; needs its own design pass.
 ---
 
 > [!NOTE]
 > **Shipped on PR #222 (2026-06-16):** PR-0 (calm `single` default + five postures
 > as Layout-menu entries) · the tablet-width onstage fix (codex review) · **PR-1**
 > (per-function recommended-view presets — auto-snap domain/projection on a function
-> change, z² landing preserved; verified across switches) · **PR-2** (opt-in posture
-> plot-captions — the active layout's `sub` as a subtle bottom-center caption, desktop
-> only, fades on rearrange). Decisions all resolved (see below). Remaining: **Phase-2**,
-> starting with the Rays X→Y linked split view.
+> change, z² landing preserved) · **PR-2** (opt-in posture plot-captions) · **Phase-2
+> MVP** (graph ↔ map function handoff). The original "Rays domain|image split inside
+> Complex Particles" was **dropped**: a [three-hats review](2026-06-16-S01-expert-synthesis.md)
+> unanimously found it would duplicate Plane Transform (Option A) or be mathematically
+> false (Option B — `DropU`/`DropV` keep `(x,y,Im f)`/`(x,y,Re f)`, neither isolates the
+> z-plane). Adopted **Option C+**: link the 4D *graph* (Complex Particles) to the plane
+> *map* (Plane Transform) via a pure, tested function-handoff codec + a top-bar link each
+> way, and renamed the posture **"Rays (X→Y)" → "z → f(z)"**. Remaining (optional):
+> **Step 2** — a graph-native correspondence tie-line overlay (`z₀ → f(z₀)` in the live
+> 3D scene), which needs its own short design pass (density/picking/perf at 80k).
 
 # Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)
 

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -11,15 +11,17 @@ followup: null
 pr: 222
 app: complex-particles
 signals: on-track
-next: PR-2 (posture plot-captions); then Phase-2 — the Rays X→Y linked split view.
+next: Phase-2 — the Rays X→Y linked split view (the one genuinely new capability).
 ---
 
 > [!NOTE]
 > **Shipped on PR #222 (2026-06-16):** PR-0 (calm `single` default + five postures
 > as Layout-menu entries) · the tablet-width onstage fix (codex review) · **PR-1**
 > (per-function recommended-view presets — auto-snap domain/projection on a function
-> change, z² landing preserved; verified across switches). Decisions all resolved
-> (see below). Remaining: PR-2 posture captions, then Phase-2 (Rays split view first).
+> change, z² landing preserved; verified across switches) · **PR-2** (opt-in posture
+> plot-captions — the active layout's `sub` as a subtle bottom-center caption, desktop
+> only, fades on rearrange). Decisions all resolved (see below). Remaining: **Phase-2**,
+> starting with the Rays X→Y linked split view.
 
 # Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)
 

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -10,9 +10,16 @@ build: passing
 followup: null
 pr: 222
 app: complex-particles
-signals: needs-dan
-next: PR-1 (per-function preset defaults) — pending Dan's reversible-decision calls.
+signals: on-track
+next: PR-2 (posture plot-captions); then Phase-2 — the Rays X→Y linked split view.
 ---
+
+> [!NOTE]
+> **Shipped on PR #222 (2026-06-16):** PR-0 (calm `single` default + five postures
+> as Layout-menu entries) · the tablet-width onstage fix (codex review) · **PR-1**
+> (per-function recommended-view presets — auto-snap domain/projection on a function
+> change, z² landing preserved; verified across switches). Decisions all resolved
+> (see below). Remaining: PR-2 posture captions, then Phase-2 (Rays split view first).
 
 # Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)
 

--- a/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
+++ b/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md
@@ -5,13 +5,13 @@ date: 2026-06-16
 title: "Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)"
 branch: claude/sleepy-bardeen-uk0cal
 slug: sleepy-bardeen-uk0cal
-status: proposed
+status: in-progress
 build: passing
 followup: null
-pr: null
+pr: 222
 app: complex-particles
 signals: needs-dan
-next: Build PR-0 (calm default + posture layouts) — the cheap, reversible, high-leverage win.
+next: PR-1 (per-function preset defaults) — pending Dan's reversible-decision calls.
 ---
 
 # Plan: tame Complex Particles' surface — postures, presets, a calm default (no new apps)
@@ -84,7 +84,7 @@ geometry" axis (Plane / Cylinder / Sphere / Branch sheets) is the **presets**.
   as **one more posture** ("Function Pairs") on the same engine. Splitting into apps
   now would *collide* with that plan (it strands pair mode's shared state).
 
-## PR-0 — A calm default + posture layouts (the high-leverage win)
+## PR-0 — A calm default + posture layouts (the high-leverage win) — ✅ shipped ([#222](https://github.com/piyarsquare/animath/pull/222))
 
 **Goal:** stop cold-opening the cockpit. Land in one quiet single-function posture;
 recast the layout menu as task-shaped postures. **No engine or state-field change** —

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -32,6 +32,22 @@ import {
   MULTIVALUED_INDICES, branchPeriod,
 } from '../../lib/complexMath';
 
+// ── Per-function "recommended view" presets (PR-1, 2026-06-16) ──────────────
+// Picking a *different* function auto-snaps the DOMAIN/PROJECTION to what that
+// function wants — never the user's appearance choices (color, size, render
+// mode, motion stay exactly as set). Anything a function doesn't list here falls
+// back to the shipped default — Perspective · ×π units (±2π) · one sheet — so
+// snapping back to an entire function restores the calm default framing, and z²
+// (the initial load, which is never a "change") is left byte-for-byte untouched.
+//
+// Poles & Möbius read best on the sphere (the Hopf projection): 1/z, 1/z², 1/z³,
+// (z²+1)/(z²−1), (z−1)/(z+1).
+const HOPF_PROJECTION_FUNCS = new Set<number>([8, 29, 10, 12, 17]);
+// Near-origin branch / essential structure frames tighter at ±2 (×1 units) than
+// at the ±2π default: the roots & logs, inverse trig, inverse hyperbolics,
+// e^{1/z}, and the Joukowski map.
+const UNIT_SCALE_FUNCS = new Set<number>([1, 16, 18, 3, 14, 20, 21, 25, 26, 27, 28, 33, 34, 35, 13, 11]);
+
 type Complex2 = [number, number];
 
 export type { ViewPoint };
@@ -785,13 +801,40 @@ export default function ComplexParticles({
     options: cat.members.map(idx => ({ value: idx, label: functionNames[idx] })),
   }));
 
+  // Auto-snap the recommended domain/projection when the function actually
+  // changes (PR-1). Domain/projection only — color, size, render mode and motion
+  // are the user's and are left exactly as set. A same-function re-pick and the
+  // initial restore never call this, so the z² landing is preserved.
+  const applyFunctionPreset = (idx: number) => {
+    state.setAxisScale(UNIT_SCALE_FUNCS.has(idx) ? 1 : Math.PI);
+    // Projection: Sphere (Hopf) for poles & Möbius, else Perspective. Only morph
+    // when it differs, so switching among same-projection functions is calm.
+    const proj = HOPF_PROJECTION_FUNCS.has(idx) ? ProjectionMode.Hopf : ProjectionMode.Perspective;
+    if (state.viewType !== proj) controls.handleViewType(proj);
+    // Sheets: a multivalued function arrives showing its full Riemann-sheet set
+    // (capped, tinted by the default sheetTint); single-valued collapses to one.
+    if (MULTIVALUED_INDICES.has(idx)) {
+      const sheets = branchPeriod(idx, expQ === 0 ? 1 : expQ) ?? 3;
+      setBranchMin(0);
+      setBranchMax(Math.min(sheets, MAX_SHEETS) - 1);
+    } else {
+      setBranchMin(0);
+      setBranchMax(0);
+    }
+  };
+
+  const selectFunction = (idx: number) => {
+    if (idx !== functionIndex) applyFunctionPreset(idx);
+    setFunctionIndex(idx);
+  };
+
   const functionPicker = (
     <>
       <Select
         label="Function"
         groups={functionGroups}
         value={functionIndex}
-        onChange={setFunctionIndex}
+        onChange={selectFunction}
       />
       {isPowPQ && (
         <>
@@ -823,7 +866,7 @@ export default function ComplexParticles({
       aria-label="Function"
       title="Function"
       value={functionIndex}
-      onChange={e => setFunctionIndex(Number(e.target.value))}
+      onChange={e => selectFunction(Number(e.target.value))}
     >
       {functionGroups.map(g => (
         <optgroup key={g.label} label={g.label}>

--- a/src/animations/ComplexParticles/ComplexParticles.tsx
+++ b/src/animations/ComplexParticles/ComplexParticles.tsx
@@ -31,6 +31,7 @@ import {
   functionNames, functionFormulas, functionCategories, POW_PQ_INDEX, QUADRATIC_INDEX,
   MULTIVALUED_INDICES, branchPeriod,
 } from '../../lib/complexMath';
+import { decodeFunction, encodeFunction, type FunctionState } from '../../lib/functionHandoff';
 
 // ── Per-function "recommended view" presets (PR-1, 2026-06-16) ──────────────
 // Picking a *different* function auto-snaps the DOMAIN/PROJECTION to what that
@@ -125,6 +126,23 @@ export default function ComplexParticles({
   const [quadA, setQuadA] = usePersistentState<Complex2>(ek('quadA'), [1, 0]);
   const [quadB, setQuadB] = usePersistentState<Complex2>(ek('quadB'), [0, 0]);
   const [quadC, setQuadC] = usePersistentState<Complex2>(ek('quadC'), [0, 0]);
+
+  // One-time function handoff (Phase-2 "graph ↔ map"): arriving from Plane
+  // Transform's "↗ 4D graph" link carries the function in the URL (?fn=…). Adopt
+  // it once, then strip the query so a later reload uses the user's own saved
+  // choice. Embed mode parses its own params, so it is skipped here.
+  useEffect(() => {
+    if (embed) return;
+    const seed = decodeFunction(window.location.hash);
+    if (seed.index === undefined) return;
+    setFunctionIndex(seed.index);
+    if (seed.p !== undefined) setExpP(seed.p);
+    if (seed.q !== undefined) setExpQ(seed.q === 0 ? 1 : seed.q);
+    if (seed.quad) { setQuadA(seed.quad.a); setQuadB(seed.quad.b); setQuadC(seed.quad.c); }
+    window.history.replaceState(null, '', window.location.hash.split('?')[0] || '#/complex-particles');
+    // run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   // Domain region (Domain panel): restrict the sampled plane to a polar radius
   // band on |z| (max thumb = no limit), applied live in the shaders (no geometry
@@ -878,6 +896,22 @@ export default function ComplexParticles({
     </select>
   );
 
+  // Cross-app handoff (Phase-2 "graph ↔ map"): open the same function as a plane
+  // map (domain → image) in Plane Transform. The link carries ONLY the function
+  // (name + p/q or quadratic coeffs), never the view — the two apps are two ways
+  // of seeing one function, not two persistence roots.
+  const fnState: FunctionState = { index: functionIndex, p: expP, q: expQ, quad: { a: quadA, b: quadB, c: quadC } };
+  const topBarExtra = (
+    <span className="am-bar-extra">
+      {functionTopSelect}
+      <a
+        className="am-bar-link"
+        href={`#/plane-transform?${encodeFunction(fnState)}`}
+        title="See this function as a plane map — the domain z-plane beside its image f(z)"
+      >↗ plane map</a>
+    </span>
+  );
+
   // Riemann-sheet range (shown for multivalued functions only). Kept min ≤ max
   // and within the sheet span (the function's finite period, else MAX_SHEETS)
   // by nudging the partner bound. Lives in the Domain section.
@@ -938,7 +972,7 @@ export default function ComplexParticles({
       functionName={displayName}
       functionFormula={displayFormula}
       functionPicker={functionPicker}
-      topExtra={functionTopSelect}
+      topExtra={topBarExtra}
       domainExtras={<>{regionControls}{isMultivalued ? branchControls : null}</>}
       readme={readmeText}
       explainer={explainerText}

--- a/src/animations/ComplexParticles/EXPLAINER.md
+++ b/src/animations/ComplexParticles/EXPLAINER.md
@@ -19,6 +19,16 @@ graph lives in **four dimensions**:
 Every particle sits at the 4-D point **(x, y, u, v)**. We can't look at 4-D
 directly, so the view *projects* it down into the 3-D scene on screen.
 
+## The graph, and the map next door
+
+This app draws the **graph** of `f` — every input paired with its output as one
+point `(z, f(z))`. A complementary way to see the *same* function is as a **map**
+of the plane: the domain `z`-plane beside its image `f(z)`. That view is its own
+app, **Plane Transform** — open it on the current function with the **↗ plane
+map** link in the top bar (it carries the function across, so you land on the
+same `f`). The graph and the map are two honest pictures of one object, not two
+different things.
+
 ## The projection slider (Camera panel)
 
 One slider moves between three ways of flattening 4-D to 3-D —

--- a/src/animations/PlaneTransform/EXPLAINER.md
+++ b/src/animations/PlaneTransform/EXPLAINER.md
@@ -4,6 +4,15 @@ Shows a complex function **f : ℂ → ℂ** as a *transformation of the plane*.
 The input pane is a colored grid of points `z = x + iy`; the output pane
 shows where each point lands, `w = f(z)`.
 
+## The map, and the graph next door
+
+This app draws the **map** `z ↦ f(z)`: the domain plane and its image, side by
+side. A complementary way to see the *same* function is as its 4-D **graph** —
+every input paired with its output as one point `(z, f(z))`, drawn as a particle
+cloud. That view is its own app, **Complex Particles** — open it on the current
+function with the **↗ 4D graph** link in the top bar. The map and the graph are
+two honest pictures of one object, not two different things.
+
 ## Reading the two panes
 
 - **Same color = same point.** A patch of color in the input pane tells you

--- a/src/animations/PlaneTransform/PlaneTransform.tsx
+++ b/src/animations/PlaneTransform/PlaneTransform.tsx
@@ -13,6 +13,7 @@ import {
   applyComplexBranch, complexPowRational, complexQuadratic,
 } from '../../lib/complexMath';
 import { usePersistentState, clearPersistedState } from '../../lib/usePersistentState';
+import { decodeFunction, encodeFunction, type FunctionState } from '../../lib/functionHandoff';
 import { vertexShader, fragmentShader } from './shaders';
 import {
   buildStandardCurve, STANDARD_CURVES,
@@ -72,6 +73,23 @@ export default function PlaneTransform({ embed }: {
   const [quadA, setQuadA] = usePersistentState<[number, number]>(ek('quadA'), [1, 0]);
   const [quadB, setQuadB] = usePersistentState<[number, number]>(ek('quadB'), [0, 0]);
   const [quadC, setQuadC] = usePersistentState<[number, number]>(ek('quadC'), [0, 0]);
+
+  // One-time function handoff (Phase-2 "graph ↔ map"): arriving from Complex
+  // Particles' "↗ plane map" link carries the function in the URL (?fn=…). Adopt
+  // it once, then strip the query so a reload uses the user's own saved choice.
+  // Embed mode parses its own params, so it is skipped here.
+  useEffect(() => {
+    if (embed) return;
+    const seed = decodeFunction(window.location.hash);
+    if (seed.index === undefined) return;
+    setFunctionIndex(seed.index);
+    if (seed.p !== undefined) setExpP(seed.p);
+    if (seed.q !== undefined) setExpQ(seed.q === 0 ? 1 : seed.q);
+    if (seed.quad) { setQuadA(seed.quad.a); setQuadB(seed.quad.b); setQuadC(seed.quad.c); }
+    window.history.replaceState(null, '', window.location.hash.split('?')[0] || '#/plane-transform');
+    // run once on mount
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const [density, setDensity] = usePersistentState(ek('density'), 240);          // points per side
   const [pointSize, setPointSize] = usePersistentState(ek('pointSize'), 2.5);
   const [viewExtent, setViewExtent] = usePersistentState(ek('viewExtent'), embed?.extent ?? 3);   // half-side of visible square
@@ -557,6 +575,18 @@ export default function PlaneTransform({ embed }: {
   // so nothing from the old drawer's About section is lost.
   const help = [explainerText, readmeText].filter(Boolean).join('\n\n---\n\n');
 
+  // Cross-app handoff (Phase-2 "graph ↔ map"): open the same function as its 4D
+  // graph in Complex Particles. Carries ONLY the function (name + p/q or quadratic
+  // coeffs), never view/appearance state.
+  const handoffState: FunctionState = { index: functionIndex, p: expP, q: expQ, quad: { a: quadA, b: quadB, c: quadC } };
+  const topBarExtra = (
+    <a
+      className="am-bar-link"
+      href={`#/complex-particles?${encodeFunction(handoffState)}`}
+      title="See this function as its 4D graph — the particle cloud (z, f(z)) in ℂ²"
+    >↗ 4D graph</a>
+  );
+
   return (
     <Workspace
       appId="plane-transform"
@@ -568,6 +598,7 @@ export default function PlaneTransform({ embed }: {
       defaultLayoutId="essentials"
       explainer={help || null}
       titlePanel="function"
+      topExtra={topBarExtra}
     />
   );
 }

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -565,6 +565,21 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
   overflow-x: auto; scrollbar-width: none;
 }
 .am-actionbar-phone .am-action-btn { min-height: 44px; }
+/* Layout caption (opt-in, desktop): the active posture's one-line subtitle, a
+   faint "guided chapter" label sitting under the plot. Non-interactive, so it
+   never intercepts canvas gestures; same layer as the action strip. */
+.am-caption {
+  position: absolute; left: 50%; bottom: 16px; transform: translateX(-50%);
+  z-index: var(--z-actionbar); pointer-events: none;
+  max-width: calc(100% - 200px);
+  padding: 5px 14px;
+  font-family: var(--font-ui); font-size: 12px; font-weight: 600; letter-spacing: 0.01em;
+  color: var(--dim); background: var(--panel);
+  backdrop-filter: blur(14px); -webkit-backdrop-filter: blur(14px);
+  border: 1px solid var(--border); border-radius: 999px; box-shadow: var(--shadow);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.am-caption-raised { bottom: 64px; } /* clear the action strip when both are present */
 /* phone cards scroll under the dock + strip — leave room to reach the end */
 .am-phone-app.am-has-actions .am-phone-scroll { padding-bottom: 148px; }
 

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -278,6 +278,15 @@ body {
 /* Inline top-bar control slot (WorkspaceProps.topExtra) + its compact select */
 .am-bar-extra { display: flex; align-items: center; min-width: 0; flex: 0 1 auto; }
 .am-bar-select { width: auto; max-width: 190px; padding: 6px 26px 6px 10px; font-size: 12px; background-position: calc(100% - 15px) 13px, calc(100% - 10px) 13px; }
+/* Cross-app handoff link in the top bar (Complex Particles "↗ plane map" /
+   Plane Transform "↗ 4D graph") — a quiet sibling of the bar's controls. */
+.am-bar-link {
+  display: inline-flex; align-items: center; flex: 0 0 auto; margin-left: 8px;
+  padding: 4px 9px; border: 1px solid var(--border); border-radius: 999px;
+  background: transparent; color: var(--dim); text-decoration: none;
+  font-family: var(--font-ui); font-size: 12px; font-weight: 600; white-space: nowrap;
+}
+.am-bar-link:hover { color: var(--fg); background: var(--hover); }
 
 .am-toggle { display: flex; align-items: center; justify-content: space-between; gap: 10px; cursor: pointer; }
 .am-switch { width: 38px; height: 22px; border-radius: 999px; background: var(--track); position: relative; flex-shrink: 0; transition: background .16s; }

--- a/src/chrome/workspace/DesktopWorkspace.tsx
+++ b/src/chrome/workspace/DesktopWorkspace.tsx
@@ -25,7 +25,7 @@ type RefMap = React.MutableRefObject<Record<string, HTMLDivElement | null>>;
  * plus the left icon rail and named layouts, persisted per app.
  */
 export default function DesktopWorkspace(props: WorkspaceProps) {
-  const { appId, title, subtitle, views, layouts: appLayouts, defaultLayoutId, explainer, titlePanel, topExtra, actions, modes, activeMode, onModeChange, immersive } = props;
+  const { appId, title, subtitle, views, layouts: appLayouts, defaultLayoutId, explainer, titlePanel, topExtra, actions, modes, activeMode, onModeChange, immersive, layoutCaptions } = props;
   /* immersive desktop: a single view fills the stage (no frame), top bar + rail
    *  + floating panels + action strip stay live over it. Single-view only. */
   const soloImmersive = !!immersive && views.length === 1;
@@ -209,6 +209,14 @@ export default function DesktopWorkspace(props: WorkspaceProps) {
 
   const openIds = Object.keys(state.open);
 
+  // The active posture's one-line caption (opt-in). Resolves the current layout
+  // id to its `sub`; once the user rearranges, state.layout is 'custom' (no
+  // match) and the caption disappears — the guided chapter ends when you start
+  // exploring on your own.
+  const captionSub = layoutCaptions
+    ? [...builtin, ...state.saved].find(l => l.id === state.layout)?.sub
+    : undefined;
+
   return (
     <div className="am-app">
       <TopBar
@@ -293,6 +301,11 @@ export default function DesktopWorkspace(props: WorkspaceProps) {
         ))}
 
         {actions && <ActionBar actions={actions} sections={sections} />}
+        {captionSub && (
+          <div className={`am-caption${actions ? ' am-caption-raised' : ''}`} aria-hidden="true">
+            {captionSub}
+          </div>
+        )}
       </div>
       {fullHelp && explainer && (
         <ExplainerModal title={title} markdown={explainer} onClose={() => setFullHelp(false)} />

--- a/src/chrome/workspace/types.ts
+++ b/src/chrome/workspace/types.ts
@@ -139,6 +139,13 @@ export interface WorkspaceProps {
   immersive?: boolean;
   /** App-specific built-in layouts; Compact + Everything are auto-appended. */
   layouts?: LayoutDef[];
+  /** Desktop-only: render the active layout's `sub` as a subtle, non-interactive
+   *  caption bottom-center of the stage — the "guided chapter" subtitle for
+   *  task-shaped postures (Complex Particles' Single Function / Representations /
+   *  …). Off by default so other apps are unaffected; it fades to nothing once
+   *  the user rearranges (the layout id becomes 'custom'). Phone hides the Layout
+   *  menu, so this has no effect there. */
+  layoutCaptions?: boolean;
   /** Initial layout; default: first app layout, else 'everything'. */
   defaultLayoutId?: string;
   /** Markdown for the top-bar "?" explainer. */

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -639,6 +639,12 @@ export default function ParticleViewerShell({
   // job, not a panel dump. The default lands calm — one quiet posture with the
   // plot left clear — and the full cockpit stays one click away in the other
   // postures and the auto-appended Everything layout ("hide, keep power").
+  //
+  // Second panels sit in the canonical second column (x:356 = WS_RAIL + one
+  // PANEL_W column), never out at the right edge: a panel there stays onstage
+  // down to a ~624px stage, i.e. across the whole desktop range (narrower than
+  // that re-chromes to phone at 740px), so no posture can push a control
+  // off-stage on tablet-width desktops.
   const layouts: LayoutDef[] = [
     {
       // The calm default: only Color opens (Domain/Range), parked in the left
@@ -651,13 +657,13 @@ export default function ParticleViewerShell({
     {
       // The four ways to draw the same graph: Points · Sheet · Tiles · Net.
       id: 'represent', name: 'Representations', sub: 'Points · Sheet · Tiles · Net', icon: 'layers',
-      open: { render: { x: 84, y: 18 }, color: { x: 800, y: 18 } },
+      open: { render: { x: 84, y: 18 }, color: { x: 356, y: 18 } },
     },
     {
       // The six 4D plane-turns are the star here — the only posture that opens
       // the 4D Rotation rig over the plot on purpose.
       id: 'basis', name: 'Change of Basis', sub: 'The six 4D plane-turns', icon: 'rotate',
-      open: { camera: { x: 84, y: 18 }, rotate: { x: 800, y: 56 } },
+      open: { camera: { x: 84, y: 18 }, rotate: { x: 356, y: 18 } },
     },
     {
       // The projection slider (Perspective → Torus → Sphere) is the whole show;
@@ -670,7 +676,7 @@ export default function ParticleViewerShell({
       // the shipped default, carries each point's identity across). The linked
       // domain | image split view upgrades this posture in Phase 2.
       id: 'rays', name: 'Rays (X→Y)', sub: 'Follow the domain net into the image', icon: 'waves',
-      open: { render: { x: 84, y: 18 }, motion: { x: 800, y: 18 } },
+      open: { render: { x: 84, y: 18 }, motion: { x: 356, y: 18 } },
     },
   ];
 

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -672,10 +672,14 @@ export default function ParticleViewerShell({
       open: { camera: { x: 84, y: 18 } },
     },
     {
-      // Net + Motion: watch the domain net sweep into the image (Domain coloring,
-      // the shipped default, carries each point's identity across). The linked
-      // domain | image split view upgrades this posture in Phase 2.
-      id: 'rays', name: 'Rays (X→Y)', sub: 'Follow the domain net into the image', icon: 'waves',
+      // The mapping z → f(z): Net + Motion watch the domain net sweep into the
+      // image (Domain coloring carries each point's identity across). The Phase-2
+      // three-hats review found a domain|image split *here* would duplicate the
+      // Plane Transform app, so the linked plane map lives there — one click away
+      // via the top-bar "↗ plane map" handoff. Named "z → f(z)", not "Rays":
+      // "rays" already means polar spokes (Net mode, Plane Transform). Id stays
+      // 'rays' to keep saved layouts stable.
+      id: 'rays', name: 'z → f(z)', sub: 'Watch the domain net sweep to its image', icon: 'waves',
       open: { render: { x: 84, y: 18 }, motion: { x: 356, y: 18 } },
     },
   ];

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -753,6 +753,7 @@ export default function ParticleViewerShell({
       explainer={help || null}
       titlePanel="function"
       topExtra={topExtra}
+      layoutCaptions
     />
   );
 }

--- a/src/components/ParticleViewerShell.tsx
+++ b/src/components/ParticleViewerShell.tsx
@@ -635,20 +635,42 @@ export default function ParticleViewerShell({
     },
   ];
 
+  // Task-shaped "postures" (decomposition plan, 2026-06-16): each layout is one
+  // job, not a panel dump. The default lands calm — one quiet posture with the
+  // plot left clear — and the full cockpit stays one click away in the other
+  // postures and the auto-appended Everything layout ("hide, keep power").
   const layouts: LayoutDef[] = [
     {
-      // 4D Rotation opens by default, floating over the plot's right edge —
-      // the successor of the old always-visible Actions floater.
-      id: 'essentials', name: 'Essentials', sub: 'Function · Camera · 4D Rotation', icon: 'tune',
-      open: { function: { x: 84, y: 18 }, camera: { x: 84, y: 240 }, rotate: { x: 800, y: 56 } },
+      // The calm default: only Color opens (Domain/Range), parked in the left
+      // gutter; the plot is left completely clear and the auto-tumble does the
+      // 4D work. The cockpit (4D rig, render variety, projection morph) is one
+      // posture away — nothing is removed, only tucked behind a click.
+      id: 'single', name: 'Single Function', sub: 'One graph, seen plainly', icon: 'fx',
+      open: { color: { x: 84, y: 18 } },
     },
     {
-      id: 'appearance', name: 'Appearance', sub: 'Color · Render · Motion', icon: 'palette',
-      open: { color: { x: 84, y: 18 }, render: { x: 366, y: 18 }, motion: { x: 84, y: 420 } },
+      // The four ways to draw the same graph: Points · Sheet · Tiles · Net.
+      id: 'represent', name: 'Representations', sub: 'Points · Sheet · Tiles · Net', icon: 'layers',
+      open: { render: { x: 84, y: 18 }, color: { x: 800, y: 18 } },
     },
     {
-      id: 'rotate', name: 'Rotate', sub: '4D rotation over the plot', icon: 'rotate',
-      open: { rotate: { x: 360, y: 96 } },
+      // The six 4D plane-turns are the star here — the only posture that opens
+      // the 4D Rotation rig over the plot on purpose.
+      id: 'basis', name: 'Change of Basis', sub: 'The six 4D plane-turns', icon: 'rotate',
+      open: { camera: { x: 84, y: 18 }, rotate: { x: 800, y: 56 } },
+    },
+    {
+      // The projection slider (Perspective → Torus → Sphere) is the whole show;
+      // keep the plot clear so the fiber collapse is legible.
+      id: 'hopf', name: 'Hopf & Projection', sub: 'Perspective → Torus → Sphere', icon: 'orbit',
+      open: { camera: { x: 84, y: 18 } },
+    },
+    {
+      // Net + Motion: watch the domain net sweep into the image (Domain coloring,
+      // the shipped default, carries each point's identity across). The linked
+      // domain | image split view upgrades this posture in Phase 2.
+      id: 'rays', name: 'Rays (X→Y)', sub: 'Follow the domain net into the image', icon: 'waves',
+      open: { render: { x: 84, y: 18 }, motion: { x: 800, y: 18 } },
     },
   ];
 
@@ -721,7 +743,7 @@ export default function ParticleViewerShell({
       sections={sections}
       views={views}
       layouts={layouts}
-      defaultLayoutId="essentials"
+      defaultLayoutId="single"
       explainer={help || null}
       titlePanel="function"
       topExtra={topExtra}

--- a/src/lib/__tests__/functionHandoff.test.ts
+++ b/src/lib/__tests__/functionHandoff.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { encodeFunction, decodeFunction, type FunctionState } from '../functionHandoff';
+import { functionNames, POW_PQ_INDEX, QUADRATIC_INDEX } from '../complexMath';
+
+/** Round-trip helper: encode to a query, then decode it back (with a path prefix
+ *  to mimic a real hash like '#/plane-transform?…'). */
+const round = (s: FunctionState) => decodeFunction('#/plane-transform?' + encodeFunction(s));
+
+describe('functionHandoff codec', () => {
+  it('round-trips a plain named function', () => {
+    const index = functionNames.indexOf('exp');
+    expect(round({ index })).toEqual({ index });
+  });
+
+  it('round-trips every named function by index', () => {
+    // The whole point: the handoff must carry any function the picker offers.
+    for (let index = 0; index < functionNames.length; index++) {
+      expect(round({ index }).index).toBe(index);
+    }
+  });
+
+  it('round-trips z^(p/q) with p and q', () => {
+    const s: FunctionState = { index: POW_PQ_INDEX, p: 3, q: 2 };
+    expect(round(s)).toEqual({ index: POW_PQ_INDEX, p: 3, q: 2 });
+  });
+
+  it('round-trips the quadratic coefficients a, b, c', () => {
+    const s: FunctionState = { index: QUADRATIC_INDEX, quad: { a: [1, -2], b: [0, 0.5], c: [-3, 0] } };
+    expect(round(s)).toEqual(s);
+  });
+
+  it('encodes a function as its name, not its raw index', () => {
+    const index = functionNames.indexOf('sin');
+    expect(encodeFunction({ index })).toBe('fn=sin');
+  });
+
+  it('decodes nothing from a query with no fn, or an unknown fn', () => {
+    expect(decodeFunction('#/complex-particles')).toEqual({});
+    expect(decodeFunction('?fn=definitely-not-a-function')).toEqual({});
+    expect(decodeFunction('')).toEqual({});
+  });
+
+  it('ignores garbled p/q and coefficient values rather than throwing', () => {
+    expect(decodeFunction('?fn=powPQ&p=abc')).toEqual({ index: POW_PQ_INDEX });
+    expect(decodeFunction('?fn=quadratic&a=1,2&b=oops&c=0,0')).toEqual({ index: QUADRATIC_INDEX });
+  });
+});

--- a/src/lib/functionHandoff.ts
+++ b/src/lib/functionHandoff.ts
@@ -1,0 +1,74 @@
+import { functionNames, POW_PQ_INDEX, QUADRATIC_INDEX } from './complexMath';
+
+/**
+ * The shared identity of a complex function, as the two viewers model it: an
+ * index into {@link functionNames}, plus the parameters the two parameterized
+ * members need — `p`/`q` for `z^(p/q)` (index {@link POW_PQ_INDEX}) and the three
+ * complex coefficients for `a·z²+b·z+c` (index {@link QUADRATIC_INDEX}).
+ */
+export interface FunctionState {
+  index: number;
+  p?: number;
+  q?: number;
+  quad?: { a: [number, number]; b: [number, number]; c: [number, number] };
+}
+
+/**
+ * Pure URL-query codec for the cross-app function handoff (Phase-2 "graph ↔ map"):
+ * Complex Particles (the 4D graph) and Plane Transform (the plane map) are two
+ * views of the SAME function, so a deep link between them needs to carry only the
+ * function's identity — never view/appearance state. Encoding by function *name*
+ * (not raw index) keeps the link stable and human-editable, and survives the
+ * append-only `functionNames` list. Anything unparseable decodes to `{}` (the
+ * target keeps its own state), so a stale or hand-typed link never crashes.
+ */
+export function encodeFunction(s: FunctionState): string {
+  const name = functionNames[s.index];
+  if (!name) return '';
+  const parts = [`fn=${encodeURIComponent(name)}`];
+  if (s.index === POW_PQ_INDEX) {
+    if (s.p !== undefined) parts.push(`p=${s.p}`);
+    if (s.q !== undefined) parts.push(`q=${s.q}`);
+  }
+  if (s.index === QUADRATIC_INDEX && s.quad) {
+    const pair = (c: [number, number]) => `${c[0]},${c[1]}`;
+    parts.push(`a=${pair(s.quad.a)}`, `b=${pair(s.quad.b)}`, `c=${pair(s.quad.c)}`);
+  }
+  return parts.join('&');
+}
+
+/**
+ * Parse a function seed from a hash or query string (e.g.
+ * `'#/plane-transform?fn=exp'` or `'fn=powPQ&p=1&q=2'`). Returns only the fields
+ * actually present and valid; `{}` when there is no parseable `fn`.
+ */
+export function decodeFunction(input: string): Partial<FunctionState> {
+  const qi = input.indexOf('?');
+  const query = qi >= 0 ? input.slice(qi + 1) : input;
+  const P = new URLSearchParams(query);
+  const fn = P.get('fn');
+  if (!fn) return {};
+  const index = functionNames.indexOf(fn);
+  if (index < 0) return {};
+  const out: Partial<FunctionState> = { index };
+  const num = (k: string) => {
+    const v = parseFloat(P.get(k) ?? '');
+    return isFinite(v) ? v : undefined;
+  };
+  if (index === POW_PQ_INDEX) {
+    const p = num('p'); const q = num('q');
+    if (p !== undefined) out.p = p;
+    if (q !== undefined) out.q = q;
+  }
+  if (index === QUADRATIC_INDEX) {
+    const pair = (k: string): [number, number] | undefined => {
+      const raw = P.get(k);
+      if (!raw) return undefined;
+      const [re, im] = raw.split(',').map(parseFloat);
+      return isFinite(re) && isFinite(im) ? [re, im] : undefined;
+    };
+    const a = pair('a'); const b = pair('b'); const c = pair('c');
+    if (a && b && c) out.quad = { a, b, c };
+  }
+  return out;
+}


### PR DESCRIPTION
## What & why

Complex Particles greeted newcomers with the full cockpit: the default `essentials`
layout parked the **470px-tall 4D Rotation rig directly over the plot**. This PR works
through the [decomposition plan](``https://github.com/piyarsquare/animath/blob/claude/sleepy-bardeen-uk0cal/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-plan-tame-the-surface.md)``
— **"hide, keep power"** (progressive disclosure), *not* splitting the app or deleting
features:

- **PR-0** — recast the Layout menu into five task-shaped **"postures"** + a calm default.
- **PR-1** — **per-function recommended-view presets** (auto-snap domain/projection).
- **PR-2** — **posture plot-captions** (the guided-chapter subtitle under the plot).
- **Phase-2 MVP** — **graph ↔ map function handoff** (the 4D graph and the plane map as two doors to one function).

## PR-0 — the five postures

| Posture | Opens | Caption |
|---|---|---|
| **Single Function** *(default)* | Color only | *One graph, seen plainly* |
| **Representations** | Render + Color | *Points · Sheet · Tiles · Net* |
| **Change of Basis** | Camera + 4D Rotation | *The six 4D plane-turns* |
| **Hopf & Projection** | Camera | *Perspective → Torus → Sphere* |
| **z → f(z)** *(was "Rays")* | Render + Motion | *Watch the domain net sweep to its image* |

Compact + Everything are still auto-appended (*Everything* = the "keep power" escape hatch).

## PR-1 — per-function presets

Picking a **different** function auto-snaps **domain/projection** (never appearance):
×1/±2 tight units for near-origin branch structure, **Sphere (Hopf)** for poles & Möbius,
and a multivalued function's full tinted Riemann-sheet set. Falls back to the shipped
default otherwise, so the z² landing is byte-for-byte preserved (it's the initial load,
never a "change").

## PR-2 — posture plot-captions

Opt-in `WorkspaceProps.layoutCaptions` renders the active layout's `sub` as a subtle,
non-interactive caption under the plot; it fades once you rearrange (layout → `custom`).
Off by default, desktop-only.

## Phase-2 MVP — graph ↔ map handoff (instead of a duplicate split)

A [three-hats review](``https://github.com/piyarsquare/animath/blob/claude/sleepy-bardeen-uk0cal/docs/sessions/progress/sleepy-bardeen-uk0cal/2026-06-16-S01-expert-synthesis.md``)
found that the originally-planned domain|image split inside Complex Particles would
**duplicate Plane Transform** (which already renders exactly that), and that the
"particle-native" variant was **mathematically false** (`DropU`/`DropV` keep
`(x,y,Im f)`/`(x,y,Re f)` — neither isolates the z-plane). So instead of duplicating:

- **`src/lib/functionHandoff.ts`** (+ vitest, 7 tests) — a pure URL-query codec carrying
  only the function identity (name + `p`/`q` + the quadratic's `a`/`b`/`c`). Encodes by
  name; unparseable input → `{}` (never crashes).
- Both apps **read a one-time seed** from the URL on mount, then strip the query (a reload
  uses the user's own saved choice); embed mode skipped.
- A top-bar link each way: Complex Particles **↗ plane map**, Plane Transform **↗ 4D graph**.
- Renamed the posture **"Rays (X→Y)" → "z → f(z)"** ("Rays" already means polar spokes).
- Explainer paragraphs in both apps naming the two models. **No engine/shader/persistence
  change; no second renderer.**

Remaining (optional, own design pass): a graph-native correspondence tie-line overlay.

## Verification (headless WebGL, fresh profile)

- Default posture lands clear; Change of Basis opens the rig; both panels stay onstage at 760px.
- Presets: `z²` unchanged on load → `sqrt` (×1, 2 sheets) → `1/z` (Sphere) → `z²` snap-back restores the landing.
- Captions update per posture (*One graph…* → *The six 4D plane-turns*).
- Handoff: `?fn=exp` → Plane Transform adopts exp + strips query; `?fn=cos` → Complex Particles adopts cos; clicking **↗ plane map** carries the function across (verified via persisted state).
- `npm run build` ✓ · `npm run lint` ✓ (0 errors) · **29 vitest tests** ✓.

## Scope & safety

- App code (`ComplexParticles.tsx`, `PlaneTransform.tsx`, explainers) + a new pure lib + an
  **opt-in, off-by-default** caption in the workspace chrome (`types.ts` / `DesktopWorkspace.tsx`
  / `theme.css`). No engine, shader, or persistence-schema change; no new WebGL context.
- Returning users keep their saved arrangement; only fresh profiles see the new `single` default.
- The z² first impression is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)