### PR TITLE
Headless mode: deep-link debug-pose harness + mobile smoke check

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -1,0 +1,35 @@
+name: Mobile smoke
+
+# Headless mobile-viewport smoke check (scripts/smoke.mjs): loads every route at
+# 390x844 in software WebGL and fails on a runtime crash / blank frame — the
+# defect class that escapes `tsc && vite build` (e.g. the #216 Torus crash). It
+# is deliberately a SEPARATE workflow from deploy.yml (which skips puppeteer's
+# Chrome download); here we DO download Chrome to run it.
+#
+# Advisory for now: the smoke step is `continue-on-error`, so it surfaces in the
+# PR's checks/logs without blocking merges. Promote to a hard gate (drop
+# continue-on-error) once it's proven quiet — the same graduation path the
+# sessions:lint --strict step took.
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - run: npm ci            # installs puppeteer's Chrome-for-Testing (NOT skipped here)
+      - run: npm run build
+      - name: Serve the production build
+        run: npm run preview &
+      - name: Wait for the server
+        run: npx --yes wait-on http://localhost:4173/animath/ --timeout 60000
+      - name: Mobile smoke (390x844, all routes)
+        continue-on-error: true   # advisory for now; drop this to make it a hard gate
+        run: npm run smoke

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -435,7 +435,8 @@ Follow **docs/BUILDING_AN_APP.md**. In short:
 > **Parallel branches.** Several app branches are often in flight at once
 > (frequently in separate agent threads). The framework keeps that conflict-free
 > because each app is a self-contained folder; the only shared files a new app
-> edits — `index.tsx`, `apps.ts`, `CLAUDE.md`, `README.md` — are all **append-only**.
+> edits — `index.tsx`, `apps.ts`, `CLAUDE.md`, `README.md` (and `package.json` when
+> adding a script/dep) — are all **append-only**.
 > Add new entries at the **end** of each list/table, never reorder existing ones,
 > and touch only your own app's lines. Before opening/finalizing a PR,
 > `git fetch && git merge origin/main`, resolve any shared-file overlap by

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -540,6 +540,8 @@ files two app branches both touch are the shared coordination points:
 - `src/index.tsx` (route map), `src/apps.ts` (catalog) and
   `src/chrome/catalog.ts` (gallery META)
 - `CLAUDE.md` and `README.md` (the route table + repo tree)
+- `package.json` when adding a script or dependency (append to the `scripts` /
+  `devDependencies` block — the one real conflict-marker near-miss landed here)
 
 All of them are edited **additively** (§3a–3d). Git auto-merges additive edits
 in different regions, so independent app branches normally merge with **no

--- a/docs/HEADLESS_WEBGL.md
+++ b/docs/HEADLESS_WEBGL.md
@@ -35,6 +35,81 @@ npm run shoot '#/topology-walk' shot.png   # capture a route to shot.png
 can confirm the context is real, not a blank quad. Env knobs: `BASE_URL`,
 `WAIT_MS`, `VIEWPORT` (`WxH`).
 
+## Debug-pose deep links (reproduce an exact frame)
+
+`shoot.mjs` captures whatever the app shows — by default its *initial* view. The
+**first-person walkers** (Polygon Worlds, Solid Worlds) also accept a **pose in the
+hash query**, so a single shareable URL reproduces an *exact* frame: world, scene
+look, camera, and player position. This turns "verified headless" from a blind
+default-view shot into a reproducible visual diff (and doubles as a shareable
+teaching link — "stand here, face the Klein flip").
+
+The parser is `src/lib/debugPose.ts` (app-agnostic; each app maps the params it
+understands, ignores the rest). Vocabulary:
+
+| Param | Meaning | Apps |
+|-------|---------|------|
+| `world=<id>` | world / spec id | both |
+| `look=<id>` | scene look (e.g. `daytime`, `dusk`, `moonlit`) | both |
+| `cam=first\|third` | camera mode | both |
+| `camd=<n>` | third-person camera distance | both |
+| `yaw=<rad>` `pitch=<rad>` | look orientation | both |
+| `x,y,z=<n>` | cube position, −1..1 | Solid Worlds |
+| `u,v=<n>` | chart position, 0..1 | Polygon Worlds |
+| `hud` / `debug=1` | show the opt-in dev HUD | both |
+| `freeze` / `t=<s>` | pin the animation clock (parsed; for animated states) | — |
+
+The opt-in **dev HUD** (`?hud`) overlays the live diagnostics — world·look, position,
+yaw/pitch, the orientation **determinant**, the fundamental cell, nearest-marker
+distance, and (Polygon Worlds) an *independent* ink-handedness **witness** — so the
+screenshot records *what the engine thinks the frame is*, not just the picture.
+
+```bash
+# Reproduce a specific walker frame, with the HUD, then read the PNG:
+npm run shoot \
+  '#/solid-worlds?world=half-turn&x=0.4&z=-0.3&yaw=0.8&look=dusk&cam=third&camd=8&hud' \
+  out.png
+npm run shoot \
+  '#/polygon-worlds?world=klein&u=0.2&v=0.85&yaw=1.2&look=dusk&cam=third&hud' out.png
+```
+
+> [!NOTE]
+> Two shots of the *same* URL from *separate* headless runs are **visually
+> identical but not byte-identical** — a handful of sub-pixel differences from
+> cross-process SwiftShader float nondeterminism. Compare frames with a **pixel
+> tolerance** (a coarse hash / per-pixel threshold), never `cmp`. (Within one page
+> load the frame is byte-stable.)
+
+## Mobile smoke (`npm run smoke`)
+
+The desktop `tsc && vite build` gate can't catch a runtime crash / blank frame that
+only shows at a real mobile viewport (the #216 Torus crash, the #215 height bug).
+`scripts/smoke.mjs` closes that no-cost tier: it loads **every route at 390×844** in
+software WebGL and fails (exit 1) on the crash class.
+
+```bash
+npm run build && (npm run preview &) && sleep 3
+npm run smoke            # PASS/FAIL across all routes; exit 0/1
+# SHOTS_DIR=./shots npm run smoke   # also dump a PNG per route to eyeball
+```
+
+Detectors (designed from a measured experiment, not assumed):
+
+- **`pageerror` (uncaught JS) + `webglcontextlost`** — *load-bearing* (fail). Three.js
+  swallows shader-compile errors, so the #216 crash surfaced as **context loss**, not
+  a console error.
+- **`console.error`** — *advisory* (warning), with a resource-load allowlist (every
+  clean route logs a 404 + a cert failure, so only a non-allowlisted error is shown).
+- **dead-frame** — low luma **variance** of the **canvas-clipped screenshot** (the true
+  composited frame). Not `gl.readPixels` (returns black on `preserveDrawingBuffer:false`)
+  and not in-page `drawImage(canvas)` (reads blank on the on-demand-render apps). A
+  dark-but-alive frame (ComplexParticles, variance ~3000) passes; a blank one fails.
+
+It is **not** a substitute for a real-device pass — `phone-needed` stays a standing
+signal — it closes the no-cost tier. CI runs it as a **non-blocking** PR check
+(`.github/workflows/smoke.yml`, `continue-on-error`); promote to a hard gate once it's
+proven quiet.
+
 ## Environment / network notes
 
 - **Network**: works under the default **Trusted** policy — Chrome-for-Testing

--- a/docs/sessions/RECIPES.md
+++ b/docs/sessions/RECIPES.md
@@ -41,7 +41,12 @@ npm run build && (npm run preview &) && sleep 3
 node scripts/shoot.mjs '#/<route>' shot.png
 ```
 
-…then **Read `shot.png`** and confirm the pixels match the intent.
+…then **Read `shot.png`** and confirm the pixels match the intent. For the
+**first-person walkers**, reproduce the *exact* frame with a debug-pose deep link
+instead of the default view, and add `?hud` to record the engine's own diagnostics:
+`node scripts/shoot.mjs '#/solid-worlds?world=half-turn&x=0.4&z=-0.3&yaw=0.8&cam=third&hud' shot.png`
+(vocabulary in `docs/HEADLESS_WEBGL.md`). If the change could crash/blank a route at
+a mobile viewport, also run **`npm run smoke`** (390×844, all routes).
 
 **DONE WHEN** I've actually looked at the image. If the claim is about touch,
 "feel", or real-device behavior that a headless shot can't show, set

--- a/docs/sessions/RECURRING_LESSONS.md
+++ b/docs/sessions/RECURRING_LESSONS.md
@@ -56,7 +56,7 @@ Status legend:
 
 | # | Recurring lesson | ~Freq | Status | Rule lives in | Check |
 |---|------------------|-------|--------|---------------|-------|
-| **L1** | Verified headless, never on a real device — visual/touch/"feel" claims ship as hypotheses; the one defect class that escapes CI is mobile/runtime | ~14 | 🟡 Promoted (rule) | self-reflection Q7 (declare the method + set `visual-unverified`/`phone-needed`); `signals:` in REPORT_STYLE §1.2 | Linter heuristic warns when a handoff says "headless/unverified" but declares no signal (`lint-sessions.mjs`). **Missing the positive check:** the deep-link debug-pose harness + headless mobile-viewport smoke (Tier-1 recs 2–3) — see TODO.md |
+| **L1** | Verified headless, never on a real device — visual/touch/"feel" claims ship as hypotheses; the one defect class that escapes CI is mobile/runtime | ~14 | 🟢 Promoted (rule + check) | self-reflection Q7 + recipe **R1** (declare the method + set `visual-unverified`/`phone-needed`); `signals:` in REPORT_STYLE §1.2 | **Positive check now built** (`headless-mode-plan` branch): the deep-link debug-pose harness + dev HUD (`src/lib/debugPose.ts`; reproduce an exact walker frame for `shoot.mjs`) **and** the 390×844 mobile smoke (`npm run smoke` → `scripts/smoke.mjs`, non-blocking CI in `smoke.yml`). Plus the lint heuristic in `lint-sessions.mjs`. See `docs/HEADLESS_WEBGL.md` |
 | **L2** | Build the full feature, then ask — the maximal/wrong-reading version finished before a cheap "how far / which meaning?" check; 3–5 build-revert cycles. *Refined 2026-06-23:* the cost is **avoidable thrash** (a knowable target guessed at), not **exploratory iteration** (the target is only discoverable by building) — the lever is sharper inputs (a reference in any modality), not more up-front planning | ~9 | 🟡 Promoted (rule) | `BUILDING_AN_APP.md` top callout + recipe **R2** ("separate exploring from guessing") | Not automatable; relies on the build-flow reflex + three-hats reviews |
 | **L3** | A green check that wasn't a real check — an invariant/probe passed while the user-visible result was wrong (matching H₁/χ on a broken complex; chirality probe green on a teleporting world) | ~6 | 🟡 Promoted (rule) | self-reflection Q7 ("does each passing check test the user-visible claim?") | No generic detector possible; the harness in L1 would have caught the specific topology cases |
 | **L4** | Missing committed unit tests for testable pure logic — pure math/engine verified with throwaway `/tmp` scripts that never land, despite the vitest harness existing | ~6 | 🟡 Promoted (rule) | `BUILDING_AN_APP.md` §6 ("Test pure logic on write") + §7 checklist | No detector yet (can't tell a "should-be-tested" module from a view); could later assert per-app `__tests__/` coverage of `lib/`-style helpers |
@@ -79,12 +79,12 @@ makes the next drift loud instead of silent.
 
 ## Still to enact (tracked in `TODO.md`)
 
-The two highest-ROI checks named by the audit are speced but not built — they live
-in the backlog so this ledger stays honest about what is rule-only vs rule+check:
-
-- **L1 positive check** — deep-link debug-pose harness (URL → camera/world/pose for
-  `shoot.mjs`) + an opt-in dev HUD, and a headless mobile-viewport smoke pass
-  (390×844, assert no console error / no NaN-in-shader across routes). Requested
-  independently three times across the topology sessions.
-- Add **`package.json`** to the append-only protected-file list (the one real
-  conflict-marker near-miss landed there, not in CLAUDE.md/apps.ts/index.tsx).
+- **L1 positive check — BUILT** (2026-06-23, `headless-mode-plan` branch). The
+  deep-link debug-pose harness + dev HUD (`src/lib/debugPose.ts`,
+  `src/components/DebugPoseHUD.tsx`; adopted by Polygon Worlds + Solid Worlds) and
+  the 390×844 mobile smoke (`npm run smoke`, `scripts/smoke.mjs`, non-blocking CI in
+  `.github/workflows/smoke.yml`) now exist; L1 is 🟢. Documented in
+  `docs/HEADLESS_WEBGL.md`. *Remaining follow-up:* Solid Worlds still lacks a genuine
+  *independent* witness (Polygon Worlds has one — its ink probe); filed in `TODO.md`.
+- **`package.json` on the append-only protected-file list — DONE** (2026-06-23):
+  added to CLAUDE.md's Parallel-branches callout + BUILDING_AN_APP.md §8.

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -45,23 +45,23 @@ informs future rounds. Delete or check off items as they land.
   signal). Still open: requiring `signals:`/`next:` at handoff (templates + skills)
   and gating the linter in CI once the corpus is clean (140 advisory warnings remain).
 
-- [ ] [docs] !high Build the deep-link debug-pose harness + headless mobile smoke (L1 in RECURRING_LESSONS.md).
-  The highest tool-ROI item from the process audit, requested independently three
-  times across the topology sessions. (a) A URL param that sets camera/world/pose so
-  `scripts/shoot.mjs` can reproduce an exact frame, plus an opt-in dev HUD (player
-  determinant, current tile, nearest-marker distance) — turns "verified headless"
-  from a blind hypothesis into a reproducible visual diff and would have caught the
-  teleporting-world / spoofed-probe cases. (b) A `shoot.mjs` pass at 390×844 across
-  all routes asserting no console error / no NaN-in-shader — the only defect class
-  that escapes the desktop `tsc && vite build` gate (#216 Torus crash, #215 height).
-  This is the "+ check" that moves L1/L3 from rule-only to rule+check. Touches
-  app/scripts/CI, so its own branch (was Phase 5, not built in the audit branch).
+- [x] [docs] Build the deep-link debug-pose harness + headless mobile smoke (L1 in RECURRING_LESSONS.md).
+  DONE 2026-06-23 (`headless-mode-plan` branch). (a) The debug-pose deep link +
+  opt-in dev HUD: `src/lib/debugPose.ts` (URL → world/look/camera/pose) +
+  `src/components/DebugPoseHUD.tsx` (determinant · cell · nearest-marker · an
+  independent ink witness on Polygon Worlds), adopted by **Polygon Worlds** and
+  **Solid Worlds** (`setPose` added to each engine). (b) `npm run smoke`
+  (`scripts/smoke.mjs`): all routes at 390×844 — `pageerror`/`webglcontextlost`
+  load-bearing, `console.error` advisory, dead-frame = low screenshot variance;
+  PASS 17/17, non-blocking CI in `.github/workflows/smoke.yml`. L1 → 🟢; documented
+  in `docs/HEADLESS_WEBGL.md`. Remaining follow-up (filed separately): a genuine
+  independent witness for Solid Worlds.
 
-- [ ] [docs] !low Add `package.json` to the append-only protected-file list.
-  The one real conflict-marker near-miss in 50 PRs landed in `package.json`, which
-  isn't on the protected list (CLAUDE.md/apps.ts/index.tsx/README.md). Add it to the
-  append-only note in CLAUDE.md + BUILDING_AN_APP.md §8 so new scripts/deps are
-  appended, not reordered. Cheap; from the process audit (Tier-4 rec 10).
+- [x] [docs] Add `package.json` to the append-only protected-file list.
+  DONE 2026-06-23. Added `package.json` (scripts/deps appended, not reordered) to the
+  append-only note in CLAUDE.md's Parallel-branches callout and BUILDING_AN_APP.md §8.
+  From the process audit (Tier-4 rec 10); the one real conflict-marker near-miss in
+  50 PRs had landed there.
 
 - [ ] [docs] !low One "sandbox gotchas" doc for the remote-execution environment.
   Wrong default branch on clone, container reset to an old commit mid-session, 403s

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -158,6 +158,33 @@ informs future rounds. Delete or check off items as they land.
   in the existing cube engine. Reference saved locally: Conway–Rossetti, "Describing
   the Platycosms" → `docs/papers/describing-the-platycosms.pdf`.
 
+- [ ] [solid-worlds] !med Give Solid Worlds a genuine independent debug witness (like PolygonWorlds' ink probe).
+  The debug-pose HUD (`?hud`, from the headless-mode harness) shows SolidWorlds'
+  determinant/cell/pos, but — unlike PolygonWorlds, which carries an *independent*
+  geometric witness (`debugProbe`: the rendered ink's handedness, a different code path
+  that cross-checks the chart's flip bookkeeping) — SolidWorlds has **no independent
+  witness yet**. That was the three-hats pedagogy lens's revision #2 (a HUD reading the
+  same state the probe reads is an echo, not a check). Deferred in Phase 3 rather than
+  faked, because building it right is its own task and risks the exact L3
+  "green-check-that-wasn't": e.g. the per-step developing determinant is legitimately
+  −1 on a glide-reflection wrap, not +1 (an L7 handedness subtlety). SolidWorlds'
+  determinant is already the dual-verified, screw-safe invariant, so the echo risk is
+  milder than the ink case — but a real independent witness (a geometric probe measured
+  off the *rendered* scene, or a wrap-aware per-frame continuity/jump value) would make
+  the headless verification honest end-to-end and is what would catch a teleporting-world
+  regression. Plumb it into the existing `DebugState.witness` field
+  (`src/lib/debugPose.ts`) the HUD already renders.
+
+- [ ] [complex-particles] !low HDR env map fails to load — `THREE.RGBELoader: Unsupported type: 1009`.
+  Surfaced by the new mobile-smoke pass (`npm run smoke`) as an advisory warning on
+  `#/complex-particles` and `#/embed/complex-particles`: the RGBELoader is called with
+  `.setDataType(THREE.UnsignedByteType)` (= 1009), which the current three@0.163
+  RGBELoader rejects, so the HDR environment map silently fails and the viewer falls
+  back to procedural/white lighting. Benign (no crash; the fallback works) but real —
+  drop the `setDataType(UnsignedByteType)` call (or switch to `HalfFloatType`) in
+  `src/lib/textures.ts` so the HDR actually loads. Verify headless with
+  `node scripts/shoot.mjs '#/complex-particles' out.png`.
+
 - [ ] [complex-particles] !med Argand: an explainer + tools for complex / dual / split-complex numbers.
   The app already runs the affine line through all three systems via the System
   slider p=j² (Complex p<0 · Dual p=0 · Split-complex p>0). Add an explainer that

--- a/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -89,6 +89,16 @@ smoke), `RECURRING_LESSONS.md` L1→🟢, `RECIPES.md` R1, TODO check-offs,
 
 ## Open / not done
 
+> [!NOTE]
+> **Post-merge review fix (Codex P2):** a debug-pose deep link's *position* didn't
+> survive startup — the parent `useEffect([spec])` runs right after `Canvas3D`'s
+> `onMount` (children-first effect order), disposed the freshly-built engine, and
+> rebuilt it without the pose, so `?u=…&v=…` / `?x=…` settled back to default spawn
+> (world/cam/look survived as React state). Fixed by skipping that first redundant
+> rebuild in both walkers. Confirmed by reading the HUD `pos` against the URL
+> (`u=0.2,v=0.85` → HUD `pos 0.20 0.85`). The lesson: the HUD exists to make exactly
+> this visible, and the original verification didn't read it against the params.
+
 - **Solid Worlds independent witness** (`[solid-worlds] !med` in TODO) — the one
   intentional gap. PolygonWorlds cross-checks its chart bookkeeping with an
   independent geometric probe; SolidWorlds shows only the (dual-verified)

--- a/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -8,7 +8,7 @@ slug: headless-mode-plan-bbk74b
 status: completed
 build: passed
 followup: low
-pr: null
+pr: 234
 app: docs, engine
 signals: phone-needed
 next: Give Solid Worlds a genuine independent witness (filed in TODO), or fix the RGBELoader HDR finding

--- a/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -1,0 +1,164 @@
+---
+kind: handoff
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Headless mode build-out — debug-pose harness + mobile smoke (shipped)
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: completed
+build: passed
+followup: low
+pr: null
+app: docs, engine
+signals: phone-needed
+next: Give Solid Worlds a genuine independent witness (filed in TODO), or fix the RGBELoader HDR finding
+---
+
+# Headless mode build-out — debug-pose harness + mobile smoke (shipped)
+
+> [!NOTE]
+> Plan → three-hats review → pre-build experiment → 5 implementation phases, all in
+> one session. The plan + the three expert reviews + synthesis are committed in this
+> branch's `progress/` folder; this handoff distills the *implementation*.
+
+## Summary
+
+Built the **L1 positive check** — the highest-ROI item in the corpus (~14
+reflections, requested independently 3×): the missing automated check behind
+"verified headless, never on a real device." Two deliverables, both shipped and
+verified: **(A)** a deep-link **debug-pose harness + opt-in dev HUD** that lets
+`shoot.mjs` reproduce an *exact* walker frame from a shareable URL (adopted by
+Polygon Worlds + Solid Worlds), and **(B)** `npm run smoke` — a 390×844 headless
+pass over every route that fails on the runtime-crash/blank-frame class escaping
+`tsc && vite build` (**PASS 17/17**, non-blocking PR CI). `RECURRING_LESSONS.md`
+**L1 is now 🟢 (rule + check)**. Build ✓ · 64/64 tests ✓ · lint 0 errors.
+
+## What changed
+
+**Shared scaffolding (Phase 1)** — `src/lib/debugPose.ts` (app-agnostic hash-query
+pose parser + `hudEnabled` + `frozenTime` + the `DebugState` type),
+`src/components/DebugPoseHUD.tsx` (opt-in corner HUD), `src/lib/nearestMarker.ts`
+(pure, unit-tested). Nothing user-visible.
+
+**Pre-build experiment** — a one-off headless probe (in scratch) measured the two
+uncertainties the three-hats synthesis flagged, *changing* the plan:
+- **Determinism holds at idle** → the `freeze`/`t=` param is insurance, not a
+  precondition (downgraded). Walkers don't animate without input.
+- **`gl.readPixels` is unreliable** (all-black on `preserveDrawingBuffer:false`) →
+  the dead-frame detector reads the **screenshot**, not `readPixels`.
+- **Variance, not brightness** (ComplexParticles: mean 23 but variance 3086).
+- **Clean routes log baseline resource `console.error`s** (404 + cert) with
+  `pageerror`=0 → the smoke gate keys on `pageerror`+`webglcontextlost`.
+
+**Walker adoption (Phases 2–3)** — added `setPose` to each engine (PolygonWorlds
+`CoverModel`/euclidean presenter; SolidWorlds `coverEngine`, generalizing
+`recenter()`). **Position + heading only** — flipped/screw sheets are reached by
+*walking* across a seam (engine derives the frame), which sidesteps both the
+frame-seeding cost and the "det validates itself" circularity. Boot params
+(`world`/`look`/`cam`/`camd`/`yaw`/`pitch`/`x,y,z`|`u,v`/`hud`) read via a ref so
+`onMount` stays dependency-free; URL wins over session defaults; `look` overrides
+engine-level (no persisted-state clobber). PolygonWorlds carries an *independent*
+ink-handedness `witness` (`debugProbe`); SolidWorlds does **not** (deferred — see
+Open).
+
+**Mobile smoke (Phase 4)** — `scripts/smoke.mjs` + `npm run smoke`. Running it
+against the real catalog forced two calibration fixes: in-page `drawImage(canvas)`
+reads blank on the on-demand-render apps (fractals/plane-transform/correspondence),
+so it now measures variance over the **canvas-clipped screenshot** round-tripped
+through an `<img>`; and `#/trinary-lab` is a DOM Lab, reclassified. CI in
+`.github/workflows/smoke.yml` (PR-triggered, separate from `deploy.yml`,
+`continue-on-error`).
+
+**Docs + ledger (Phase 5)** — `docs/HEADLESS_WEBGL.md` (deep-link vocabulary +
+smoke), `RECURRING_LESSONS.md` L1→🟢, `RECIPES.md` R1, TODO check-offs,
+`package.json` added to the append-only protected-file list.
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`src/lib/debugPose.ts`](https://github.com/piyarsquare/animath/blob/74aff96/src/lib/debugPose.ts) | Hash-query pose parser + `DebugState` type (the convention) |
+| [`src/components/DebugPoseHUD.tsx`](https://github.com/piyarsquare/animath/blob/74aff96/src/components/DebugPoseHUD.tsx) | Shared opt-in dev HUD (mounts only on `?hud`/`?debug`) |
+| [`src/lib/nearestMarker.ts`](https://github.com/piyarsquare/animath/blob/74aff96/src/lib/nearestMarker.ts) | Pure nearest-marker distance (+ `__tests__`, 11 cases) |
+| [`scripts/smoke.mjs`](https://github.com/piyarsquare/animath/blob/74aff96/scripts/smoke.mjs) | `npm run smoke` — 390×844 all-route crash/blank check |
+| [`.github/workflows/smoke.yml`](https://github.com/piyarsquare/animath/blob/74aff96/.github/workflows/smoke.yml) | Non-blocking PR smoke CI (separate from deploy) |
+| [`src/animations/PolygonWorlds/presenters/euclidean.ts:448`](https://github.com/piyarsquare/animath/blob/74aff96/src/animations/PolygonWorlds/presenters/euclidean.ts#L448) | `setPose(u,v)` impl (inverse of `chart()`) |
+| [`src/animations/SolidWorlds/coverEngine.ts:724`](https://github.com/piyarsquare/animath/blob/74aff96/src/animations/SolidWorlds/coverEngine.ts#L724) | `setPose({u,v,w})` (generalized `recenter`) + `getChirality`/`getMapState` |
+| [`docs/HEADLESS_WEBGL.md`](https://github.com/piyarsquare/animath/blob/74aff96/docs/HEADLESS_WEBGL.md) | The user-facing doc for both deliverables |
+| [`docs/sessions/RECURRING_LESSONS.md`](https://github.com/piyarsquare/animath/blob/74aff96/docs/sessions/RECURRING_LESSONS.md) | L1 ledger row — now 🟢 (rule + check) |
+
+## Open / not done
+
+- **Solid Worlds independent witness** (`[solid-worlds] !med` in TODO) — the one
+  intentional gap. PolygonWorlds cross-checks its chart bookkeeping with an
+  independent geometric probe; SolidWorlds shows only the (dual-verified)
+  determinant. Deferred, not faked, because a wrong witness is the exact L3 trap
+  the harness exists to prevent (e.g. the per-step developing determinant is
+  legitimately −1 on a glide wrap — an L7 subtlety). Plumb into `DebugState.witness`.
+- **RGBELoader HDR finding** (`[complex-particles] !low` in TODO) — the smoke pass
+  surfaced `THREE.RGBELoader: Unsupported type: 1009`; the HDR env map silently
+  fails on ComplexParticles and falls back. Benign but real; fix in `lib/textures.ts`.
+- **Smoke → hard CI gate** — currently `continue-on-error`. Drop that once it's
+  proven quiet across a few PRs (the `sessions:lint --strict` graduation path).
+- **`freeze`/`t=`** param is parsed but no app consumes it yet (insurance for any
+  future animated/spin state).
+
+> [!CAUTION]
+> Two headless shots of the *same* deep-link URL from *separate* processes are
+> **visually identical but not byte-identical** (sub-pixel SwiftShader float
+> nondeterminism). Compare frames with a **pixel tolerance**, never `cmp`.
+
+> [!IMPORTANT]
+> The smoke CI is a **separate** workflow on purpose. `deploy.yml` sets
+> `PUPPETEER_SKIP_DOWNLOAD` (no Chrome) and the Pages runner lacks SwiftShader libs —
+> don't move the smoke step into it.
+
+## Context
+
+- Branch is off `main` (not stacked); diff is ~3041 insertions across src/scripts/
+  docs, no unrelated work. Append-only shared files touched: `package.json` (added
+  `smoke` script), `CLAUDE.md`, plus the docs ledger — all additive.
+- The walkers early-return on `inFormField()` (typing in a panel mustn't drive the
+  scene); the HUD/pose wiring left that untouched.
+- Verify any walker pose change headless with a deep link, not the default view:
+  `node scripts/shoot.mjs '#/solid-worlds?world=half-turn&x=0.4&z=-0.3&yaw=0.8&cam=third&hud' shot.png`.
+
+## Self-reflection
+
+1. **What would you do with another session?** Build the Solid Worlds independent
+   witness (the deferred item) so its headless verification is honest end-to-end like
+   PolygonWorlds', and fix the RGBELoader HDR bug the smoke surfaced. Both are filed.
+2. **What would you change about what you produced?** The DebugPoseHUD position is a
+   hand-tuned corner offset (`top:180,right:12`) chosen to dodge each walker's
+   existing overlays — fragile if those overlays move. A more robust approach would
+   anchor it relative to a known-empty region or render it via portal above the
+   panels.
+3. **What were you not asked that you think is important?** Whether the deep-link
+   vocabulary should also drive the *non-walker* WebGL apps (fractals center/zoom,
+   particle camera) — they'd benefit from reproducible frames too, but it was
+   deliberately out of scope ("walkers first").
+4. **What did we both overlook?** Initially, that cross-process renders aren't
+   byte-identical — the determinism concern was framed as within-frame, but the real
+   subtlety is process-to-process. Caught it during Phase 2 verification and
+   documented the pixel-tolerance rule.
+5. **What did you find difficult?** Deciding the Solid Worlds witness honestly. The
+   pull to surface *something* labeled "independent witness" was strong, but every
+   cheap candidate was either an echo of the determinant or an L7 trap (per-step det
+   is −1 on glide wraps). Choosing to defer rather than fake it was the right call but
+   not the comfortable one.
+6. **What would have made this task easier?** A shared "diagnostics overlay" slot in
+   the workspace chrome (a designated, collision-free HUD region) would have removed
+   the per-app position tuning.
+7. **How did you verify this, and does each passing check test the user-visible
+   claim?** Mixed, and mostly real: `nearestMarker` by committed vitest (11 cases);
+   the harness by **headless screenshots I actually read** (PolygonWorlds klein/torus,
+   SolidWorlds half-turn — every param visibly took); the smoke pass by running it to
+   PASS 17/17 *and* watching it correctly FAIL (trinary-lab dead-frame, the RGBELoader
+   warning) before calibration; reproducibility by a real two-shot `cmp` that revealed
+   the byte-vs-visual nuance. The one **proxy**: the smoke's dead-frame variance is a
+   blank-detector, not a correctness check — SwiftShader tolerates the NaN real mobile
+   GPUs crash on, so a green smoke ≠ correct mobile render. That's documented, and
+   `phone-needed` stays a standing signal (set in frontmatter).
+8. **Follow-up value:** LOW — the deliverables are complete and verified; the two
+   open TODO items (SolidWorlds witness, RGBELoader fix) are enhancements/cleanup, not
+   corrections to what shipped.

--- a/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/handoff/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -147,10 +147,14 @@ smoke), `RECURRING_LESSONS.md` L1→🟢, `RECIPES.md` R1, TODO check-offs,
    vocabulary should also drive the *non-walker* WebGL apps (fractals center/zoom,
    particle camera) — they'd benefit from reproducible frames too, but it was
    deliberately out of scope ("walkers first").
-4. **What did we both overlook?** Initially, that cross-process renders aren't
-   byte-identical — the determinism concern was framed as within-frame, but the real
-   subtlety is process-to-process. Caught it during Phase 2 verification and
-   documented the pixel-tolerance rule.
+4. **What did we both overlook?** Two things. (a) Cross-process renders aren't
+   byte-identical — caught during Phase 2 and documented (pixel-tolerance rule).
+   (b) **The pose-survival bug** (Codex P2): a debug-pose deep link's *position* was
+   silently discarded by the mount-time engine rebuild. My verification read the HUD
+   for world/cam/look but never compared the HUD's `pos` to the URL's `u,v`/`x,y,z` —
+   so the one check the HUD was built to enable is exactly the one I skipped. A
+   reviewer bot caught it; fixed + re-verified by reading `pos` against the params.
+   This is a live instance of L1/L3 ("verified headless ≠ tested the specific claim").
 5. **What did you find difficult?** Deciding the Solid Worlds witness honestly. The
    pull to surface *something* labeled "independent witness" was strong, but every
    cheap candidate was either an echo of the determinant or an L7 trap (per-step det
@@ -160,15 +164,18 @@ smoke), `RECURRING_LESSONS.md` L1→🟢, `RECIPES.md` R1, TODO check-offs,
    the workspace chrome (a designated, collision-free HUD region) would have removed
    the per-app position tuning.
 7. **How did you verify this, and does each passing check test the user-visible
-   claim?** Mixed, and mostly real: `nearestMarker` by committed vitest (11 cases);
-   the harness by **headless screenshots I actually read** (PolygonWorlds klein/torus,
-   SolidWorlds half-turn — every param visibly took); the smoke pass by running it to
-   PASS 17/17 *and* watching it correctly FAIL (trinary-lab dead-frame, the RGBELoader
-   warning) before calibration; reproducibility by a real two-shot `cmp` that revealed
-   the byte-vs-visual nuance. The one **proxy**: the smoke's dead-frame variance is a
-   blank-detector, not a correctness check — SwiftShader tolerates the NaN real mobile
-   GPUs crash on, so a green smoke ≠ correct mobile render. That's documented, and
-   `phone-needed` stays a standing signal (set in frontmatter).
-8. **Follow-up value:** LOW — the deliverables are complete and verified; the two
-   open TODO items (SolidWorlds witness, RGBELoader fix) are enhancements/cleanup, not
+   claim?** Mixed, mostly real — but with one **caught miss**. Solid: `nearestMarker`
+   by committed vitest (11 cases); the smoke pass by running it to PASS 17/17 *and*
+   watching it correctly FAIL (trinary-lab dead-frame, RGBELoader) before calibration;
+   reproducibility by a real two-shot `cmp` revealing the byte-vs-visual nuance. The
+   **miss**: I verified the harness by reading screenshots for world/cam/look, but
+   *not* the `pos` value against the exact URL params — so a real correctness bug (pose
+   not surviving startup) shipped to the PR and was caught in review, then fixed and
+   re-verified by reading `pos` (`u=0.2,v=0.85` → HUD `pos 0.20 0.85`). The standing
+   **proxy**: the smoke's dead-frame variance is a blank-detector, not a correctness
+   check — SwiftShader tolerates the NaN real mobile GPUs crash on, so green smoke ≠
+   correct mobile render. Documented; `phone-needed` stays a standing signal.
+8. **Follow-up value:** LOW — the deliverables are complete and verified (incl. the
+   reviewer-caught pose-survival fix, re-verified against the HUD); the two open TODO
+   items (SolidWorlds witness, RGBELoader fix) are enhancements/cleanup, not
    corrections to what shipped.

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-consultant.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-consultant.md
@@ -1,0 +1,520 @@
+---
+kind: three-hats
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Expert consultant review — headless debug-pose harness + mobile smoke
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: proposed
+build: n/a
+followup: high
+pr: null
+app: docs, engine
+signals: needs-dan
+next: Resolve the determinism gap (freeze time / settle-on-idle) before Phase 4 is treated as a real gate
+---
+
+# Expert consultant review — headless debug-pose harness + mobile smoke
+
+## Plan under review
+
+<details><summary>Original request</summary>
+
+Review the headless-mode build-out plan at docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md — the deep-link debug-pose harness + dev HUD for the topology walkers, and the 390x844 headless mobile smoke pass.
+
+</details>
+
+I am wearing the **Architecture & Quality / front-end systems** hat: no attachment
+to the existing code, judging the plan on its structural merits, its
+maintainability, and — because this is fundamentally a *verification* proposal —
+on whether the proposed checks actually catch the defects they claim to catch.
+
+## Executive summary
+
+This is a well-scoped, well-phased plan whose **two halves are not equally
+sound**. Deliverable A (deep-link debug-pose + HUD) is structurally excellent:
+it reuses an established URL-as-state pattern, draws the right boundary between a
+generic parser and per-app mapping, and adds exactly one new computation. I would
+ship it close to as-written.
+
+Deliverable B (mobile smoke) is **directionally right but under-specified on the
+one axis that matters most for a screenshot harness: determinism**. The plan
+selects three good detectors but never addresses how it gets a *reproducible
+frame* out of a continuous-rAF, `getDelta()`-timed walker. A `WAIT_MS` settle is
+not a frame-pinning strategy; it is a race. The `readPixels` "dead-frame"
+detector is the weakest of the three and, as specified, will be the flakiest
+thing in CI. And the plan's stated honest caveat — SwiftShader tolerates the exact
+NaN that #216 exploited — quietly undercuts B's headline justification more than
+the plan admits.
+
+My verdict: **approve A; approve B's *console + context-loss* detectors;
+send the determinism strategy and the dead-frame detector back for a design
+pass before B is wired anywhere near a gate.** Details below.
+
+| Area | Assessment |
+|---|---|
+| A0 generic helper vs per-app mapping boundary | ✅ correct, composes beyond two walkers |
+| A1 `setPose` engine seam | ✅ right seam; SolidWorlds needs care (below) |
+| A2 URL-wins-over-persisted rule | 🟡 right default, but a real precedence trap |
+| A3 HUD overlay (render-prop / rAF polling) | ✅ sound; tree-shaking claim needs a check |
+| A4 nearest-marker pure helper | ✅ exemplary — the one new bit, unit-tested |
+| B determinism / frame-pinning | ❌ **the blind spot** — unaddressed |
+| B1/B2 console + context-loss detectors | ✅ the real value; catch the #216 class |
+| B2 readPixels dead-frame detector | 🟡 weak proxy, flaky as specified |
+| B "catches #216 on SwiftShader" | ⚠️ overclaimed — see §6 |
+| Query location (`hash` vs `search`) | 🟠 latent inconsistency with `polydebug` |
+
+---
+
+## 1 · Pattern recognition — what this resembles, and what to borrow
+
+The plan is, at heart, two well-known patterns. Naming them sharpens what "good"
+looks like and exposes the corners the plan skips.
+
+**Deliverable A is URL-as-state / deep-linkable state** — the same pattern as a
+router query, Redux-state-in-URL, or a Grafana/Observable "permalink to this
+view." The canonical concerns of that pattern are: (a) a single parse seam,
+(b) precedence vs other state sources, (c) round-tripping (can the app *emit* the
+URL it can *consume*?), and (d) graceful degradation on unknown/garbage params.
+The plan nails (a) and (d) explicitly, addresses (b) (the "URL wins" rule), and —
+notably — **skips (c)**. See §4.
+
+**Deliverable B is a headless smoke / golden-frame harness** — the Puppeteer/
+Playwright smoke pattern. Prior art here is mature and the plan should lean on its
+lessons harder than it does:
+
+- **Settle-on-idle, not fixed sleep.** Every robust visual-regression tool
+  (Playwright's `toHaveScreenshot`, Percy, Loki, Storybook test-runner) learned
+  the same lesson: a fixed `WAIT_MS` is a flake generator. They settle on a
+  *signal* — network idle, fonts loaded, an explicit `window.__ready` flag, or
+  animation disabled. The plan keeps `WAIT_MS ~3500` from `shoot.mjs`. For a
+  *screenshot you eyeball once* that's fine; for a *CI gate run 19×* it is the
+  wrong primitive (§5).
+- **Determinism is the precondition, not a nice-to-have.** Golden-frame tools
+  freeze the clock (`page.evaluate` to stub `Date.now`/`performance.now`, or
+  `clock.install()` in Playwright) and disable CSS/JS animation. The walkers run a
+  continuous rAF driven by `THREE.Clock.getDelta()` (`PolygonWorlds.tsx:145`,
+  `clockRef.current.start()` at `:141`). Two runs will *not* render the same frame
+  unless time is pinned. The plan's acceptance criterion "*lands the same view
+  twice*" (§7) is **not achievable** under the current design without a
+  frame-pinning mechanism the plan does not specify. This is the headline gap.
+
+> [!CAUTION]
+> **Gotcha — the plan asserts a property it has no mechanism to deliver.**
+> Acceptance criterion 1 ("the same view twice") requires a deterministic frame.
+> The walkers' pose is mostly input-driven (good — no input means no movement), so
+> a *static* pose may in practice be stable. But the *lighting, fog, and any
+> idle animation* still ride a wall-clock-timed loop, and `getDelta()` returns a
+> nonzero first delta whose size depends on load latency. The plan must either (a)
+> prove the walker frame is time-invariant when idle, or (b) add a freeze hook.
+> Right now it does neither.
+
+---
+
+## 2 · Structural soundness — are the boundaries right?
+
+This is the plan's strongest dimension, and I want to be specific about *why* the
+A-side boundaries are good, because they are the part most likely to be eroded
+during implementation.
+
+### 2.1 The three-layer split is correct
+
+```
+lib/debugPose.ts        — generic: parse the query, typed accessors, hudEnabled()
+  (per app) boot mapping — semantic: which param drives which piece of state
+  engine.setPose(...)    — mechanical: write pose into the developing-map closure
+```
+
+This is the right factoring. The helper knows *nothing* app-specific (it parses
+`URLSearchParams` and coerces), the **mapping** (does `z` mean cube-z or
+chart-w?) lives in the app where the semantics live, and the **mechanism**
+(`setPose`) lives in the engine that owns the closure state. Each layer can change
+without touching the others. This composes past the two walkers: any future app
+opts in by importing `debugPose` and writing its own ~6-line mapping. The plan is
+right to resist a single opaque `pose=` blob — named scalars are the correct
+choice for *hand-authored* debug URLs, and it justifies that explicitly.
+
+### 2.2 `setPose` is the right seam — but it is not symmetric work across the two engines
+
+The plan frames `setPose` as "the missing inverse of the existing getter,"
+symmetric across both walkers. It is **not** symmetric, and the plan slightly
+undersells SolidWorlds' difficulty:
+
+| | PolygonWorlds | SolidWorlds |
+|---|---|---|
+| Existing read | `getPose()` + `getMapState()` (`engineTypes.ts:51-54`) | `getMapState()` + `getChirality()` |
+| Existing reset | (none explicit) | `recenter()` (`coverEngine.ts:720-723`) |
+| Pose state to set | chart `u,v` + heading (presenter-internal) | `pos`, `bodyLinear`, `cell`, `yaw/pitch` |
+| Difficulty | writes go *through the CoverModel presenter* | writes the developing-map frame directly |
+
+For SolidWorlds, `setPose` must seed `pos`, **reset `bodyLinear` to identity and
+`cell` to `{0,0,0}`**, then place position — i.e. it is `recenter()` plus a
+position/heading write, which the plan correctly identifies ("generalize
+`recenter`"). Good. The subtle part the plan flags but should *emphasize*: setting
+a position is one thing; setting it **on the correct orientation sheet** is the
+L7 orientation problem all over again. If you teleport into a flipped cell you
+must decide whether `bodyLinear` carries the flip. The plan's answer — "the HUD's
+determinant readout is the check" — is clever (the harness validates itself) but
+means **`setPose` for SolidWorlds is only meaningful for poses within the home
+fundamental cube** (det = +1, cell = origin). That is a real semantic limitation
+and should be stated as such: *the deep link reproduces a pose in the
+fundamental domain; it does not reproduce "having walked through three glide
+reflections."* For a debug harness that is the right scope — but say it.
+
+For PolygonWorlds the harder issue is the opposite: pose is owned by the
+*presenter* (`cover.chart()` / `cover.pose()` are reads at
+`fundamentalSquareEngine.ts:152,162`), and there are **three** presenters
+(euclidean/spherical/hyperbolic). A `setPose(u,v)` written against the euclidean
+presenter may be meaningless or unimplemented for the spherical one. The plan says
+"write the cover's chart position" as if `CoverModel` has one setter; it does not
+today. **`setPose` on PolygonWorlds is really `CoverModel.setChart?.()` across
+three presenters, optional per presenter** — which is fine, but it is more surface
+than "add one method to the interface." Phase 2 is not as cheap as billed.
+
+### 2.3 The query-location inconsistency (latent bug)
+
+The plan's helper reads the query from **inside the hash**:
+
+```ts
+new URLSearchParams(window.location.hash.split('?')[1] ?? '')   // #/poly?u=0.3
+```
+
+But the **existing** PolygonWorlds debug hook reads the query from
+`location.search` — the *real* query string before the `#`:
+
+```ts
+if (location.search.includes('polydebug')) { … }   // PolygonWorlds.tsx:105
+```
+
+These are two different places a `?…` can live. The router splits on the hash
+(`index.tsx:65`, `hash.split('?')[0]`), so the *app's* convention is hash-query —
+making the plan's choice the correct one. But it means **`?hud` and `?polydebug`
+would live in different parts of the URL**, which is a maintenance trap: a future
+reader will copy one and wonder why the other doesn't fire. The plan should
+either (a) migrate `polydebug` to the same hash-query seam as part of Phase 2
+(cheap, and unifies the debug story), or (b) explicitly document the split. Right
+now it does neither, and "reuse the `polydebug` precedent" (§2 of the plan) papers
+over the fact that the precedent reads a *different query*. Flag and unify.
+
+> [!IMPORTANT]
+> **Recommendation.** Fold `polydebug` into `debugPose` (it becomes
+> `hudEnabled()` plus the typed accessors) during Phase 2, so there is **one**
+> debug-query convention, read from **one** place. This is the cheapest moment to
+> do it and it removes the inconsistency before SolidWorlds copies the pattern.
+
+---
+
+## 3 · Verification & contracts — the three detectors
+
+This is the core of a verification proposal, so I will be blunt about each
+detector's strength.
+
+### 3.1 Detector 1 — console / pageerror scraping ✅
+
+Correct and cheap. Already half-wired in `shoot.mjs:52-54`. The only refinement:
+the current code *logs* console errors; the smoke script must *record and fail* on
+them, and it should **allow-list** known-benign warnings or it will be noisy
+(Three.js emits deprecation warnings; the HDR loader can warn). The plan says
+"record + fail" — good — but does not mention an allow-list, which it will need on
+first contact with reality. Add one.
+
+### 3.2 Detector 2 — `webglcontextlost` via `evaluateOnNewDocument` ✅✅
+
+This is the **best** detector in the plan and the one genuinely tied to the #216
+defect class. Registering the listener *before* boot is exactly right (the app has
+no such handler today — confirmed: no `webglcontextlost` anywhere in the engines).
+This is the seam that would actually have caught the #216 Torus crash, because —
+as the plan correctly notes — Three.js swallows shader-compile failures and the
+symptom was context loss, not a console error. Keep this always-on, no allow-list,
+hard signal. If only one detector survives to become a gate, it should be this
+one.
+
+One addition: also listen for `webglcontextcreationerror` on the canvas, which
+fires when context creation *fails* outright (a different failure mode from a lost
+context). Cheap, same seam.
+
+### 3.3 Detector 3 — `readPixels` dead-frame scan 🟡 (the weak one)
+
+This is the detector I would not gate on, and I want to lay out exactly why, because
+the plan's own risk section gestures at the problem without resolving it.
+
+**Problem A — reliability of `readPixels` on SwiftShader.** `readPixels` against
+the *default framebuffer* after a Three.js render is fragile: the canvas may have
+been cleared/swapped, `preserveDrawingBuffer` matters (it is `true` in `Canvas3D`
+— good, but the walkers may use their own renderer config), and SwiftShader's
+async readback timing differs from hardware. Reading from the **canvas 2D context
+via `drawImage` + `getImageData`** is often more reliable than `gl.readPixels` for
+a "is this frame all one color" check, because it samples the *composited* result
+the screenshot would capture. The plan should pick the readback path
+deliberately; "`gl.readPixels` a small sample" is under-specified.
+
+**Problem B — the dark-look false-positive, and the proposed mitigation is
+hand-wavy.** The plan acknowledges `moonlit`/dark looks trip an all-black check,
+and proposes "tune thresholds, or skip readPixels for known-dark looks." That is
+not a design; it is a TODO. A threshold tuned to pass `moonlit` is a threshold
+that *also passes a genuinely dead black frame* — the two are not separable by a
+brightness threshold, which is the whole problem. Better framings:
+
+- **Variance, not brightness.** A dead frame is *uniform* (all one color, dark or
+  light); a real render — even a dark one — has spatial variance. Sample a grid of
+  pixels and fail only if their **variance is below ε** (and, optionally, the mean
+  alpha is ~0). This separates "dark scene" from "no scene" far more robustly than
+  a brightness floor. Still imperfect (a fog-saturated frame is low-variance) but
+  much better than a black-level threshold.
+- **Pin the look.** The smoke run should force a *known, mid-bright* look via
+  `SEED_LS` (the harness already supports seeding localStorage) so it never
+  samples a dark look in the first place. This is strictly better than tuning, and
+  the plan already has the mechanism — it just doesn't connect it to the
+  dead-frame detector.
+
+> [!WARNING]
+> **The dead-frame detector, as specified, will be the flakiest thing in CI.**
+> A brightness threshold cannot distinguish a dark scene from a dead one. Replace
+> it with a **variance** check and/or **force a bright look via `SEED_LS`** for the
+> smoke run. If neither is done, keep this detector *advisory-only* and never let
+> it gate — the context-loss detector is the one that earns the gate.
+
+### 3.4 What none of the three detectors catch (be honest in the doc)
+
+The plan's gap table claims B closes the "*runtime crash/NaN that only shows at a
+real viewport*" class. The three detectors catch: a thrown error, a lost context,
+and a uniform frame. They **do not** catch:
+
+- a *visually wrong but non-crashing* render at 390×844 (#215 was a *height* bug —
+  layout, not WebGL; none of the three detectors see layout). The plan lists #215
+  in its motivation table but no detector addresses it. To catch #215-class you
+  need a *layout assertion* (canvas dimensions, scroll overflow, element
+  visibility), not a framebuffer scan. Either add a cheap DOM assertion (canvas
+  fills its container; no horizontal scroll) or drop the #215 claim.
+- a NaN that SwiftShader *tolerates* — which is, by the plan's own admission, the
+  #216 mechanism. See §6.
+
+---
+
+## 4 · Maintainability & the missing round-trip
+
+**Can a newcomer follow it in 6 months?** The A-side: yes, easily — a 5-line
+parser, a documented param table, one HUD component modeled on an existing one.
+The complexity is justified and the vocabulary lock (§6 of the plan) is exactly
+the right instinct (one documented table beats each app inventing `?px=`/`?posx=`).
+
+The one maintainability gap is the **round-trip**, the (c) I flagged in §1. The
+plan lets you *consume* a pose URL but never *produce* one. In practice the most
+valuable affordance of a deep-pose system is a **"copy link to this view" button**
+(or, minimally, the HUD printing the current URL). Without it, authoring a debug
+URL means hand-computing `yaw`/`pitch`/`x,y,z` radians — exactly the friction the
+plan elsewhere optimizes away by choosing readable named params. The HUD *already
+reads* all the state it would need to emit the URL. Adding a one-line
+`?…`-string to the HUD's text output (copy-paste-able) is nearly free and turns
+"author a debug URL" from a chore into "walk there, copy the line." I would make
+this a first-class acceptance criterion, not an afterthought.
+
+> [!TIP]
+> The HUD already polls determinant / cell / pos / yaw / pitch every frame. Have it
+> render the corresponding `#/<app>?…` string as its last line. The reproduction
+> workflow becomes: walk to the bug, read the line, paste into `shoot.mjs`. That is
+> the single highest-leverage addition to the A side, and it costs ~10 lines.
+
+---
+
+## 5 · Performance & footprint
+
+| Concern | Assessment |
+|---|---|
+| HUD bundle impact when unused | 🟡 **Verify the tree-shaking claim** |
+| HUD rAF polling cost | ✅ negligible (text-only, one getter read) |
+| `nearestMarker` per-frame cost | 🟡 depends — see below |
+| Smoke wall-clock across 19 routes on SwiftShader | ⚠️ **the real cost** — quantify it |
+
+**Tree-shaking.** The plan asserts the HUD has "zero impact on the shipped UI"
+because it "never mounts unless the param is present." Mounting is a *runtime*
+guard; it does **not** remove the component from the bundle. `DebugPoseHUD.tsx` is
+imported statically by each walker, so its code ships to every user regardless of
+the `?hud` flag. For a text-only overlay this is a few KB — acceptable — but the
+plan's claim is wrong as stated. If the goal is genuinely zero shipped bytes, the
+HUD must be `React.lazy`-loaded behind the `hudEnabled()` check. I would *not*
+bother (the KB is trivial) but I *would* fix the claim: say "negligible bytes,"
+not "zero impact." Precision here matters because the same loose reasoning ("it's
+behind a flag so it's free") is how dev-only code creeps into prod bundles.
+
+**`nearestMarker` cost.** Pure and unit-tested — exemplary (this is the plan's
+best small decision and honors L4). One caveat: if it is O(markers) per frame and
+the HUD polls every frame, fine at ~dozens of markers, but note it only needs to
+run when `hudEnabled()`. The plan implies that (HUD-only) but should state it —
+don't compute nearest-marker on every shipped frame.
+
+**Smoke wall-clock — the unquantified cost.** 19 routes × (HDR load + 3.5s settle
++ readback) on *software* WebGL. ComplexParticles alone wants 3500ms; SwiftShader
+boot per route is multiple seconds. This is plausibly a **2–5 minute** CI step.
+The plan makes it `continue-on-error` (good — non-blocking), but a 3-minute
+non-blocking step that everyone learns to ignore has negative value: it costs CI
+minutes and trains people to skip the logs. Two mitigations the plan should adopt:
+(1) **parallelize** across routes (Puppeteer can run N pages, or shard); (2) settle
+on a `window.__ready` signal instead of a fixed 3.5s ceiling per route (§1) so fast
+routes don't pay the slow route's tax. As specified (serial, fixed waits) the
+wall-clock is the hidden cost that will get the step deleted in six months.
+
+---
+
+## 6 · The SwiftShader honesty problem (B's headline is overclaimed)
+
+The plan's own risk #1 is the most important sentence in the document, and it
+deserves to be elevated from "risk" to "scope boundary":
+
+> SwiftShader … *tolerates* exactly the NaN the #216 bug exploited on real
+> hardware.
+
+If that is true — and it is the standard behavior; software rasterizers clamp/skip
+NaN where a real GPU driver kills the context — then **the smoke pass cannot catch
+a #216-class NaN defect**, because on SwiftShader the bug *does not reproduce*.
+The context never gets lost, so detector 2 never fires; the frame rasterizes
+(garbage-but-not-uniform), so detector 3 may pass; nothing throws, so detector 1
+is silent. The plan lists "#216 Torus crash" as the marquee case B would catch
+(gap table, §1), and then in §6 concedes B *wouldn't* catch its NaN. **These two
+statements are in tension and the plan should resolve it in the doc, not bury the
+resolution in a risk bullet.**
+
+What B *does* honestly catch: gross failures — a route that throws on boot, a
+shader that fails to compile *and* loses the context even on SwiftShader, a
+genuinely blank render. That is real value (it closes the "did this route even
+load at a phone viewport" tier for free). But the framing must change from
+"catches #216" to "catches the *boot/blank* failures #216 was *adjacent to*; the
+NaN itself still needs `phone-needed`." The plan's "honest framing in the doc"
+instinct is right — I am asking for it to be *more* honest and to fix the gap
+table accordingly. The deferred "in-shader NaN-assert build flag" is the only
+thing that would truly catch the NaN headless; the plan is right to defer it, but
+then it must not claim the cheap path catches what only the deferred path would.
+
+---
+
+## 7 · Smaller findings
+
+- **Route list as single source — good, but watch the DOM/WebGL split.** The plan
+  routes DOM-only apps (`#/argand`, `#/agentic-sorting`, …) to console-checks-only.
+  Correct. But `#/fractals-cpu` is Canvas2D and `#/fractals` (GPU) is WebGL — the
+  split must be by *renderer*, not by "is it a fractal." The plan gets this right
+  (it lists fractals-cpu as Canvas2D) — just make the route table carry an explicit
+  `kind: 'webgl' | 'dom' | 'canvas2d'` tag so the detector dispatch is data-driven,
+  not a hand-maintained `if` ladder that drifts.
+- **`shoot.mjs` query preservation — verify, don't assume.** The plan says
+  "confirm it preserves the `?query`" (§A5). I checked: `route.replace(/^#?\/?/, '#/')`
+  operates on the *leading* `#/` only and leaves the rest (including `?…`) intact, so
+  it does preserve the query. ✅ But the plan correctly flags it as a Phase-1
+  verify-step — keep that.
+- **`preserveDrawingBuffer: true`** in `Canvas3D` (`:42`) is what makes the
+  screenshot/readPixels reliable for *those* apps. The walkers may construct their
+  own renderer (SolidWorlds calls `renderer.localClippingEnabled = true` directly on
+  a passed renderer — so they *do* use `Canvas3D`'s renderer). Confirm every smoke
+  target's renderer has `preserveDrawingBuffer` or `readPixels`-after-render may read
+  a cleared buffer. This interacts with detector 3's reliability (§3.3).
+- **`continue-on-error` graduation path is the right call.** Mirroring the
+  `sessions:lint --strict` "advisory now, gate later" pattern is exactly the
+  established convention. No objection. Just make sure the *quiet* bar for promotion
+  is "the dead-frame detector has been made non-flaky" (§3.3), not merely "it didn't
+  fail this week."
+- **StrictMode double-invoke.** `index.tsx:81` wraps the app in `StrictMode`, which
+  double-invokes effects in dev. The boot-param `setPose` lands in `onMount`; confirm
+  applying the pose twice is idempotent (it should be — it's an absolute set, not a
+  delta — but the SolidWorlds `recenter`-then-place path must be verified
+  idempotent). Cheap to check, annoying to debug if missed.
+
+---
+
+## 8 · What I would change before Phase 1
+
+1. **Add a determinism mechanism to B** (freeze the clock or prove idle-frame
+   time-invariance), or downgrade acceptance criterion 1 from "same view twice" to
+   "loads and renders." Do not ship a "reproducible" claim you can't back. *(blocking
+   for B-as-gate; not blocking for A)*
+2. **Replace the dead-frame brightness threshold with a variance check and/or a
+   forced bright look via `SEED_LS`.** *(blocking for detector-3-as-gate)*
+3. **Fix the gap table / §6 tension**: stop claiming the cheap smoke catches the
+   #216 NaN; claim what it actually catches (boot/blank). *(doc honesty — blocking)*
+4. **Add the round-trip**: HUD prints the reproducible `?…` URL. *(high-leverage,
+   non-blocking)*
+5. **Unify `polydebug` into `debugPose`** so there is one debug-query convention
+   read from one place. *(non-blocking, cheapest now)*
+6. **Correct the tree-shaking claim** ("negligible bytes," not "zero impact") and
+   gate `nearestMarker` to HUD-only. *(precision — non-blocking)*
+7. **Quantify and parallelize the smoke wall-clock**, settle-on-signal not
+   fixed-wait. *(prevents the step from being ignored/deleted)*
+
+None of these block Deliverable A's Phase 1, which is pure additive scaffolding and
+should proceed. They gate **B's promotion to anything load-bearing**.
+
+## Verdict
+
+**Approve Deliverable A; conditionally approve Deliverable B's console +
+context-loss detectors; send B's determinism strategy and dead-frame detector back
+for a design pass before either becomes a gate.**
+
+Deliverable A is the strongest part of the plan: the generic-helper / per-app-
+mapping / engine-`setPose` three-layer split is the correct factoring, it reuses an
+established URL-as-state pattern, it composes past the two walkers, and its one new
+computation is pure and unit-tested. My only substantive A asks are the missing
+**round-trip** (have the HUD emit the reproducible URL — the single
+highest-leverage addition) and **unifying the two debug-query conventions**
+(`polydebug` reads `location.search`; the new helper reads the hash-query — a
+latent inconsistency). SolidWorlds' `setPose` is meaningfully harder than the plan
+implies (it is `recenter` + place, valid only within the home cube) and
+PolygonWorlds' is presenter-plural; neither is fatal, both should be stated.
+
+Deliverable B is directionally right and its **context-loss detector is the real
+prize** — the seam that would actually have caught the #216 *symptom*. But the plan
+has a **determinism blind spot**: it claims reproducibility it has no mechanism to
+deliver, because the walkers run a wall-clock-timed rAF and the plan never freezes
+the frame. Its **dead-frame detector** cannot distinguish a dark scene from a dead
+one with a brightness threshold and will be the flakiest thing in CI as specified
+(use variance, or force a bright look via the `SEED_LS` mechanism the harness
+already has). And the plan's own honest caveat — SwiftShader tolerates the #216
+NaN — means B's marquee claim ("catches #216") is overstated and should be
+narrowed to "catches boot/blank failures." Fix the determinism story, harden the
+dead-frame detector, and correct the doc's claims, and B becomes a genuinely
+useful no-cost tier. As written, ship its console+context-loss half as advisory and
+hold the rest.
+
+## Self-reflection
+
+1. **What would you do with another session?** Actually run `scripts/shoot.mjs`
+   twice against an identical walker pose URL to empirically test whether the idle
+   frame is deterministic on SwiftShader — that single experiment would convert my
+   "determinism is unaddressed" *argument* into a *measurement* and settle whether
+   the gap is fatal or merely cosmetic. I would also prototype the variance-based
+   dead-frame check on a real dark-look screenshot to confirm it separates
+   `moonlit` from black.
+2. **What would you change about what you produced?** It is long; a maintainer in a
+   hurry needs the §0 summary table and the Verdict, and I front-loaded both, but
+   the middle could be 20% shorter. I leaned hard on the determinism point — if
+   measurement shows idle walker frames *are* stable, I over-weighted it.
+3. **What were you not asked that you think is important?** Whether the *real-device*
+   tier (`phone-needed`) has any cheaper substitute than a human with a phone — e.g.
+   BrowserStack/Sauce real-device clouds in CI. The plan and request both treat
+   real-device as irreducible; that may be a false constraint worth a sentence.
+4. **What did we both overlook?** The round-trip / "copy this view's URL" affordance
+   — the plan optimizes hard for *readable* hand-authored URLs but never lets the
+   app *emit* one, which is the higher-leverage half of a deep-link system. Neither
+   the plan nor the review request mentioned it until I named it.
+5. **What did you find difficult?** Judging SwiftShader's NaN-tolerance behavior
+   from reasoning alone — I am confident in the direction (software rasterizers
+   tolerate what drivers kill) but not in the specifics for this exact shader, and
+   that uncertainty rides directly on top of B's headline justification.
+6. **What would have made this task easier?** A captured before/after screenshot of
+   the #216 failure (what did the *broken* frame actually look like on SwiftShader
+   vs hardware?) would let me judge whether detector 3 would have caught it, instead
+   of reasoning about it abstractly.
+7. **How did you verify this, and does each passing check test the user-visible
+   claim?** Method: **reasoning + static code reading only.** I read both engines,
+   `Canvas3D`, the router, `shoot.mjs`, the existing `polydebug` hook, and the
+   verify-script conventions, and I confirmed concrete facts (the query lives in the
+   hash; `polydebug` reads `location.search` — a real inconsistency; `shoot.mjs`'s
+   regex preserves the query; no `webglcontextlost` handler exists today). I did
+   **not** run anything: I did not execute `shoot.mjs`, did not test SwiftShader's
+   NaN behavior, and did not measure idle-frame determinism — so my two most
+   load-bearing claims (the determinism gap and the SwiftShader-tolerates-NaN point)
+   are *reasoned, not measured*. They are the first things a follow-up should test.
+   Setting `signals: needs-dan` (a precedence decision and a scope-honesty call are
+   on Dan) and `followup: high` accordingly.
+8. **Follow-up value:** HIGH — the two pivotal claims (determinism gap; SwiftShader
+   masks the #216 NaN) are reasoned from code, not empirically verified, and both
+   could be settled with one 10-minute `shoot.mjs` experiment; if idle frames turn
+   out deterministic the B-side critique softens materially.

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-maintainer.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-maintainer.md
@@ -1,0 +1,485 @@
+---
+kind: three-hats
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Framework-maintainer review — headless debug-pose harness + mobile smoke
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: proposed
+build: n/a
+followup: null
+pr: null
+app: docs, engine
+signals: needs-dan
+next: Confirm the setPose-per-cover cost estimate with Dan before Phase 2/3 sizing
+---
+
+# Framework-maintainer review — headless debug-pose harness + mobile smoke
+
+## Plan under review
+
+<details><summary>Original request</summary>
+
+Review the headless-mode build-out plan at docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md — the deep-link debug-pose harness + dev HUD for the topology walkers, and the 390x844 headless mobile smoke pass.
+
+</details>
+
+The plan is `docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md`:
+a plan-only session that specs (A) a shared deep-link debug-pose harness
+(`src/lib/debugPose.ts`) + opt-in dev HUD (`src/components/DebugPoseHUD.tsx`) +
+a `setPose` setter on both walker engine interfaces, and (B) a headless
+390×844 mobile smoke sweep (`scripts/smoke.mjs`) wired as a non-blocking
+`deploy.yml` step. It is the L1 "positive check" from `RECURRING_LESSONS.md`.
+
+## Executive summary
+
+This is a **good plan with one materially under-costed seam**. The motivation is
+exactly right — L1 ("verified headless, never on a real device") is the
+single most-recurring lesson in the corpus, and the two deliverables map cleanly
+onto the two defect classes that escape `tsc && vite build` (correctness on a
+visually-wrong render; runtime crash at a real viewport). The plan correctly
+reads the codebase: it knows the router splits `?query`, that PolygonWorlds
+already has a `?polydebug` bridge, that the HUD overlays exist to copy, and that
+`shoot.mjs` preserves the query in its route arg. The phasing is sane and
+parallel-branch-aware, and it explicitly defers the SwiftShader-fidelity limit
+to honest framing rather than over-claiming.
+
+My one substantive pushback is on **A1 (`setPose`)**: the plan calls it a
+"symmetric setter" and "the missing direction," which undersells it. For
+PolygonWorlds the pose lives **three layers down** in three separate
+`CoverModel` implementations (euclidean / spherical / hyperbolic), none of
+which exposes a `setChart`/`setPose`; for SolidWorlds it means generalizing
+`recenter()` while writing into `bodyLinear`/`cell` consistently on flip/screw
+worlds — itself the L7 orientation-hardness class the harness is meant to
+expose. That is real work, not a getter's mirror image. Everything else I would
+ship close to as written, with small adjustments to the CI wiring and the
+"URL wins" rule.
+
+| Deliverable | Verdict | Risk |
+|---|---|---|
+| A0 — shared `debugPose.ts` URL parser | ✅ endorse | low — correctly minimal |
+| A1 — `setPose` on both engines | 🟡 endorse with re-sizing | **med-high** — 3-cover plumbing in PolygonWorlds; orientation-correct write in SolidWorlds |
+| A2 — apply params on boot | ✅ endorse | low-med — lazy-init ordering needs care |
+| A3 — shared `DebugPoseHUD.tsx` | ✅ endorse | low |
+| A4 — nearest-marker pure helper + test | ✅ endorse | low — exactly the L4 class |
+| B — `smoke.mjs` + detectors | ✅ endorse | med — false-positive tuning |
+| B4 — non-blocking `deploy.yml` step | 🟡 endorse with reservation | med — preview-in-Pages-CI is heavier than the lint precedent |
+
+## 1. History & context: does it repeat an abandoned approach?
+
+No — and notably, it is **enacting a ledger item rather than re-discovering a
+lesson**, which is precisely the loop `RECURRING_LESSONS.md` exists to drive
+(WRITE → READ → ENACT → RETIRE). L1 is at 🟡 *Promoted (rule)*; the "Missing the
+positive check" note in its row literally names this harness. Building it flips
+L1 toward 🟢 and is the highest-tool-ROI backlog item (`TODO.md`, requested
+independently three times). That is the system working as designed.
+
+The plan also respects history in the small:
+
+- It reuses the **`?polydebug` precedent** (`PolygonWorlds.tsx:105`) instead of
+  inventing a parallel debug channel. That existing bridge already does
+  `setYaw`, `clearTrail`, `plantSign`, `auditDecor`, `auditInk` off
+  `window.__poly` — so the "engine has a getter but the component pokes refs
+  directly for debugging" pattern is established. The new `setPose` is a
+  cleaner, typed version of `setYaw`.
+- It copies the **opt-in HUD overlay** convention (`ChiralityHUD`,
+  `SquareMiniMap`) — both rAF loops reading a getter — rather than introducing
+  React-state-driven overlays that would re-render per frame.
+- It honors the **"don't persist camera/transient view"** convention by routing
+  world/cam/look through `useState`/`usePersistentState` and only the *pose*
+  through the engine.
+
+> [!NOTE]
+> The one piece of history the plan glosses: PolygonWorlds and SolidWorlds are
+> **deliberately not factored into a shared walker engine** (L5 in the ledger
+> flags "near-parallel copy instead of factoring" as Open, and a soft
+> dedup-lint was *deliberately not added* to avoid fighting in-flight branches).
+> The plan's instinct to share `debugPose.ts` + `DebugPoseHUD.tsx` across them is
+> the *right* place to share (app-agnostic glue), precisely because the engines
+> themselves stay separate. It is not re-litigating the no-shared-engine
+> decision. Good.
+
+## 2. Scrutiny (a): is `setPose` on the engine interfaces really clean?
+
+**This is the plan's weakest claim and the place I'd push hardest.** The plan
+says (A1): "Both walkers compute pose inside an engine closure; only
+PolygonWorlds exposes a *getter*. Add a symmetric *setter*… PolygonWorlds
+already exposes `getPose()`/`getMapState()` — this is the missing direction."
+
+The reality from reading the code:
+
+### PolygonWorlds — pose is three layers deep
+
+`fundamentalSquareEngine.ts` does **not** own the pose. It delegates:
+
+```ts
+// fundamentalSquareEngine.ts:152,162
+const p = cover.pose();              // PlayerPose, read-only
+Object.assign(mapState, cover.chart());   // SquareMapState, read-only
+```
+
+`cover` is a `CoverModel` (`coverModel.ts:52`) with **three implementations**
+(`kind: 'euclidean' | 'spherical' | 'hyperbolic'`). Its interface exposes
+`update()`, `pose()`, `chart()` — all read-only — and *no* `setChart`/`setPose`.
+So "the inverse of the existing `cover.chart()`/`cover.pose()` read" is not a
+one-line setter on the engine: it requires
+
+1. a **new method on the `CoverModel` interface** (`setPose`/`setChart`), and
+2. **three implementations** — and the spherical and hyperbolic covers
+   parametrize position differently from the euclidean (a planet vs a tiled
+   plane), so "write u,v + heading" means three different internal writes, each
+   of which must also re-place the camera so the very next `update()` doesn't
+   snap back.
+
+The plan's effort estimate ("Phase 2 is the cheaper first integration… it
+already has `getPose()`") is backwards on this axis: PolygonWorlds is *cheaper
+to wire the boot params and HUD*, but *more expensive to implement `setPose`
+correctly* because of the cover indirection. SolidWorlds owns its pose directly
+in the engine closure (`pos`, `bodyLinear`, `cell` at `coverEngine.ts:65-68`),
+so its `setPose` is a more local edit.
+
+### SolidWorlds — generalizing `recenter()` is an orientation problem
+
+`recenter()` (`coverEngine.ts:720`) is trivial because it writes the **identity
+frame**:
+
+```ts
+recenter() {
+  pos.set(0, 0, 0); bodyLinear.identity();
+  cell.x = 0; cell.y = 0; cell.z = 0; hasStamp = false;
+  ...
+}
+```
+
+`setPose({x,y,z,yaw,pitch})` is not that. Setting an arbitrary in-cube position
+is fine, but the plan itself flags (Risk §6) that **`setPose` correctness on
+flip/screw worlds is itself an orientation problem (L7)**. If the deep link is
+meant to "put me at the seam facing the arch on the mirrored sheet," then
+`setPose` must be able to seed a **non-identity `bodyLinear`** (a flipped/rotated
+carried frame) — otherwise it can only ever place you on the home sheet, and the
+most valuable debug poses (the chirality cases the harness exists to reproduce)
+are exactly the ones it can't express. The plan's param table only carries
+`x,y,z,yaw,pitch` — no sheet/cell/determinant selector — so as specced,
+**`setPose` reproduces position+heading but not the developing-frame state**,
+which is the thing W1/W3 (teleporting-world, spoofed chirality) were about.
+
+> [!WARNING]
+> **Re-size A1 before committing to the phasing.** As written the plan implies
+> `setPose` is a getter's mirror. It is: (1) a new `CoverModel` interface method
+> + 3 implementations in PolygonWorlds; (2) a frame-seeding generalization of
+> `recenter()` in SolidWorlds that, to be useful for the chirality cases, needs
+> a way to express the non-identity sheet. Recommend the plan either (a) scope
+> `setPose` to position+heading only and state plainly that *sheet/holonomy is
+> reached by walking there in the deep link* (you can still author a URL that
+> teleports near a seam and take one step), or (b) add a `cell=`/`sheet=` param
+> and own the frame-seeding cost explicitly. Option (a) is the honest minimal
+> cut for this branch; (b) is the complete version. Don't let the plan ship the
+> middle, where `setPose` exists but silently can't reach the interesting poses.
+</br>
+
+A pragmatic middle the plan doesn't consider: for the chirality reproductions,
+you may not need `setPose` to *write* the frame at all — you can deep-link
+position+heading and let an extra param (`steps=`, or a target cell the walker
+auto-walks toward) drive the developing map honestly through the real gluing.
+That keeps the engine seam tiny and means the HUD's determinant readout is
+testing a genuinely-developed frame, not one you hand-set (which would be its
+own L3 "green check that wasn't a real check" risk — a hand-set determinant
+proves nothing).
+
+## 3. Scrutiny (b): the non-blocking `deploy.yml` smoke step
+
+The plan models B4 on the existing `sessions:lint -- --strict` precedent. Two
+things to separate:
+
+**The `continue-on-error` pattern itself — fine and well-precedented.** The
+deploy already runs `sessions:lint -- --strict` (deploy.yml:38). The
+RECURRING_LESSONS "meta-lesson" section explicitly documents the graduation
+path: land a check as non-blocking, prove it quiet, promote to a hard gate. A
+non-blocking smoke step fits that template exactly. Endorse the *shape*.
+
+**The *cost* of what runs inside it — heavier than the lint precedent, and in
+the wrong job.** `sessions:lint` is a fast pure-Node parse. The proposed step is
+`npm run build && (npm run preview &) && sleep 5 && npm run smoke`, which:
+
+- boots a **headless Chromium with SwiftShader** and iterates **~18 routes** at
+  a real viewport with multi-second settles each (the plan itself sets
+  `WAIT_MS ~3500` for ComplexParticles and an 8s canvas wait). That is plausibly
+  **2–5 minutes of CPU-bound software rasterization** added to the *Pages deploy
+  job* on every push to `main`.
+- requires the **puppeteer Chrome download that the deploy job currently
+  skips on purpose** — `deploy.yml:34-35` sets `PUPPETEER_SKIP_DOWNLOAD: 'true'`
+  with the comment "The Pages build doesn't screenshot anything." Adding smoke
+  to this job **reverses that deliberate optimization** and re-adds the ~150MB
+  download + the `install_headless_webgl.sh` system-lib provisioning, which today
+  only runs in the cloud `SessionStart` hook, not in GitHub Actions at all. The
+  plan does **not** account for getting SwiftShader's apt dependencies installed
+  in the CI runner.
+
+> [!IMPORTANT]
+> **Don't bolt smoke onto the Pages-deploy job.** Two cleaner options, in order
+> of preference:
+> 1. A **separate `smoke` workflow** triggered on PR / push (not gated to
+>    deploy), so a slow software-WebGL sweep never sits on the critical path to
+>    publishing the site, and so the deploy job keeps `PUPPETEER_SKIP_DOWNLOAD`.
+>    This is also more useful — you want smoke on PRs *before* merge, not at
+>    deploy time after merge.
+> 2. If it must live in `deploy.yml`, give it its **own job** that needs nothing
+>    and blocks nothing (parallel to `build`), with its own Chrome install step,
+>    so the deploy artifact upload isn't waiting on a 3-minute SwiftShader sweep.
+>
+> The plan's "mirror the `sessions:lint` step" instinct is right about
+> *blocking semantics* but wrong about *placement*: lint is cheap and shares the
+> build job's setup; smoke is expensive and needs setup that job deliberately
+> avoids.
+</br>
+
+Also verify before wiring: `npm run preview` serves at `:4173` and the plan's
+`sleep 5` may be too short for the first cold `vite preview` on a CI runner; the
+existing docs use `sleep 3` for a *local* preview but CI is colder. Prefer a
+wait-on-port loop over a fixed sleep (flaky-sleep is its own recurring CI sin).
+
+## 4. Scrutiny (c): is `debugPose.ts` over-abstraction for two adopters?
+
+**No — it's correctly minimal, and arguably it's barely an abstraction at all.**
+The proposed module is four tiny functions: `poseParams()` (the exact
+`hash.split('?')[1]` idiom already used in `TrinaryLab.tsx` and the router),
+plus `pNum`/`pBool`/`pStr`/`hudEnabled` typed accessors. This is the kind of
+6-line helper that earns its place the moment a *second* caller would otherwise
+copy-paste the `URLSearchParams` + `Number()` + `NaN`-guard dance. Two adopters
+named, a third implied (any future walker / `BUILDING_AN_APP.md` mention), and
+the parsing is genuinely identical across them.
+
+The line the plan draws is the right one: **the helper is generic (parse), the
+mapping is per-app (what `u,v` vs `x,y,z` mean)**. That keeps app-specific pose
+semantics out of the shared module, so it never grows a `switch (app)`. This is
+the opposite of premature abstraction — it's the small-shared-glue layer that
+L5's "near-parallel copy" lesson actually *wants* (share the glue, not the
+engine).
+
+One nit: `debugPose.ts` and the `?polydebug` `window.__poly` bridge will now
+coexist in PolygonWorlds. They serve different needs (test-harness poking vs
+boot-time deep-link), but the plan should say a sentence about whether
+`?polydebug` stays, gets folded into the new `hud`/`debug=1` vocabulary, or is
+left alone. Leaving it alone is fine — but name it, so the next reader doesn't
+think one supersedes the other.
+
+`DebugPoseHUD.tsx` as a shared component is a slightly bigger bet than the
+parser, since SolidWorlds wants `cell` and PolygonWorlds wants `flipped`. The
+plan's `DebugState` interface handles that with an optional `cell?` field, which
+is fine for two apps. If a third app needs a differently-shaped readout, the
+honest move is to let it pass its own rows rather than growing `DebugState` into
+a union — but that's a future concern, not a now one. Endorse as specced.
+
+## 5. Scrutiny (d): "URL param wins over persisted state"
+
+The plan proposes (Risk §6): **URL param wins over persisted/default when
+present** ("it's an explicit request"), flagged `needs-dan`.
+
+I endorse this as the default, with the framework-correctness caveat that it's
+**slightly subtle to implement given `usePersistentState`'s lazy initializer**.
+Today `usePersistentState(key, initial)` seeds from `load(key, initial)` in a
+`useState(() => …)` (usePersistentState.ts:35). To make the URL win, you
+**cannot** just set state in an effect after mount — the engine is built in
+`onMount` from refs seeded at first render (e.g. `worldRef.current = spec` where
+`spec = worldById(worldId)`), so a post-mount `setWorldId` would rebuild the
+engine (the `useEffect([spec])` rebuild path) — a visible flash and a wasted
+build. The plan's A2 already half-sees this ("set `worldId` *before* engine
+build… lazy initializer reading the param").
+
+The clean implementation is a **param-aware initial value at the
+`useState`/`usePersistentState` call site**, e.g.
+
+```ts
+const p = poseParams();            // once, module-top of the component
+const [worldId, setWorldId] = useState(() => {
+  const w = p.get('world');
+  return w && worldById(w) ? w : DEFAULT_WORLD_ID;
+});
+```
+
+For `usePersistentState`-backed values, "URL wins over persisted" means the URL
+param must be checked **before** the persisted load, i.e. the call becomes
+`usePersistentState(pk('look'), p.get('look') ?? defaultLook)` — but note that
+makes the URL value the *fallback*, and the **persisted value still wins** if one
+exists, because `load()` returns the stored value over the initial. So to truly
+make URL win you must **bypass persistence when the param is present** (pass
+`key = null` for that field when the URL sets it, or write the URL value into the
+store first). The plan should call this out concretely; "URL wins" is a one-liner
+to state and a genuine gotcha to implement, and getting it half-right yields the
+confusing "my deep link is ignored because I once changed that setting" bug.
+
+> [!IMPORTANT]
+> **Decision to confirm with Dan, and refine:** URL-wins is the right default,
+> *but only the params explicitly present in the URL should override*; absent
+> params must fall through to persisted-then-default unchanged (the plan's
+> "params absent → behave exactly as today" zero-regression promise). The
+> implementation detail above (URL param must short-circuit `usePersistentState`'s
+> load, not merely supply its `initial`) is the part most likely to be
+> mis-built; spell it out in Phase 1.
+</br>
+
+## 6. Parallel-branch safety & shared-file churn
+
+This is where I'd normally worry most, and the plan is **mostly disciplined**:
+
+| File touched | Append-only? | Plan's handling | Assessment |
+|---|---|---|---|
+| `package.json` | per open TODO, should be | adds `"smoke"` script; plan *also adds package.json to the protected list* | ✅ good — closes the TODO in-flight |
+| `deploy.yml` | not on protected list | one new step/job | ⚠️ shared infra; low conflict odds but see §3 placement |
+| `src/lib/debugPose.ts` | **new file** | additive | ✅ zero conflict |
+| `src/components/DebugPoseHUD.tsx` | **new file** | additive | ✅ zero conflict |
+| `src/animations/PolygonWorlds/*` | self-contained folder | engine + onMount edits | ✅ isolated to its app |
+| `src/animations/SolidWorlds/*` | self-contained folder | engine + onMount edits | ✅ isolated to its app |
+| `coverModel.ts` interface (PolygonWorlds) | within the app | new method + 3 impls | ✅ in-app, but see §2 cost |
+| `HEADLESS_WEBGL.md`, `BUILDING_AN_APP.md`, `RECIPES.md`, `RECURRING_LESSONS.md`, `TODO.md` | docs | additive / ledger advance | ✅ correct (ledger is a living advance, not append) |
+
+The two genuinely-shared files are **`package.json`** and **`deploy.yml`**. The
+plan handles package.json model-citizen-ly (appends the script *and* adds the
+file to the protected list, enacting the other open TODO). `deploy.yml` is the
+one to watch — but it's rarely touched by app branches, so the conflict risk is
+low; the substantive concern there is §3 (placement), not churn.
+
+> [!NOTE]
+> The plan creates **two new top-level shared modules** (`lib/debugPose.ts`,
+> `components/DebugPoseHUD.tsx`). These are new files (no conflict), but they do
+> add to the surface a new app must know about. The plan already commits to
+> documenting the convention in `BUILDING_AN_APP.md` + a `RECIPES.md` R-entry,
+> which is the right way to keep new shared surface discoverable rather than
+> orphaned. Make sure the RECIPES entry is concrete ("to verify a walker change,
+> shoot the exact pose") — that's the line that actually changes behavior.
+</br>
+
+## 7. Tech-debt ledger: does it add or reduce debt?
+
+**Net debt-reducer**, on balance:
+
+- **Reduces** the L1/L3 gap from rule-only to rule+check (the headline win).
+- **Honors L4** by committing a vitest file for `nearestMarker` — exactly the
+  "testable pure logic gets a committed test" class the ledger keeps flagging.
+  Note: `npm test` is **not a CI gate** (only `npm run build` is), so the new
+  test green-ness rides on convention — fine, but the plan shouldn't imply the
+  test *gates* anything.
+- **Closes** the package.json protected-list TODO as a side effect.
+- **Adds** a small amount of surface (two shared modules, two new engine
+  methods, one new `CoverModel` method + 3 impls). The `setPose`-per-cover work
+  (§2) is the only place it risks *adding* debt — if `setPose` is bolted onto
+  three covers hastily to hit the phase deadline, that's new branchy code in the
+  exact engines L5 already flags as long. Do it deliberately or scope it down.
+
+One consistency check the plan gets right: it keeps the HUD **`pointer-events:
+none`, text-only, never-mounted-without-the-param**, so the shipped UI is
+byte-identical without `?hud`. That's the correct "debug instrument, not a
+feature" posture and matches the existing `?polydebug` discipline.
+
+## 8. Scope: too much, too little, boundary clear?
+
+Scope was pinned (walkers first; advisory-now/gate-later smoke; plan-only this
+session) and the plan **stays inside it**. The phasing is genuinely
+independently-shippable (Phase 1 is pure additive scaffolding + a unit test; 2/3
+parallelize; 4 depends on nothing in 1–3). I'd make two scope adjustments:
+
+1. **Split Phase 1's HUD from its parser.** `debugPose.ts` + the `nearestMarker`
+   helper + its test are *truly* zero-risk and could land first/alone.
+   `DebugPoseHUD.tsx` is slightly more (it bakes the `DebugState` shape both apps
+   must satisfy) — fine to keep in Phase 1, but if `DebugState` proves contentious
+   it shouldn't block the parser landing.
+2. **Move `setPose` decision (§2) to the front.** Whether `setPose` writes the
+   developing frame or just position+heading changes the param vocabulary
+   (`cell=`/`sheet=`?) and the Phase 2/3 cost. That's a "decide before building,"
+   not a "discover while building" question (L2/L6) — answer it in the plan,
+   don't let Phase 2 discover it.
+
+The smoke detector tuning (B2.3 readPixels on dark looks) is correctly called out
+as a risk and correctly mitigated (keep console + context-loss always-on; make
+the dead-frame scan skippable per known-dark look). Good — that's the detector
+most likely to cry wolf and the plan already knows it.
+
+## Verdict
+
+**Endorse, with one re-sizing and one CI-placement change before implementation
+starts.**
+
+What I endorse as written:
+
+- The whole **motivation and framing** — this is the ledger's enact-loop working,
+  the highest-ROI backlog item, and the honest "closes the no-cost tier,
+  `phone-needed` stays" framing is exactly right.
+- **A0 `debugPose.ts`** — correctly minimal, not over-abstraction; the
+  generic-parser / per-app-mapping split is the right seam.
+- **A3/A4** — the shared HUD and the unit-tested `nearestMarker` helper (honors
+  L4); HUD discipline (opt-in, pointer-events:none, never-mounts) is correct.
+- **B detectors** — three-detector design (console + context-loss + dead-frame)
+  is sound; the context-loss listener via `evaluateOnNewDocument` before boot is
+  the right way to catch the #216-class silent failure.
+- **Parallel-branch hygiene** — new files + self-contained folders + closing the
+  package.json TODO in-flight.
+
+What concerns me / what I'd change:
+
+1. **Re-cost A1 `setPose`.** It is *not* a getter's mirror. PolygonWorlds needs a
+   new `CoverModel.setPose` + **three cover implementations**; SolidWorlds needs
+   a frame-seeding generalization of `recenter()` that, to reach the chirality
+   cases the harness exists for, must express a **non-identity developing
+   frame** — itself the L7 orientation problem. **Decide in the plan:** scope
+   `setPose` to position+heading and reach interesting sheets by *walking* in the
+   deep link (tiny seam, and the HUD's determinant then tests a genuinely
+   developed frame, avoiding a hand-set-determinant L3 trap), **or** add a
+   `cell=`/`sheet=` param and own the frame-seeding cost. Don't ship the middle.
+2. **Don't put smoke in the Pages-deploy job.** It reverses the deliberate
+   `PUPPETEER_SKIP_DOWNLOAD` optimization, needs SwiftShader apt-deps the CI
+   runner doesn't have today, and adds minutes of software-WebGL to the publish
+   critical path. Run it as a **separate PR/push workflow** (more useful — catches
+   regressions before merge) or at least its **own non-blocking job**. Replace
+   the fixed `sleep 5` with a wait-on-port loop.
+3. **Spell out "URL wins" concretely.** It must **short-circuit
+   `usePersistentState`'s load**, not merely supply its `initial` — otherwise a
+   previously-persisted value silently beats the deep link. Confirm the default
+   with Dan; only present params override, absent ones fall through unchanged.
+
+None of these block Phase 1 (pure scaffolding + test), which can start
+immediately. They block the *sizing* of Phases 2–4, which is exactly what a
+plan review is for.
+
+## Self-reflection
+
+1. **What would you do with another session?** Read the three `CoverModel`
+   implementations end-to-end (euclidean/spherical/hyperbolic) to give a concrete
+   line-count estimate for `setPose` per cover, and read the SolidWorlds
+   `develop`/`frame` path to confirm whether a non-identity `bodyLinear` can be
+   safely seeded mid-stream or only at a cell boundary. That would turn my §2
+   "re-size it" into an actual number.
+2. **What would you change about what you produced?** I leaned on the plan's own
+   risk section for the L7/flip-world point rather than independently proving
+   that `setPose` can't reach the mirrored sheet — I inferred it from the param
+   table lacking a sheet selector plus `recenter()` writing identity, which is
+   strong but not a code-traced proof.
+3. **What were you not asked that you think is important?** Whether the smoke
+   sweep should run in the *cloud agent session* (where SwiftShader is already
+   provisioned by the SessionStart hook) as the primary venue, with CI as
+   secondary — that may be the more natural home than GitHub Actions, and the
+   plan treats CI as the default without weighing it.
+4. **What did we both overlook?** The interaction between the new `?hud`/`debug=1`
+   vocabulary and the existing `?polydebug` `window.__poly` bridge — the plan
+   doesn't say whether they merge, coexist, or one retires. Minor, but a future
+   reader will wonder.
+5. **What did you find difficult?** Confirming the true cost of `setPose` without
+   reading all three cover implementations — I established the *shape* of the cost
+   (interface + 3 impls + camera re-place) from the `CoverModel` interface and the
+   engine delegation, but not the magnitude.
+6. **What would have made this task easier?** A one-line note in the plan stating
+   whether `setPose` is meant to reproduce only position+heading or the full
+   developing frame — that single ambiguity drove most of my §2.
+7. **How did you verify this, and does each passing check test the user-visible
+   claim?** Reasoning only, over the actual source: I read both engine interfaces,
+   both `onMount` paths, `coverModel.ts`, the `recenter()` impl, `deploy.yml`,
+   `package.json`, `usePersistentState.ts`, the router, and the ledger/TODO. I ran
+   no build or test (this is a plan review; build: n/a). My structural claims
+   (cover indirection, `recenter()` writes identity, the `PUPPETEER_SKIP_DOWNLOAD`
+   optimization, router preserves `?query`) are grep/read-verified; my cost
+   *magnitude* claim for `setPose` is inferred, not measured. `signals: needs-dan`
+   set (the URL-wins rule and the `setPose` scope are Dan-facing decisions).
+8. **Follow-up value:** MEDIUM — the review is sound and actionable, but the
+   `setPose`-per-cover cost should be pinned with a real read of the three cover
+   implementations before Phases 2/3 are scheduled.
+</content>
+</invoke>

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-pedagogy.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-pedagogy.md
@@ -1,0 +1,354 @@
+---
+kind: three-hats
+session: 2026-06-23-S01
+date: 2026-06-23
+title: "Three-hats — pedagogy/math-fidelity lens on the headless debug-pose harness"
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: proposed
+build: n/a
+followup: null
+pr: null
+app: docs, engine, solid-worlds, polygon-worlds
+---
+
+# Three-hats — pedagogy/math-fidelity lens on the headless debug-pose harness
+
+## Plan under review
+
+<details><summary>Original request</summary>
+
+Review the headless-mode build-out plan at docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md — the deep-link debug-pose harness + dev HUD for the topology walkers, and the 390x844 headless mobile smoke pass.
+
+</details>
+
+I am wearing one hat: the **mathematician-educator who uses these walkers to
+understand and teach topology, and cares whether the picture is TRUE**. This is
+a developer-tooling plan, not a user feature, so my question adapts: *does this
+tooling protect and improve the mathematical correctness of what ships?* A
+diagnostic HUD and a smoke pass are only worth building if they let a reviewer
+**see** that a frame is honest — and the deepest failure mode in this codebase
+is a green check that wasn't a real check (L3/W3). I will push hardest exactly
+there.
+
+## Executive summary
+
+The plan is well-aimed and reuses the right precedents (`ChiralityHUD`,
+`SquareMiniMap`, `__poly`, the `?query` router split). The deep-link harness is
+genuinely the missing positive check for L1, and a reproducible pose URL is also
+a real pedagogical artifact ("stand here, face the Klein flip"). **But the
+plan's central correctness claim is partly circular**, and three of its
+proposed readouts are *necessary but not sufficient* to catch the very bugs it
+cites. The determinant readout cannot, on its own, certify a wrong-sheet
+placement; `setPose` on a flip/screw world is itself an orientation problem that
+the HUD reading the same state cannot independently audit; and the smoke pass's
+SwiftShader caveat, while honestly named, still risks shipping false confidence
+if it ever graduates to a gate. None of these sink the plan — they sharpen it.
+
+| Concern | Severity | One-line |
+|---|---|---|
+| Determinant-alone can't catch wrong-sheet placement | 🔴 High | det = +1 is satisfied by infinitely many wrong poses |
+| HUD reads the same state the probe reads → can co-spoof | 🔴 High | the deepest L3 risk; needs an *independent* witness |
+| `setPose` self-validation is circular | 🟡 Medium | "HUD checks the set pose" only checks consistency, not truth |
+| Missing invariants a topologist needs to trust a frame | 🟡 Medium | holonomy class, last face crossed, frame continuity, distance-to-seam |
+| Pose vocabulary not yet pedagogically named | 🟡 Medium | `x,y,z` is the cube, not the *teaching moment* |
+| Smoke green ≠ correct math (false-confidence on graduation) | 🟡 Medium | honestly caveated now; the caveat must survive promotion |
+
+## 1 · Are these the right invariants to surface?
+
+The plan's `DebugState` surfaces: `determinant (±1)`, `cell`, `pos`, `yaw`,
+`pitch`, `nearestMarkerDist`, `world`, `look`. Mapped against the two documented
+defect classes it claims to close:
+
+| Defect (cited) | What actually went wrong | Does the proposed HUD catch it? |
+|---|---|---|
+| **Teleporting world** (S06) | the chirality probe *"checks orientation, not continuity"* — a discontinuous jump across the seam left orientation intact | **No, not as specified.** `determinant` + `cell` are both orientation/winding readouts. Nothing in `DebugState` measures **continuity** across a frame step. |
+| **Spoofed chirality probe** (S05) | a **pixel** probe was *"spoofed by cyan corner discs"*; the fix was a **geometric** `up×forward` frame check | Partially. The HUD reads the *geometric* `bodyLinear.determinant()`, which is the post-fix honest source — good. But see §2: if `setPose` writes a wrong `bodyLinear`, the HUD echoes the wrong value with full confidence. |
+
+> [!CAUTION]
+> **Gotcha — the headline bug this plan exists to catch is the one its HUD does
+> not measure.** S06 was a *continuity* failure that *passed* an
+> *orientation* probe. The plan's HUD is, again, an orientation/winding panel
+> (`determinant` + `cell` + `pos`). A teleport that lands you one cell over with
+> the correct handedness would read **green on every field**. The single most
+> important addition is a **continuity witness**: the magnitude of the
+> per-frame jump in developed world position (and in the body frame), flagged
+> when it exceeds a stride. The engine already knows this — `coverEngine.ts:639`
+> uses exactly `d > U*0.55 && d < size*0.7` to *skip* the wrap jump when laying
+> footprints. Surface that same `d` (and whether a wrap fired this frame) in the
+> HUD and you have caught the teleport directly.
+
+### What a topologist wants on-screen to trust a frame
+
+Beyond the proposed fields, here is the readout set I would actually need to
+*believe* a walker frame is honest. The good news: the engines already compute
+almost all of it; this is mostly *exposing* state, not new math.
+
+| Readout | Why a topologist needs it | Already computed? |
+|---|---|---|
+| **Holonomy class** (rotation+reflection, not just det) | det collapses a 2:1 worth of information; on the screw worlds the *rotation angle* is the invariant, not the sign. The `ChiralityHUD` already shows `ROTATED n°` — the dev HUD must too, not just `±1`. | Yes — `getChirality().rotationDeg` (`coverEngine.ts:727`). The plan drops it; restore it. |
+| **Last face crossed** (which generator was applied) | "which gluing did I just go through" is the single most useful debugging fact when a pose looks wrong — it tells you *which* deck element to suspect. | Partially — `cell` accumulates net crossings, but the *most-recent* axis+sign is not retained. Cheap to add (`lastWrap: {axis, sign}` in the wrap loop at `:617`). |
+| **Frame continuity** (Δpos, Δframe this step) | the L3/S06 killer; see callout above. | Computable from `pos`/`bodyLinear` deltas; the engine already gates on `d`. |
+| **Distance-to-seam** (per axis: `h() − |pos|`) | lets a deep link target *"just before the seam"* vs *"just after"* — the pedagogically load-bearing pair of frames for showing a flip. | Trivial from `pos` and `h()`. |
+| **`perStepDet` (the continuous-step det)** | the engine's own proof that *nothing local flipped*; the reversal is the loop's, not a point's. This is the distinction the whole app teaches. | Yes — `ChiralityState.perStepDet` (always 1 by construction; surfacing it *and asserting it* is the check). |
+| **Orientability of the current world** | so a `−1` readout reads as "expected on this non-orientable world" vs "bug on this orientable one". | Yes — `analysis.orientable` (PolygonWorlds `:317`); SolidWorlds has `freeness.ts` H₁. |
+
+> [!IMPORTANT]
+> **Decision I'd push:** the dev HUD should not be a *subset* of the shipped
+> `ChiralityHUD` — it should be a strict *superset*. Dropping `rotationDeg` to a
+> bare `±1` is a regression in fidelity. A topologist reading `det = −1` on the
+> quarter-turn space cannot tell a genuine screw reflection from a 90°-rotated
+> orientable frame; only the angle disambiguates. Keep the angle; add the four
+> rows above.
+
+## 2 · The deepest question — can the HUD itself be spoofed?
+
+This is the L3 question and the plan half-acknowledges it ("the HUD's
+determinant readout is the check that the set pose is on the right sheet"). I do
+not think that claim survives scrutiny.
+
+**The structural problem.** The HUD reads `getChirality()`/`getMapState()`,
+which read `bodyLinear`/`cell`/`pos` — *the exact same engine state that
+`setPose` writes and that `frame()` mutates*. So the HUD is a **mirror of the
+probe's state, not an independent witness of it**. If `setPose` puts you on the
+wrong sheet by writing a wrong `bodyLinear`, `getChirality()` faithfully reports
+that wrong `bodyLinear`'s determinant — and the HUD glows green-consistent with
+a wrong world. This is *precisely* the S05 shape (the probe and the thing it
+measured shared a representation) one abstraction level up.
+
+> [!CAUTION]
+> **A diagnostic that reads the same possibly-wrong state it is meant to audit
+> is not a check — it is an echo.** `determinant(bodyLinear)` answering
+> "is this pose's frame right-handed?" tells you the *frame you stored* is
+> right-handed. It does not tell you the frame you stored is the *correct* frame
+> for *this position in this world*. Those are different claims, and the gap
+> between them is exactly where wrong-sheet bugs live.
+
+**What an independent witness looks like.** The codebase already contains the
+template for breaking this circularity — and the plan should adopt it rather
+than reinvent it:
+
+- PolygonWorlds' `debugProbe()` measures handedness from the **rendered
+  footprint geometry** (`up×forward`), *not* from the state variable that drives
+  it (`engineTypes.ts:55`). The post-S05 fix was specifically to stop reading a
+  representation that the state could spoof and instead read a *consequence*.
+- `auditInk()` compares **mirror-print radius vs walking-shell radius** — a
+  second, geometrically-independent quantity that must agree.
+
+The analogue for the dev HUD: surface **two derivations of the same invariant
+that come from different code paths**, and flag any disagreement. Concretely:
+
+| Invariant | Path A (state) | Path B (independent) | Agreement check |
+|---|---|---|---|
+| Handedness | `bodyLinear.determinant()` | `det` of the freshest **rendered footprint** frame (`debugProbe`) | A === B or **flag** |
+| Position in cube | `pos` (engine var) | back-projected from the **camera matrix** the renderer actually used | within ε or **flag** |
+| Cell / world wrap | `cell` accumulator | sign of `worldById(world)` generator applied to raw position | consistent or **flag** |
+
+This is more than the plan scopes — but **without at least one independent
+witness, the harness reproduces the L3 failure it was commissioned to end**.
+The whole justification ("make headless verification HONEST") rests on the HUD
+not being co-spoofable, and as specified it is. I would make the
+*single-witness-is-an-echo* point a first-class risk in the plan, not a
+footnote, and add `debugProbe()` to `DebugState` for at least PolygonWorlds
+(it already exists; SolidWorlds should gain the 3D analogue).
+
+## 3 · Is `setPose` self-validation circular?
+
+The plan: *"`setPose` correctness on flip/screw worlds is itself an orientation
+problem (L7) — the HUD's determinant readout is the check that the set pose is
+on the right sheet. Good: the harness validates itself."*
+
+**"The harness validates itself" is the sentence to be most suspicious of.**
+What the determinant readout actually validates is **internal consistency**:
+that the `bodyLinear` you wrote has the determinant you intended. It does *not*
+validate **correspondence to the world** — that the pose lands on the sheet the
+mathematics says it should. On a screw world the difference is the entire bug
+class: the 2026-06-20 screw fix was *"two independent bugs"* settled only by
+*"the determinant"* plus *a finer subdivision and gluing by the whole in-cube
+orbit* (CLAUDE.md, SCREW_BUG.md). A `setPose` that seeds the wrong orbit member
+would produce a self-consistent, green-det, **wrong** frame.
+
+> [!WARNING]
+> **`setPose` introduces a new way to be wrong that the old code path didn't
+> have.** Today, every frame's `bodyLinear` is *reached continuously* from the
+> identity by composing deck generators (`coverEngine.ts:622-626`) — it is
+> correct by construction of the walk. `setPose` lets you *teleport into* a
+> frame, bypassing that construction. The determinant readout cannot tell a
+> continuously-reachable frame from one that isn't. The honest self-check is not
+> "does det read right" but **"is the set pose reachable by an actual walk?"** —
+> e.g. set the pose, then assert that `frame()`-stepping a closed loop back to
+> the origin returns `bodyLinear` to (a deck-conjugate of) identity. That is a
+> *behavioral* check on a *consequence*, and it is the kind that does not lie.
+
+Recommendation: keep `setPose`, but **scope its claim honestly in the plan** —
+"the HUD confirms the set frame is *self-consistent*; correctness on
+flip/screw worlds is verified by a round-trip walk test, not by the readout."
+And add that round-trip assertion to the unit-test set (it is pure engine logic,
+so it belongs there per L4 anyway).
+
+## 4 · Reproducibility as pedagogy — is the vocabulary expressive enough?
+
+A deep link that reproduces an exact frame is a **shareable teaching artifact**,
+and the plan rightly notes the URLs are hand-authored. As a teacher, I judge the
+vocabulary by whether I can encode a *pedagogically meaningful pose* and whether
+it is *named the way a topologist thinks*.
+
+**Expressiveness — mostly yes, with gaps:**
+
+| I want to link a student to… | Expressible today? |
+|---|---|
+| "Stand at the seam, facing the arch" | Partly — `x,y,z,yaw,pitch` can place it, but I must compute the seam coordinate by hand. A `seam=<axis>±` shorthand ("snap to the +x face") would make these URLs authorable. |
+| "The frame just *before* the Klein flip" / "…just *after*" | Only by manual ε offsets. A `seam=+x&eps=-0.02` pair would make the *before/after* couplet — the core teaching unit — trivial and exact. |
+| "After one full loop, showing you returned mirrored" | **Not expressible.** The vocabulary sets a *static* pose; it cannot express *"having walked this loop."* For a non-orientable world the *whole point* is the holonomy after a path — a static pose with `det=−1` looks identical to a bug. A `loop=x,x,y` (apply these generators) param would let a link *demonstrate* holonomy, not just assert it. |
+| "From the third-person chirality view" | Yes — `cam=third`, `camd`. Good. |
+
+> [!TIP]
+> The most valuable pedagogical link is not a *pose* but a *path*: "walk this
+> closed loop and watch the readout flip." Consider a `loop=` (or `path=`)
+> param applying a generator word, with the HUD then showing the resulting
+> holonomy. This turns the harness from a screenshot tool into a *proof
+> animation* link — and it doubles as the round-trip correctness check from §3.
+
+**Naming — adequate but not topologist-native.** `x,y,z` is the *cube*, not the
+*concept*. A topologist thinks in **face/generator** terms ("I crossed the
+A-pairing"), **chart coordinates**, and **holonomy words**. The proposed names
+won't mislead, but `seam`, `face`, `loop`/`word`, and naming the world by its
+mathematical id (`quarter-turn`, `hantzsche-wendt`) rather than an opaque slug
+would let the URL read like a sentence a topologist would say. Lock the
+*generic* names now (good instinct), but reserve room for these
+*semantic* shortcuts — they are what make the link a teaching artifact rather
+than a coordinate dump.
+
+## 5 · Is the SwiftShader caveat honest enough?
+
+The plan states it plainly: *"software WebGL tolerates exactly the NaN the #216
+bug exploited on real hardware… `phone-needed` stays."* That is the right
+disclosure, and I credit it. Two refinements:
+
+> [!CAUTION]
+> **Green smoke ≠ correct math, and green smoke ≠ runs-on-a-phone.** The smoke
+> pass detects *gross* failure (console error, context loss, dead frame). It
+> says nothing about whether the topology is right (that's deliverable A's job)
+> and — by the plan's own admission — nothing about the real-GPU NaN. The
+> danger is the **graduation step**: the plan proposes promoting smoke "to a
+> hard gate once proven quiet." A *quiet* SwiftShader gate is the most seductive
+> green-check-that-wasn't of all, because it will be quiet *precisely on the
+> NaN cases SwiftShader tolerates*. Promotion must not be read as "now mobile is
+> covered." I'd write into the plan: **the smoke gate, even when hard, never
+> retires `phone-needed`** — it is a floor (catches regressions software WebGL
+> *can* see), never a ceiling.
+
+The `readPixels` dead-frame detector is a real fidelity hazard too: a
+legitimately dark look (`moonlit`, `dusk`) is indistinguishable from a dead
+frame to an all-black test, and a *garbage* frame (the actual failure mode) need
+not be all-black. The plan notes the dark-look false-positive but not the
+**false-negative**: a NaN-corrupted frame can rasterize to plausible-looking
+non-black garbage. Frame *darkness* is a weak proxy for frame *correctness*. Far
+better, where cheap: a **golden-frame hash** per pose-deep-link (deliverable A's
+reproducibility makes this possible — same URL, same bytes, §7 already asserts
+"lands the same view twice"). That turns "did it render *something*" into "did
+it render *the* something," which is the only pixel check worth gating on.
+
+## 6 · What the plan gets right (credit where due)
+
+- **Reuses, doesn't reinvent.** `ChiralityHUD` as the HUD template, the
+  `?query` router split, `__poly` precedent, the `verify-*.ts` exit-code
+  convention — all correct precedents, all cited with line numbers.
+- **Pure helper + committed test for `nearestMarker`** honors L4 explicitly —
+  this is the lesson recurring as recently as Argand/Trees shipping testless.
+- **Non-blocking-then-graduate CI path** mirrors the `sessions:lint --strict`
+  pattern that is the codebase's established, proven-quiet graduation template.
+- **"URL param wins over persisted"** is the right default for a *debug* link
+  (explicit request beats sticky state) — confirm with Dan as flagged, but it's
+  the correct call.
+- **Honest about not replacing a real device.** `phone-needed` stays a standing
+  signal; that framing is exactly right and must be preserved through §5's
+  graduation.
+
+## 7 · Concrete additions I'd make to the plan
+
+1. **Add a continuity witness to `DebugState`** — per-frame `Δpos` and a
+   `wrappedThisFrame` flag (the engine already gates footprints on this `d`).
+   *This is the single change that makes the HUD catch the headline S06
+   teleport bug it currently misses.*
+2. **Restore `rotationDeg` and add `perStepDet` + `orientable`** to the HUD —
+   det-alone under-reports holonomy on screw worlds.
+3. **Add at least one independent witness** (`debugProbe()` for PolygonWorlds
+   now; the 3D analogue for SolidWorlds) and display *both* derivations with a
+   disagreement flag. Without this the harness can co-spoof (§2).
+4. **Re-scope the `setPose` self-validation claim** to "self-consistency, not
+   correctness," and add a **round-trip-walk unit test** (set pose → walk a
+   closed generator word → assert `bodyLinear` returns to a deck-conjugate of
+   identity). Pure logic; belongs in `__tests__/` per L4.
+5. **Add `seam`/`eps` (and ideally `loop`/`word`) params** so the
+   *before/after-the-flip* couplet and the *holonomy-after-a-path*
+   demonstration — the actual teaching units — are authorable.
+6. **Replace (or back) the dead-frame detector with a golden-frame hash** per
+   reproducible deep link; gate on *that*, not on darkness.
+7. **Write into the plan that the smoke gate never retires `phone-needed`**, and
+   that promotion to a hard gate is a regression-floor, not mobile coverage.
+
+## Verdict
+
+**Proceed — but harden the correctness story before Phase 2/3, because as
+written the harness can reproduce the exact L3 failure it was built to end.**
+The skeleton is right: reuse of `ChiralityHUD`, the reproducible deep link as a
+teaching artifact, the pure-helper-plus-test discipline, and the
+honestly-caveated smoke pass are all sound. My three load-bearing objections are
+(1) the HUD measures *orientation/winding* but the headline teleport bug is a
+*continuity* failure it would not see — add a per-frame jump witness, which the
+engine already computes; (2) a HUD reading the same `bodyLinear` the probe
+writes is an **echo, not a check** — it needs at least one independent witness
+(PolygonWorlds' geometric `debugProbe` is the existing template); and (3)
+"`setPose` validates itself via the determinant" is **circular** — det confirms
+self-consistency, not correspondence to the world, so add a round-trip-walk
+test for the real check. Fix these and the tooling genuinely protects the math.
+Ship it as specified and you get a prettier, more reproducible version of the
+green-check-that-wasn't.
+
+For the pedagogy: the reproducible link is excellent; push it one step further
+to encode *paths and seams*, not just static poses — the holonomy-after-a-loop
+link is the artifact a topology teacher actually wants.
+
+## Self-reflection
+
+1. **What would you do with another session?** Read `coverEngine.ts`'s wrap loop
+   and PolygonWorlds' `coverModel.debugProbe`/`auditInk` implementations in full,
+   and sketch the concrete `DebugState` continuity-witness fields and the
+   round-trip-walk test signature, so the recommendations land as diffs rather
+   than prose.
+2. **What would you change about what you produced?** I asserted the HUD "would
+   read green on a teleport" from the *shape* of `DebugState` plus the S06
+   finding; I did not run a teleport and observe it. The claim is well-grounded
+   (the fields are orientation/winding; S06 is documented as a continuity-not-
+   orientation failure) but it is reasoning, not a reproduction.
+3. **What were you not asked that you think is important?** Whether the smoke
+   gate's graduation to "hard gate" could be *misread* as mobile coverage — I
+   raised it unprompted because it is the next green-check-that-wasn't waiting to
+   happen.
+4. **What did we both overlook?** The plan and I both initially treated `det`
+   as the chirality check; the codebase's own S05 history (geometric probe beats
+   pixel probe) is the proof that a *single* representation is spoofable, and
+   that lesson applies one level up to the HUD itself.
+5. **What did you find difficult?** Distinguishing self-consistency from
+   correctness for `setPose` precisely enough to be actionable rather than
+   merely skeptical — the round-trip-walk test is my attempt to make the
+   distinction operational.
+6. **What would have made this task easier?** A one-line spec of the exact
+   `bodyLinear`/`cell` mutation `setPose` would perform on a screw world; without
+   it I reasoned about the orientation hazard from the existing `recenter()` and
+   the wrap loop.
+7. **How did you verify this, and does each passing check test the user-visible
+   claim?** Reasoning only, over the plan plus the cited engine source
+   (`coverEngine.ts`, both `engineTypes.ts`, the HUD components) and the
+   RECURRING_LESSONS / process-audit W1/W3 records. No code run, no frame shot —
+   this is a design review. My structural claims (HUD reads probe state; det
+   under-reports holonomy; continuity is unmeasured) are grounded in the read
+   source, but the behavioral claim ("a teleport reads green") is unreproduced.
+   Setting `visual-unverified` would be apt for any follow-up that acts on it.
+8. **Follow-up value:** MEDIUM — the verdict is sound and the additions are
+   concrete, but items 1–4 of §7 (continuity witness, independent witness,
+   round-trip test) deserve a short implementation-design pass before Phase 2 so
+   they ship *with* the harness rather than after it.
+</content>
+</invoke>

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-synthesis.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-expert-synthesis.md
@@ -1,0 +1,182 @@
+---
+kind: three-hats
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Three-hats synthesis — headless-mode build-out plan
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: proposed
+build: n/a
+---
+
+# Three-hats synthesis — headless-mode build-out plan
+
+## Plan under review
+
+<details><summary>Original request</summary>
+
+Review the headless-mode build-out plan at docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md — the deep-link debug-pose harness + dev HUD for the topology walkers, and the 390x844 headless mobile smoke pass.
+
+</details>
+
+Convergence analysis across the three expert reviews:
+
+- [Framework Maintainer](2026-06-23-S01-expert-maintainer.md) — operational/parallel-branch lens
+- [Architecture & Quality Consultant](2026-06-23-S01-expert-consultant.md) — patterns/verification lens
+- [Math-Viz & Pedagogy](2026-06-23-S01-expert-pedagogy.md) — correctness/fidelity lens
+
+## 1. Points of agreement (high confidence)
+
+All three endorse the plan's **direction** and converge on several specifics:
+
+| Agreement | Maintainer | Consultant | Pedagogy |
+|-----------|:---------:|:----------:|:--------:|
+| **Deliverable A (deep-link pose + HUD) is the strong, correct part — ship it** | ✅ | ✅ (A's three-layer split is "the plan's strongest part") | ✅ ("skeleton is right") |
+| **`lib/debugPose.ts` is correctly minimal, not over-abstraction** | ✅ | ✅ | — |
+| **Reusing `ChiralityHUD`/`SquareMiniMap` + pure-helper-with-vitest (L4) is right discipline** | ✅ | ✅ | ✅ |
+| **The smoke pass's "catches #216" claim is OVERSTATED** — SwiftShader *tolerates* the exact NaN real GPUs crash on | (implied) | ✅ narrow to "boot/blank failures" | ✅ "honest framing must go further" |
+| **The `webglcontextlost` detector is the genuine prize of the smoke pass** | — | ✅ | — |
+| **Reproducible deep-link is also a shareable teaching artifact** | — | — | ✅ |
+
+> [!IMPORTANT]
+> The unanimous read: **Deliverable A is sound and should proceed; Deliverable B's
+> *value proposition* needs to be narrowed and its detectors hardened before it
+> gates anything.** No expert wants to stop the work; all three want the
+> correctness/determinism story tightened before Phases 2–4.
+
+## 2. Points of tension (require a decision)
+
+### T1 — `setPose` scope: cheap mirror vs. owning the frame (Maintainer ⟂ Pedagogy)
+
+The **maintainer** says `setPose` is *materially under-costed*: it is **not** a
+getter's mirror. PolygonWorlds keeps pose three layers down across three `CoverModel`
+implementations with no setter; SolidWorlds' `recenter()` writes only the **identity**
+frame. To reach the chirality/flip cases the harness exists for, you'd need to seed a
+**non-identity developing frame** (the L7 problem) — which the `x/y/z/yaw/pitch` param
+table *cannot express*.
+
+The **pedagogy** expert independently lands on why seeding the frame is also *wrong*:
+"`setPose` validates itself via the determinant" is **circular** — the determinant
+confirms self-consistency, not correspondence to the world.
+
+**Resolution (the two objections cancel):** make `setPose` **position + heading only**;
+reach flipped/screw sheets by **walking or placing across a seam** and letting the
+**engine** apply the holonomy. This (a) sidesteps the maintainer's frame-seeding cost
+and (b) removes the pedagogy's circularity in one move — the frame you observe is the
+one the engine *derived*, not one the harness *asserted*. The param table stays as-is.
+
+### T2 — How much diagnostic to surface (Maintainer "resize down" ⟂ Pedagogy "add more")
+
+The maintainer wants to **limit** scope; the pedagogy expert wants **more** witnesses
+(per-frame jump/continuity witness; an *independent* probe; `loop=`/`seam=` path
+encoding; a round-trip-walk test). These reconcile because the witnesses the pedagogy
+expert wants are **cheap and already computed**: the SolidWorlds engine has a jump
+witness at `coverEngine.ts:639`; PolygonWorlds has a geometric `debugProbe` (post-S05).
+Surfacing an *existing independent* quantity is not the heavy frame-seeding the
+maintainer is guarding against — so: **keep `setPose` minimal (T1) but add the
+continuity/independent witness to the HUD.**
+
+### T3 — Where the smoke pass runs in CI (Maintainer correction to the plan)
+
+The plan §4.4 proposed mirroring the `sessions:lint --strict` `continue-on-error` step
+**inside `deploy.yml`**. The maintainer flags this as **wrong**: `deploy.yml`
+deliberately sets `PUPPETEER_SKIP_DOWNLOAD` and the Pages runner lacks the SwiftShader
+runtime libs. **Decision: a separate PR-triggered workflow**, not the deploy job. The
+"advisory-now/gate-later" graduation still holds — just in its own workflow.
+
+## 3. Blind spots (none fully addressed by the plan)
+
+> [!WARNING]
+> **B1 — Determinism. The plan claims "same view twice" but nothing freezes the
+> frame.** (Consultant; missed by the plan and the other two experts.) The walkers run
+> a wall-clock `getDelta()` rAF with time-based motion. A deep link sets the *pose* but
+> not the *clock* — two shots of the same URL can differ. **Without a freeze
+> (a `?freeze`/`t=` param, disabling animation, or settle-on-idle instead of a fixed
+> `WAIT_MS`), the harness's core promise is unmet.** This is arguably the single most
+> important gap.
+
+- **B2 — Two debug-query conventions.** PolygonWorlds' existing `polydebug` reads
+  `location.search`; the new helper reads the **hash**-query (`#/route?…`). A real
+  latent inconsistency (consultant confirmed in code) — unify them.
+- **B3 — No round-trip.** The HUD shows pose but doesn't **emit** the reproducible URL.
+  A "copy deep-link" affordance closes the loop (author a frame → get a shareable URL)
+  and is what makes it a teaching artifact (consultant + pedagogy).
+- **B4 — Dead-frame detector is brightness-based.** Can't separate a legitimately dark
+  look (`moonlit`) from a dead frame. Use **variance** instead of mean brightness, or
+  **force a bright look via the `SEED_LS` the harness already has** before the readPixels
+  scan (consultant).
+
+## 4. Recommended action
+
+**Proceed — Deliverable A, Phase 1 scaffolding, as written.** Before Phases 2–4, fold
+in the following revisions (most are *narrowing*, not new work):
+
+1. **`setPose` = position + heading only** (T1). Document that flipped/screw sheets are
+   reached by walking/placing across a seam — the engine derives the frame. Removes both
+   the under-costing and the circularity.
+2. **HUD adds an independent continuity/jump witness** (T2/B-correctness), sourced from
+   the engine quantity that already exists (`coverEngine.ts:639`; PolygonWorlds
+   `debugProbe`) — not just the determinant the probe itself reads.
+3. **Add determinism** (B1): a `freeze`/`t=` param (or settle-on-idle) so a shot is
+   actually reproducible. **This is a precondition for the acceptance criterion "lands
+   the same view twice."**
+4. **Unify the debug-query convention** (B2) and **add a "copy deep-link" round-trip**
+   (B3).
+5. **Narrow Deliverable B's claim** to *boot / blank / context-loss* failures; make
+   **console + `webglcontextlost`** the load-bearing detectors; replace the brightness
+   threshold with **variance or a forced bright look** (B4). Drop or caveat "catches
+   #216."
+6. **CI: a separate PR-triggered smoke workflow** (T3), not the Pages-deploy job.
+   `PUPPETEER_SKIP_DOWNLOAD` stays off in deploy.
+7. **"URL wins" must short-circuit `usePersistentState`'s load** (maintainer), not merely
+   supply its initial value.
+8. *Optional pedagogy stretch (defer):* `loop=`/`seam=` path encoding + a round-trip-walk
+   unit test — the holonomy-after-a-loop is what a topology teacher actually wants, but
+   it's a v2.
+
+> [!NOTE]
+> **One cheap experiment settles the two highest-stakes uncertainties** (consultant
+> flagged these as reasoned-from-code, not measured): a single `shoot.mjs` run that
+> (a) double-shoots one URL to confirm/deny the determinism gap, and (b) checks whether
+> `gl.readPixels` returns usable data on a SwiftShader framebuffer at all. Run it at the
+> top of implementation, before committing to B's detector design.
+
+Net: the plan is **endorsed in direction and in Deliverable A**; Deliverable B is
+**rescoped to what software-WebGL can honestly assert**; and one real blind spot
+(determinism) is promoted to a precondition.
+
+## Self-reflection
+
+**Q1 — What was the actual ask vs. what I did?** Synthesize three expert reviews of a
+plan into a convergence analysis. I read all three verdicts, mapped agreements/tensions/
+blind spots, and resolved the one apparent expert conflict (T1/T2) rather than just
+reporting it.
+
+**Q2 — Where did I extrapolate beyond evidence?** The T1/T2 resolution ("position+heading
+only, walk across seams, engine derives the frame") is *my* synthesis, not stated by any
+single expert — it's an inference that the maintainer's and pedagogy's objections cancel.
+It should be validated against the actual engine APIs before being treated as settled.
+
+**Q3 — What would change my conclusion?** If `setPose` position+heading alone cannot in
+fact place the walker onto a flipped/screw sheet without seeding a frame (i.e. if you
+*must* start mid-cell on the wrong sheet), T1's tidy resolution collapses and the
+frame-seeding cost is unavoidable. Unverified against code.
+
+**Q4 — Verification method.** Reasoning over three committed reports + the plan; **not**
+run against code or a live render. No build/test executed by this synthesis step.
+
+**Q5 — Biggest risk in my output?** Presenting the T1/T2 resolution with more confidence
+than an unverified API inference warrants.
+
+**Q6 — Follow-up signal.** `visual-unverified` (the underlying determinism/correctness
+claims remain reasoned-from-code until the one-shot experiment in §4 is run).
+
+**Q7 — Does each conclusion test the user-visible claim?** Partly. The synthesis
+correctly elevates the determinism blind spot (which directly governs the "reproducible
+frame" user-visible promise), but its own resolutions are design recommendations, not
+checks — they become real only when Phase 1 code + the §4 experiment run.
+
+**Follow-up value:** HIGH — the T1/T2 resolution and the determinism precondition should
+be confirmed by a short `shoot.mjs` experiment + an engine-API read before the plan is
+revised and implemented.
+</content>

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -41,6 +41,43 @@ from two prior threads:
 
 ## Working notes
 
+### 🟢 code · 15:01 — Phase 2: PolygonWorlds adopts the harness (verified headless)
+**Why:** the cheaper first integration (it already exposes `getPose`/`getMapState`/`debugProbe`); proves the convention end-to-end.
+
+Wired the debug-pose deep link + HUD into PolygonWorlds (euclidean χ=0 worlds):
+- **Engine seam (`setPose`, position+heading-only per revision #1):** added
+  `setPose?(u,v)` to `CoverModel` + implemented in the **euclidean** presenter
+  (inverse of `chart()`'s home-cell branch; resets `flipAcc=0`, clears the trail so
+  there's no streak). Threaded `setPose({u,v})` through `PolygonEngine`. Spherical/
+  hyperbolic no-op for now (optional). Heading stays the host's look-yaw — flipped
+  sheets are reached by *walking* across a seam, not seeded.
+- **Boot params** (`PolygonWorlds.tsx`): `world`/`cam`/`camd` via lazy `useState`
+  initializers (URL wins over the session default; `world` validated against
+  `WORLDS`); `yaw`/`pitch` → refs; `look` overridden **engine-level** (doesn't
+  clobber the user's persisted look); `u,v` → `engine.setPose` — all read via a ref
+  so `onMount` stays dependency-free (no new `exhaustive-deps` warning).
+- **HUD** (`?hud`/`?debug`): mounts the shared `DebugPoseHUD` showing world·look,
+  pos (u,v), yaw/pitch, **determinant** (chart flip bookkeeping) cross-checked by the
+  independent **`witness`** = ink handedness (`debugProbe`, a *different* code path),
+  plus `nearestMarker` (chart-space, via the Phase-1 helper). Guarded the witness to
+  show only when finite (empty trail after `setPose` → omit).
+- Refined `DebugState`: `jump` → a labeled `witness {label,value}` that fits both
+  walkers' independent checks.
+
+**Verified headless** at 390×844 (eyeballed PNGs): `?world=klein&u=…&v=…&yaw=…&
+look=dusk&cam=third&hud` lands the Klein bottle in third person with the HUD
+readout; `?world=torus&look=moonlit&cam=first` flips to a cool first-person torus —
+every param takes. Build ✓ · **64/64 tests** ✓ · lint 0 errors (no new warnings).
+
+> [!NOTE]
+> **Reproducibility nuance (refines revision #3 again).** Two shots of the *same*
+> deep link from *separate* Chromium processes differ by ~96 B / 336 KB — visually
+> identical, a handful of sub-pixel SwiftShader differences (cross-process float
+> nondeterminism), **not** an app pose difference. So a future visual-diff/smoke
+> gate must compare with a **pixel tolerance** (coarse hash / per-pixel threshold),
+> never `cmp`. Within a single page load the frame is byte-stable (the 14:40
+> experiment).
+
 ### 🔵 finding · 14:40 — Pre-Phase-2 experiment: measured the two reasoned-from-code uncertainties
 **Why:** the synthesis flagged determinism + `readPixels` as the highest-stakes unknowns; a single `shoot.mjs`-style run settles both before building on them.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -41,6 +41,39 @@ from two prior threads:
 
 ## Working notes
 
+### 🟢 code · 15:24 — Phase 3: SolidWorlds adopts the harness (verified headless)
+**Why:** the 3-manifold walker — where the teleporting-world / spoofed-probe bugs lived; completes the "walkers first" scope.
+
+Wired the deep-link + HUD into SolidWorlds, mirroring Phase 2:
+- **Engine seam:** generalized `recenter()` into `setPose({u,v,w})` on `SolidEngine`
+  + `coverEngine` (cube coords −1..1 → world `pos`, frame upright, cell/holonomy
+  cleared). Position only; heading is the host yaw (grounded modes re-lock `v` to
+  floor height next frame — use `fly`/`x,z` for an exact drop).
+- **Boot params** (`world`/`cam`/`camd`/`yaw`/`pitch`/`look`/`x,y,z`): lazy
+  `useState` initializers (URL wins; `world` validated against `SOLID_WORLDS`),
+  `look` overridden engine-level, `x,y,z` → `setPose`, all read via the bootRef so
+  `onMount` stays dependency-free.
+- **HUD** (`?hud`): world·look, pos (u,v,w), yaw/pitch, **determinant** (from
+  `mapState.mirrored` — the dual-verified screw-safe invariant), `cell`, and
+  `nearestMarker` = distance to the nearest cube vertex (reusing the existing
+  `CUBE_CORNERS` as markers via the Phase-1 helper).
+
+**Verified headless** at 390×844: `?world=half-turn&x=0.4&z=-0.3&yaw=0.8&look=dusk&
+cam=third&camd=8&hud` drops the walker off-center in the half-turn dicosm, third
+person, with the HUD + the existing ChiralityHUD ("ORIGINAL") both reading. Build ✓
+· **64/64 tests** ✓ · lint 0 errors.
+
+> [!NOTE]
+> **Honest scope on the independent witness (revision #2).** PolygonWorlds got a
+> genuine independent `witness` (ink handedness via `debugProbe` — a different code
+> path than the chart). **SolidWorlds carries none yet** — it has no geometric
+> ink-probe analog, and inventing one correctly is its own task (and risks the very
+> L3 "green check that wasn't" the harness exists to prevent: e.g. measuring the
+> per-step developing determinant is subtle — it's legitimately −1 on a
+> glide-reflection wrap, not +1, an L7 trap). Its determinant is already the
+> authoritative, dual-verified, screw-safe invariant, so the echo risk is milder
+> than PolygonWorlds' ink case. **Deferred** as a follow-up, not faked.
+
 ### 🟢 code · 15:01 — Phase 2: PolygonWorlds adopts the harness (verified headless)
 **Why:** the cheaper first integration (it already exposes `getPose`/`getMapState`/`debugProbe`); proves the convention end-to-end.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -41,6 +41,29 @@ from two prior threads:
 
 ## Working notes
 
+### 🟢 code · 13:42 — Phase 1 scaffolding landed (build + tests + lint green)
+**Why:** Dan approved starting Phase 1 — the pure additive scaffolding, no app behavior change.
+
+Added three app-agnostic modules + a unit test:
+- **`src/lib/debugPose.ts`** — hash-query pose parser: `poseParams()`,
+  `pNum/pBool/pStr`, `hudEnabled()`, and `frozenTime()` (the determinism param from
+  synthesis revision #3, parseable from day one). Also exports the shared
+  **`DebugState`** interface — including the independent **`jump`** witness field
+  (revision #2), so engines can import the type without pulling React.
+- **`src/lib/nearestMarker.ts`** — the one diagnostic not already computed; pure,
+  dimension-agnostic (`distance`, `nearestMarker`, `nearestMarkerDistance`).
+- **`src/lib/__tests__/nearestMarker.test.ts`** — 11 cases (2D/3D, empty, ties,
+  Infinity) honoring L4 (test pure logic on write).
+- **`src/components/DebugPoseHUD.tsx`** — shared opt-in HUD modeled on
+  `ChiralityHUD`: a `pointer-events:none` corner overlay polling a `get()` →
+  `DebugState` in a rAF loop, rendering whichever fields are present. Never mounts
+  unless `?hud`/`?debug` — zero impact on the shipped UI.
+
+Verified: `npm run build` ✓ (tsc + vite), `vitest` 11/11 ✓, `eslint` 0 errors on the
+new files. No shared registry files touched (parallel-branch safe). Next:
+Phase 2 — PolygonWorlds adoption (it already exposes `getPose()`), preceded by the
+one `shoot.mjs` determinism/`readPixels` experiment the synthesis flagged.
+
 ### 🔵 finding · 12:50 — Reviewed all headless documentation; the task is L1's two named checks
 **Why:** the focus said "review all the documentation on this problem in reports and todo" before planning.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -66,6 +66,26 @@ Why it matters (the defects it would have caught, per the audit): the
 visually-wrong render), and the **#216 Torus crash / #215 height** runtime defects
 that escape the `tsc && vite build` gate.
 
+### 🟡 milestone · 13:40 — Three-hats review complete; plan revised
+**Why:** Dan asked me to run the multi-lens review; it surfaced concrete revisions worth folding into the plan before any implementation.
+
+Ran `/three-hats` (maintainer · consultant · pedagogy + synthesis, all committed in
+this folder). Unanimous: **direction + Deliverable A endorsed**; **Deliverable B
+rescoped**. Key outcomes folded into the plan as §9:
+- **`setPose` = position + heading only** — the maintainer's "under-costed" and the
+  pedagogy's "det-validates-itself is circular" objections *cancel*: walk/place
+  across a seam, let the engine derive the frame.
+- **Determinism is the real blind spot** (consultant): walkers run wall-clock
+  `getDelta()` rAF; a pose-only link isn't reproducible without a `freeze`/`t=`
+  param. Promoted to a precondition for "same view twice."
+- **HUD needs an *independent* continuity/jump witness** (engine already computes one,
+  `coverEngine.ts:639`), not just the determinant the probe reads.
+- **Smoke: narrow to boot/blank/context-loss** (SwiftShader tolerates the #216 NaN);
+  console + `webglcontextlost` are load-bearing; CI goes in a **separate PR workflow,
+  not deploy.yml**.
+- One cheap `shoot.mjs` experiment (double-shoot + `readPixels` probe) settles the two
+  reasoned-from-code uncertainties before implementation.
+
 ### 🔵 finding · 13:10 — Walker pose surface mapped; precedents already exist
 **Why:** deliverable (a) needs the exact state, engine seams, and URL/HUD precedents to be a real plan.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -41,6 +41,34 @@ from two prior threads:
 
 ## Working notes
 
+### 🟢 code · 15:45 — Phase 4: mobile smoke harness (PASS 17/17) + CI wiring + TODOs
+**Why:** the second deliverable — the 390×844 runtime-crash check that escapes `tsc && vite build`; built on the *measured* detector design, not guesswork.
+
+Added `scripts/smoke.mjs` + `npm run smoke` + a separate non-blocking CI workflow:
+- **Detectors (grounded in the 14:40 experiment):** `pageerror` + `webglcontextlost`
+  are **load-bearing** (fail); `console.error` is **advisory** (warn) with a
+  resource-load allowlist; **dead-frame = low luma variance**.
+- **Two calibration fixes from running it against real routes** (this is why the
+  detector design had to be tested, not assumed):
+  1. In-page `drawImage(canvas)` reads **blank on the on-demand-render apps**
+     (fractals / plane-transform / correspondence don't run a continuous rAF, so
+     their buffer is already cleared) — false "dead frame." **Fix:** measure
+     variance over the **canvas-clipped puppeteer screenshot** (the true composited
+     frame), round-tripped through an `<img>` (no new deps). Now fractals reads
+     var≈3369, not 0.
+  2. `#/trinary-lab` is a **DOM/readout Lab** (its first `<canvas>` is a mini-sim),
+     not a full WebGL scene → reclassified `webgl:false` (the WebGL Observatory is
+     `#/trinary`, var≈1108).
+- **Result: PASS 17/17, exit 0**, 2 advisory warnings — a **real benign finding**
+  the smoke surfaced: `THREE.RGBELoader: Unsupported type: 1009` (the HDR env map
+  fails to load on ComplexParticles, falls back to white). Filed `!low` in TODO.
+- **CI:** `.github/workflows/smoke.yml` — PR-triggered, **separate** from
+  `deploy.yml` (which skips puppeteer's Chrome), `continue-on-error` (advisory-now /
+  gate-later, the `sessions:lint --strict` graduation path). Revision #6.
+
+Per Dan's request, filed the **SolidWorlds independent-witness** follow-up in TODO
+(revision #2, deferred from Phase 3).
+
 ### 🟢 code · 15:24 — Phase 3: SolidWorlds adopts the harness (verified headless)
 **Why:** the 3-manifold walker — where the teleporting-world / spoofed-probe bugs lived; completes the "walkers first" scope.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -41,6 +41,26 @@ from two prior threads:
 
 ## Working notes
 
+### 🟡 milestone · 16:18 — Phase 5: docs + ledger close-out; harness shipped end-to-end
+**Why:** the L1 positive check is built and verified across all 5 phases — close the loop so it stops being re-discovered.
+
+- **`docs/HEADLESS_WEBGL.md`** — added the *Debug-pose deep links* vocabulary (with
+  the cross-process byte-vs-visual caveat) and the *Mobile smoke* section (the
+  three detectors + the no-real-device caveat).
+- **`RECURRING_LESSONS.md`** — **L1 flipped 🟡 → 🟢 (rule + check)** with pointers to
+  the harness + smoke + `smoke.yml`; "Still to enact" updated (L1 built; `package.json`
+  protected-list done); the SolidWorlds-witness follow-up noted.
+- **`RECIPES.md` R1** — now points at the debug-pose deep link (`?…&hud`) and
+  `npm run smoke` for the mobile-crash class.
+- **`TODO.md`** — checked off the L1 harness line and the `package.json` protected-file
+  line; the SolidWorlds independent-witness + RGBELoader items remain open.
+- **`package.json` on the append-only protected list** — added to CLAUDE.md's
+  Parallel-branches callout + BUILDING_AN_APP.md §8 (Tier-4 rec 10).
+
+Session deliverable complete: the L1 positive check exists, is verified
+(walkers reproduce exact frames; smoke PASS 17/17), documented, and enacted in the
+ledger + recipes. Build ✓ · 64/64 tests ✓ · lint 0 errors.
+
 ### 🟢 code · 15:45 — Phase 4: mobile smoke harness (PASS 17/17) + CI wiring + TODOs
 **Why:** the second deliverable — the 390×844 runtime-crash check that escapes `tsc && vite build`; built on the *measured* detector design, not guesswork.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -41,6 +41,44 @@ from two prior threads:
 
 ## Working notes
 
+### 🔵 finding · 14:40 — Pre-Phase-2 experiment: measured the two reasoned-from-code uncertainties
+**Why:** the synthesis flagged determinism + `readPixels` as the highest-stakes unknowns; a single `shoot.mjs`-style run settles both before building on them.
+
+Ran a headless probe at **390×844** over `#/solid-worlds`, `#/polygon-worlds`,
+`#/complex-particles` (double-sampled each frame ~600 ms apart, via both a composited
+`drawImage→getImageData` path and live `gl.readPixels`). Eyeballed the PNGs — all three
+render genuine scenes (SolidWorlds 3-Torus with the avatar + FRONT sign + ChiralityHUD
+"ORIGINAL"; ComplexParticles' vivid phase cloud). Results **revise three plan
+assumptions**:
+
+1. **Determinism gap did NOT manifest at idle.** All three routes — including
+   ComplexParticles — produced **byte-identical** frames A vs B (0/128 grid cells
+   changed; mean+variance identical to 2 dp). With no input the walkers' rAF is
+   effectively static. → **Downgrade `freeze`/`t=` from a precondition to insurance**
+   for *animated* states (continuous spin, n-body Trinary). The "same view twice"
+   acceptance criterion already holds for static poses. (Still keep `frozenTime()` —
+   cheap, and needed the moment a spin is on.)
+2. **`gl.readPixels` is unreliable; the composited/screenshot path is not.** readPixels
+   returned real data for the two walkers but **all-black** for ComplexParticles
+   (preserveDrawingBuffer:false), while `drawImage→getImageData` (and the puppeteer
+   screenshot) captured all three correctly. → **The smoke dead-frame detector must
+   read the screenshot, not `gl.readPixels`.** (Confirms the consultant's suspicion
+   concretely.)
+3. **Variance, not brightness.** ComplexParticles is *dark but alive* — mean luma
+   **23**, 83% black pixels, yet **variance 3086**. A brightness/black-fraction
+   threshold would false-flag it dead; variance cleanly separates it from a blank
+   frame. → **Dead-frame check = low variance, not low brightness.**
+
+Plus a **new** finding the plan didn't anticipate:
+
+4. **Every clean route logs baseline `console.error`s** (a 404 + an `ERR_CERT_AUTHORITY_INVALID`
+   resource-load failure), but `pageerror` count was **0** and no `webglcontextlost`
+   fired anywhere. → A naive "fail on any console.error" smoke gate would false-positive
+   on **all** routes. **Key the detector on `pageerror` (JS exceptions) + `webglcontextlost`
+   as load-bearing; treat `console.error` as advisory with a resource-load allowlist
+   (`net::ERR_*`, HTTP 4xx).** Net baseline-green result: the walkers + particles throw
+   no JS exceptions and lose no context at mobile viewport.
+
 ### 🟢 code · 13:42 — Phase 1 scaffolding landed (build + tests + lint green)
 **Why:** Dan approved starting Phase 1 — the pure additive scaffolding, no app behavior change.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -66,6 +66,28 @@ Why it matters (the defects it would have caught, per the audit): the
 visually-wrong render), and the **#216 Torus crash / #215 height** runtime defects
 that escape the `tsc && vite build` gate.
 
+### 🔵 finding · 13:10 — Walker pose surface mapped; precedents already exist
+**Why:** deliverable (a) needs the exact state, engine seams, and URL/HUD precedents to be a real plan.
+
+- **URL parse precedent already in-repo:** `TrinaryLab.tsx` uses
+  `new URLSearchParams(window.location.hash.split('?')[1] ?? '')`; the router
+  (`index.tsx:65`) already splits `?query` off the path; PolygonWorlds already
+  reads `location.search.includes('polydebug')` to expose `window.__poly`.
+- **Diagnostics already computed:** SolidWorlds `getChirality()` (determinant ±1,
+  rotation angle) + `getMapState()` (u,v,w, cell) in `coverEngine.ts:724-741`;
+  PolygonWorlds `mapState.flipped` + u,v + `getPose()` exposed on the engine.
+  **Nearest-marker distance is the one quantity not yet computed** (needs a
+  landmark scan).
+- **HUD templates exist:** `ChiralityHUD` (SolidWorlds) and `SquareMiniMap`
+  (PolygonWorlds) are both rAF-loop overlays reading a getter — copy them for a
+  shared `DebugPoseHUD`.
+- **The seam to add:** PolygonWorlds engine exposes `getPose()` but **neither
+  walker exposes a pose *setter***; SolidWorlds engine only has `recenter()`. So
+  the harness must add a `setPose(...)` to each engine interface.
+- **Why URL params (not just `SEED_LS`):** `worldId`/`thirdPerson`/`camDistance`
+  are **session-only `useState`** (not persisted), so `SEED_LS` can't reach them —
+  a deep-link param is the only way to pin world + camera for a shot.
+
 ### 🔵 finding · 13:05 — Smoke-pass surface mapped (routes + how the crash class shows up)
 **Why:** the plan's deliverable (b) needs the exact route enumeration and a real detection mechanism, not a hand-wave.
 

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -1,0 +1,111 @@
+---
+kind: progress
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Plan the headless mode build-out (debug-pose harness + mobile smoke)
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: in-progress
+build: unknown
+followup: null
+pr: null
+app: docs, engine
+signals: needs-dan
+next: Confirm scope/priorities, then write the kind:plan report for the L1 harness + mobile smoke
+---
+
+# Plan the headless mode build-out (debug-pose harness + mobile smoke)
+
+## Session purpose
+
+Build out the **headless mode** for animath. Review all existing documentation on
+the problem (reports + TODO), then develop a *complete plan* for the work. This is
+the **L1 positive check** from `RECURRING_LESSONS.md` — the highest tool-ROI item
+in the 2026-06-22 process audit, requested independently three times across the
+topology sessions and filed `!high` in `TODO.md`.
+
+## Previous session
+
+First tracked session on this branch (no handoff folder yet). The work descends
+from two prior threads:
+
+- [headless-webgl-cloud 2026-06-07-S01](../headless-webgl-cloud/2026-06-07-S01-headless-webgl-tooling.md)
+  — built the **screenshot tooling** that exists today (`scripts/shoot.mjs`,
+  `scripts/install_headless_webgl.sh`, `docs/HEADLESS_WEBGL.md`, the `SessionStart`
+  hook). Status **completed**, PR #187. That gave us the *ability to render a
+  frame*; this session plans the *ability to render a chosen frame and to assert on
+  it*.
+- [process-audit-collaboration 2026-06-22-S01](../process-audit-collaboration-tvrn9b/2026-06-22-S01-process-audit-findings.md)
+  — Tier-1 recs **2 & 3** (debug-pose harness + dev HUD; mobile-viewport smoke) are
+  the spec this plan executes. Both filed OPEN, own branch.
+
+## Working notes
+
+### 🔵 finding · 12:50 — Reviewed all headless documentation; the task is L1's two named checks
+**Why:** the focus said "review all the documentation on this problem in reports and todo" before planning.
+
+The "headless mode" build-out is precisely the **L1 positive check** named in three
+places that all agree:
+
+- `RECURRING_LESSONS.md` L1 (~14 recurrences, 🟡 rule-only): *"Verified headless,
+  never on a real device."* The rule + signals exist; the **check is missing** — the
+  deep-link debug-pose harness + headless mobile smoke.
+- `TODO.md` line 48 (`!high`, own branch): two deliverables —
+  **(a)** a URL param that sets camera/world/pose so `shoot.mjs` can reproduce an
+  *exact* frame, plus an opt-in **dev HUD** (player determinant, current tile,
+  nearest-marker distance); **(b)** a `shoot.mjs` pass at **390×844** across all
+  routes asserting **no console error / no NaN-in-shader**.
+- Process-audit findings Tier-1 recs 2–3 (the originating spec).
+
+What already exists (don't rebuild): `scripts/shoot.mjs` (route + out-path args;
+`SEED_LS`, `SKIN`, `WAIT_MS`, `VIEWPORT` env knobs; prints the live WebGL renderer
+string; waits for `<canvas>`), the cloud install hook, and `npm run shoot`.
+
+Why it matters (the defects it would have caught, per the audit): the
+**teleporting-world** and **spoofed-probe** cases (W1/W3 — a green invariant on a
+visually-wrong render), and the **#216 Torus crash / #215 height** runtime defects
+that escape the `tsc && vite build` gate.
+
+### 🔵 finding · 13:05 — Smoke-pass surface mapped (routes + how the crash class shows up)
+**Why:** the plan's deliverable (b) needs the exact route enumeration and a real detection mechanism, not a hand-wave.
+
+Exploration of `src/index.tsx` + `src/apps.ts`: **19 resolvable hash routes**
+(13 public catalog + 4 legacy/merged: `#/fractals-cpu`, `#/mobius`, `#/wrap-world`,
+`#/trinary-lab` + 2 embeds). **10 are WebGL** (Three.js/Canvas3D), **9 DOM/CSS**
+(Argand, AgenticSorting, StableMatching, Fractals2D-CPU=Canvas2D, Gallery).
+
+Key technical finding for NaN detection: **Three.js swallows shader-compile errors**
+— they never reach `console`. The #216 Torus crash surfaced as **WebGL context
+loss / black canvas** (a NaN written to a varying via `normalize(cross(du,dv))` with
+a ~0 cross product; SwiftShader tolerates it, real mobile GPUs hard-crash). So the
+smoke pass needs **three detectors**, not just console scraping:
+1. `page.on('console', type==='error')` + `page.on('pageerror')` → exit non-zero
+   (already half-wired in `shoot.mjs:52-54`).
+2. A `webglcontextlost` listener (animath has **none** today) — register one before
+   boot and fail if it fires.
+3. A `gl.readPixels` framebuffer scan for NaN/all-black after settle.
+
+Conventions to match: `verify-*.ts` scripts exit 0/1; `shoot.mjs` is `.mjs`/ESM,
+waits for `<canvas>` (8 s) then `WAIT_MS` (2500, bump to ~3500 for HDR on
+ComplexParticles). All apps are `React.lazy` (Suspense `LoadingScreen`).
+
+### 🟣 decision · 12:55 — Scope pinned with Dan (3 answers)
+**Why:** L2 ("build the full thing before asking") is itself the audit's top lesson; pin scope before drafting.
+
+1. **Harness reach:** *Topology walkers first* — build the URL-pose param + dev HUD
+   for **SolidWorlds & PolygonWorlds** (where teleporting-world / spoofed-probe bugs
+   lived), with a **generic convention** others can adopt later. Not all WebGL apps.
+2. **Mobile smoke CI:** *Advisory now, gate later* — ship `npm run smoke` + doc,
+   wire into `deploy.yml` as a **non-blocking** step (`continue-on-error`) like
+   `sessions:lint`, promote to a hard gate once proven quiet.
+3. **Deliverable:** *Plan only this session* — write the complete `kind: plan`
+   report (`status: proposed`); implementation is a later branch. Optional
+   `/three-hats` review of the plan.
+
+### 🟡 milestone · 12:50 — Session oriented; drafting the plan next
+**Why:** progress report is the session's memory; record the orientation before planning.
+
+Branch `claude/headless-mode-plan-bbk74b` (first session). The deliverable is a
+plan, not yet code — a `kind: plan` report in this branch's `progress/` folder.
+</content>
+</invoke>

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-headless-mode-plan.md
@@ -5,13 +5,13 @@ date: 2026-06-23
 title: Plan the headless mode build-out (debug-pose harness + mobile smoke)
 branch: claude/headless-mode-plan-bbk74b
 slug: headless-mode-plan-bbk74b
-status: in-progress
-build: unknown
-followup: null
-pr: null
+status: completed
+build: passed
+followup: low
+pr: 234
 app: docs, engine
-signals: needs-dan
-next: Confirm scope/priorities, then write the kind:plan report for the L1 harness + mobile smoke
+signals: phone-needed
+next: Give Solid Worlds a genuine independent witness (filed in TODO), or fix the RGBELoader HDR finding
 ---
 
 # Plan the headless mode build-out (debug-pose harness + mobile smoke)

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
@@ -308,19 +308,30 @@ Phases 2–4** (most are *narrowing*, not new work):
    probe already reads — the SolidWorlds engine already computes one
    (`coverEngine.ts:639`); PolygonWorlds has a geometric `debugProbe`. The headline
    teleport bug was a *continuity* failure the determinant alone would not catch.
-3. **Determinism is now a precondition, not a nicety** (the one real blind spot): the
-   walkers run a wall-clock `getDelta()` rAF, so a pose-only deep link is *not*
-   reproducible frame-to-frame. Add a `freeze`/`t=` param (or settle-on-idle) — the
-   acceptance criterion "lands the same view twice" depends on it.
+3. **Determinism — insurance, not a precondition** (revised by the 2026-06-23
+   experiment). *Original concern:* the wall-clock `getDelta()` rAF makes a pose-only
+   link non-reproducible. *Measured result:* at idle, all three probed routes (incl.
+   ComplexParticles) produced **byte-identical** frames 600 ms apart — the walkers don't
+   visibly animate without input, so "same view twice" already holds for static poses.
+   The `freeze`/`t=` param (parsed by `frozenTime()` since Phase 1) is retained as
+   **insurance** for *animated* states (continuous spin, n-body Trinary), not a gate.
 4. **Unify the debug-query convention** (PolygonWorlds' `polydebug` reads
    `location.search`; the new helper reads the hash-query) and **add a "copy
    deep-link" round-trip** so the HUD *emits* the reproducible URL (closes the loop;
    makes it a shareable teaching artifact).
 5. **Narrow Deliverable B's claim** to *boot / blank / context-loss* failures —
    SwiftShader *tolerates* the exact #216 NaN, so "catches #216" is overstated.
-   **Console + `webglcontextlost` are the load-bearing detectors;** replace the
-   brightness-threshold dead-frame check with **variance** (or force a bright look via
-   `SEED_LS` before `readPixels`).
+   **Detector design (refined by the 2026-06-23 experiment):**
+   - **`pageerror` (JS exceptions) + `webglcontextlost` are load-bearing** — both were
+     clean (0) across the probed routes, so a real failure stands out.
+   - **`console.error` is advisory with a resource-load allowlist** — every clean route
+     already logs baseline resource errors (a 404 + a cert failure), so a naive
+     "fail on any console.error" gate false-positives on all routes; filter
+     `net::ERR_*` / HTTP 4xx.
+   - **Dead-frame check = low *variance* of the composited screenshot, NOT
+     `gl.readPixels`** — readPixels returned all-black for ComplexParticles
+     (preserveDrawingBuffer:false) while the screenshot captured it; and a dark-but-alive
+     frame (mean 23, variance 3086) proves brightness/black-fraction is the wrong signal.
 6. **CI: a separate PR-triggered smoke workflow, NOT the Pages-deploy job** — §4.4's
    `deploy.yml` placement is wrong (deploy sets `PUPPETEER_SKIP_DOWNLOAD` and the
    runner lacks SwiftShader libs). Advisory-now/gate-later still holds, in its own
@@ -330,9 +341,11 @@ Phases 2–4** (most are *narrowing*, not new work):
 8. *Deferred v2:* `loop=`/`seam=` path encoding + a round-trip-walk unit test (the
    holonomy-after-a-loop a topology teacher actually wants).
 
-> [!TIP]
-> Run **one `shoot.mjs` experiment first** (before revising/implementing): double-shoot
-> a single URL to confirm/deny the determinism gap, and verify `gl.readPixels` returns
-> usable data on a SwiftShader framebuffer at all. Both are currently
-> reasoned-from-code, not measured.
+> [!NOTE]
+> **Experiment done (2026-06-23).** The two flagged uncertainties are now *measured*,
+> not reasoned-from-code: determinism holds at idle (revision #3 downgraded to
+> insurance); `gl.readPixels` is unreliable so the dead-frame check reads the composited
+> screenshot with a *variance* threshold; and clean routes carry baseline resource
+> `console.error`s, so the smoke gate keys on `pageerror` + `webglcontextlost` (revision
+> #5). See the 2026-06-23 finding in the session log.
 </content>

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
@@ -5,13 +5,13 @@ date: 2026-06-23
 title: Headless mode build-out — deep-link debug-pose harness + mobile smoke
 branch: claude/headless-mode-plan-bbk74b
 slug: headless-mode-plan-bbk74b
-status: proposed
-build: unknown
+status: completed
+build: passed
 followup: null
 pr: null
 app: docs, engine
-signals: needs-dan
-next: Implement Phase 1 (shared URL-pose + HUD scaffolding) on a fresh branch
+signals: null
+next: Optional — give Solid Worlds a genuine independent witness (filed in TODO)
 ---
 
 # Headless mode build-out — deep-link debug-pose harness + mobile smoke

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
@@ -1,0 +1,290 @@
+---
+kind: plan
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Headless mode build-out — deep-link debug-pose harness + mobile smoke
+branch: claude/headless-mode-plan-bbk74b
+slug: headless-mode-plan-bbk74b
+status: proposed
+build: unknown
+followup: null
+pr: null
+app: docs, engine
+signals: needs-dan
+next: Implement Phase 1 (shared URL-pose + HUD scaffolding) on a fresh branch
+---
+
+# Headless mode build-out — deep-link debug-pose harness + mobile smoke
+
+> [!NOTE]
+> **Status: proposed.** This is the implementation plan for the **L1 positive
+> check** (`RECURRING_LESSONS.md`), filed `!high` in `TODO.md`. It is plan-only;
+> no code is written this session. Scope was pinned with Dan: **walkers first**
+> (generic helper, SolidWorlds + PolygonWorlds as first adopters); mobile smoke
+> **advisory-now / gate-later**; **plan-only** this session.
+
+## 1. Why this exists
+
+"Verified headless, never on a real device" is the most-recurring lesson in the
+corpus (~14 reflections, `RECURRING_LESSONS.md` L1). The screenshot tooling from
+PR #187 lets us *render a frame*, but two gaps remain — and they map to the two
+defect classes that actually escape the `tsc && vite build` CI gate:
+
+| Gap | Defect class it closes | Real cases it would have caught |
+|-----|------------------------|---------------------------------|
+| **(A) Deep-link debug-pose harness + dev HUD** | *Correctness* — a green invariant on a visually-wrong render (L3) | teleporting-world; spoofed chirality probe (W1/W3) |
+| **(B) Headless mobile-viewport smoke** | *Runtime* — a crash/NaN that only shows at a real viewport | #216 Torus crash (WebGL context loss); #215 height |
+
+Neither replaces a real-device pass — `phone-needed` stays a standing signal. They
+close the **no-cost** verification tier so the next agent can produce a
+*reproducible* visual diff instead of shooting a blind default view.
+
+## 2. What already exists (do not rebuild)
+
+- `scripts/shoot.mjs` — headless Chromium + SwiftShader, route + out-path args,
+  `SEED_LS`/`SKIN`/`VIEWPORT`/`WAIT_MS` env knobs, prints the live WebGL renderer,
+  waits for `<canvas>`, captures `console`/`pageerror` to stdout (`:52-54`).
+- `scripts/install_headless_webgl.sh` + the `SessionStart` hook (cloud provisioning).
+- `docs/HEADLESS_WEBGL.md`, `npm run shoot`.
+- **Precedents to copy, not invent:**
+  - URL-query parse: `TrinaryLab.tsx` →
+    `new URLSearchParams(window.location.hash.split('?')[1] ?? '')`; the router
+    already splits `?query` off the path (`index.tsx:65`).
+  - Opt-in HUD overlays: `ChiralityHUD` (SolidWorlds `SolidWorlds.tsx:404-435`),
+    `SquareMiniMap` (PolygonWorlds `PolygonWorlds.tsx:605-641`) — both rAF loops
+    reading a getter.
+  - Existing debug hook: PolygonWorlds `location.search.includes('polydebug')`
+    exposes `window.__poly` (`PolygonWorlds.tsx:105`).
+
+## 3. Deliverable A — deep-link debug-pose harness + dev HUD
+
+### A0. The convention (shared, app-agnostic)
+
+One small helper module, `src/lib/debugPose.ts`, that every app can opt into; the
+two walkers are the first adopters. It does **not** know app-specific state — it
+just parses the query and offers typed accessors:
+
+```ts
+// src/lib/debugPose.ts
+export function poseParams(): URLSearchParams {
+  return new URLSearchParams(window.location.hash.split('?')[1] ?? '');
+}
+export const pNum  = (p: URLSearchParams, k: string, d: number) => { … };
+export const pBool = (p: URLSearchParams, k: string, d: boolean) => { … };
+export const pStr  = (p: URLSearchParams, k: string, d: string) => { … };
+export const hudEnabled = (p = poseParams()) => p.has('hud') || p.get('debug') === '1';
+```
+
+**Documented param vocabulary** (HEADLESS_WEBGL.md gains a "Debug-pose deep links"
+section). Generic params first, then app-specific position:
+
+| Param | Meaning | Apps |
+|-------|---------|------|
+| `world=<id>` | world/spec id (`worldById`) | both |
+| `look=<id>` | scene look | both |
+| `cam=first\|third` | camera mode | both |
+| `camd=<n>` | camera distance (third person) | both |
+| `yaw=<rad>` `pitch=<rad>` | look orientation | both |
+| `x,y,z=<n>` | cube position (−1..1) | SolidWorlds |
+| `u,v=<n>` | square chart position (0..1) | PolygonWorlds |
+| `hud` / `debug=1` | show the dev HUD | both (opt-in) |
+
+Unknown params are ignored, so apps can extend the vocabulary without breaking the
+helper. Position semantics differ per app (3D cube vs 2D chart) by design — the
+*helper* is generic; the *mapping* lives in each app.
+
+> Rationale for named scalar params over one opaque `pose=` blob: these URLs are
+> **hand-authored** when debugging ("put me at the seam facing the arch"), so
+> readability beats compactness.
+
+### A1. Engine seam — add `setPose`
+
+Both walkers compute pose **inside an engine closure**; only PolygonWorlds exposes
+a *getter*. Add a symmetric *setter* to each engine interface:
+
+- **PolygonWorlds** — `src/animations/PolygonWorlds/engineTypes.ts`: add
+  `setPose(p: { u?: number; v?: number; yaw?: number; pitch?: number }): void`.
+  Implement in `fundamentalSquareEngine.ts` by writing the cover's chart position
+  and heading (the inverse of the existing `cover.chart()` / `cover.pose()` read at
+  `:153,162`). PolygonWorlds already exposes `getPose()`/`getMapState()` — this is
+  the missing direction.
+- **SolidWorlds** — `src/animations/SolidWorlds/engineTypes.ts`: add the same.
+  Implement in `coverEngine.ts` by setting `pos`, resetting `bodyLinear`/`cell` to
+  the home frame, and seeding `yawRef`/`pitchRef` in the component. Today the
+  engine has only `recenter()` (`:64-98`); generalize it.
+
+Camera mode / world / look are **component state**, not engine state, so they're
+set in the component (A2), not via `setPose`.
+
+### A2. Apply params on boot
+
+In each walker's `onMount` (`SolidWorlds.tsx:80-112`, `PolygonWorlds.tsx:90-158`),
+after the engine is built:
+
+1. `const p = poseParams();`
+2. If `world` present and valid (`worldById` non-null) → set `worldId` **before**
+   engine build (move the parse above the build `useEffect`, or gate the initial
+   `useState` with a lazy initializer reading the param). World/camera/look feed
+   `useState`/`usePersistentState` initial values via lazy initializers so the
+   first engine build already uses them.
+3. `cam`/`camd`/`look`/`hud` → seed the matching state initializers.
+4. `yaw/pitch/x/y/z` (or `u/v`) → call `engine.setPose(...)` once after build.
+
+Edge cases the plan must honor: invalid `world` id → ignore, keep default (don't
+crash); params absent → behave exactly as today (zero regression); typing in a
+panel must still early-return (the `inFormField()` guard at
+`SolidWorlds.tsx:153` / `PolygonWorlds.tsx:198` is untouched).
+
+### A3. Dev HUD (opt-in)
+
+A shared `src/components/DebugPoseHUD.tsx` modeled on `ChiralityHUD`: a fixed-corner
+overlay, mounted only when `hudEnabled()`, reading a per-app `getDebug()` in a rAF
+loop. The `DebugState` it renders:
+
+```ts
+interface DebugState {
+  determinant: 1 | -1;             // bodyLinear.determinant() / mapState.flipped
+  cell?: Record<'x'|'y'|'z', number>;  // SolidWorlds only
+  pos: { x: number; y: number; z?: number };
+  yaw: number; pitch: number;
+  nearestMarkerDist: number;       // NEW — see A4
+  world: string; look: string;
+}
+```
+
+SolidWorlds wires `getDebug` off the existing `getChirality()` + `getMapState()`;
+PolygonWorlds off `getPose()` + `getMapState()`. The HUD is **text-only**,
+`pointer-events:none`, and never mounts unless the param is present — zero impact on
+the shipped UI.
+
+### A4. Nearest-marker distance (the one new computation)
+
+The only diagnostic not already computed. Add a small pure helper that, given the
+player position and the world's landmark/marker positions (PolygonWorlds
+`landmarkCount`/`arrangement`; SolidWorlds decor markers), returns the min distance.
+Keep it **pure and unit-tested** (`__tests__/`), honoring L4 — this is exactly the
+"testable pure logic" class.
+
+### A5. Using it from `shoot.mjs`
+
+No script change needed for capture — the route arg already carries the query:
+
+```bash
+npm run shoot \
+  '#/solid-worlds?world=amphicosm&x=0.1&y=0.2&z=0.3&yaw=1.5&pitch=0.1&look=dusk&hud' \
+  out.png
+```
+
+`shoot.mjs` already re-prepends `#/`; confirm it preserves the `?query` (it uses
+`route.replace(/^#?\/?/, '#/')`, which keeps the query — verify in Phase 1).
+
+## 4. Deliverable B — headless mobile smoke (`scripts/smoke.mjs`)
+
+### B1. What it does
+
+Iterate **all routes** at **390×844**, boot each in headless SwiftShader, and fail
+(exit 1) on any of three detectors. Matches the `verify-*.ts` convention
+(`process.exit(fails ? 1 : 0)`, stdout summary).
+
+Route list (single source, exported so it can't drift): 13 public + the WebGL
+legacy/merged routes (`#/mobius`, `#/wrap-world`, `#/trinary-lab`) + the 2 embeds.
+DOM-only routes (`#/argand`, `#/agentic-sorting`, `#/stable-matching`,
+`#/fractals-cpu` (Canvas2D), `#/`) get **console/pageerror checks only**.
+
+### B2. The three detectors (console scraping alone is insufficient)
+
+Three.js **swallows shader-compile errors** — the #216 crash surfaced as silent
+**WebGL context loss**, not a console error. So:
+
+1. **Console/JS errors** — `page.on('console', m => m.type()==='error')` +
+   `page.on('pageerror')` → record + fail. (Half-wired in `shoot.mjs:52-54`.)
+2. **WebGL context loss** — `evaluateOnNewDocument` to register a
+   `canvas.addEventListener('webglcontextlost', …)` flag *before* boot (animath has
+   **no** such handler today); fail if it fires within the settle window.
+3. **NaN / dead-frame scan** — after settle, `gl.readPixels` a small sample and
+   fail if it's all-black/all-NaN on a route that should render (cheap proxy for the
+   "garbage rasterization" failure mode). Tune thresholds to avoid false positives
+   on legitimately dark looks (e.g. `moonlit`).
+
+### B3. Timing & robustness
+
+`WAIT_MS` ~3500 for the HDR-loading ComplexParticles route; wait for `<canvas>`
+(8 s) on WebGL routes; per-route try/catch so one failure doesn't abort the sweep;
+print a `PASS n/m` summary with the failing routes named. Optional `--shots` flag
+to also dump a PNG per route into a gitignored dir for eyeballing.
+
+### B4. Wiring
+
+- `package.json`: `"smoke": "node scripts/smoke.mjs"` (append — and add
+  `package.json` to the protected-file list per the open TODO).
+- `deploy.yml`: add a **non-blocking** `continue-on-error` step
+  (`npm run build && (npm run preview &) && sleep 5 && npm run smoke`) mirroring the
+  `sessions:lint -- --strict` pattern — surfaces in CI logs without blocking merges.
+  Promote to a hard gate once proven quiet (the established graduation path).
+- `docs/HEADLESS_WEBGL.md`: document `npm run smoke` + the detectors + the
+  known-dark-look caveat.
+
+## 5. Phasing
+
+1. **Phase 1 — shared scaffolding (no app behavior change yet).**
+   `lib/debugPose.ts` + `components/DebugPoseHUD.tsx` + the `nearestMarker` pure
+   helper **with its vitest file**. Build + unit test green. Lowest risk; nothing
+   user-visible.
+2. **Phase 2 — PolygonWorlds adoption.** It already has `getPose()` and a debug
+   precedent, so it's the cheaper first integration. Add `setPose`, wire boot
+   params + HUD + `getDebug`. Verify headless with a known deep link.
+3. **Phase 3 — SolidWorlds adoption.** Same, plus generalizing `recenter()` into a
+   `setPose`. Verify the chirality HUD still reads correctly and a seam-facing deep
+   link reproduces.
+4. **Phase 4 — `scripts/smoke.mjs`** + `npm run smoke` + the non-blocking
+   `deploy.yml` step + HEADLESS_WEBGL.md. Run it once across all routes; fix or file
+   any real defects it surfaces (don't bury them).
+5. **Phase 5 — ledger close-out.** Flip `RECURRING_LESSONS.md` L1 to **🟢 Promoted
+   (rule + check)** with pointers to the harness + smoke; check off the `TODO.md`
+   line; note the new debug-deep-link convention in `BUILDING_AN_APP.md` (so new
+   walkers adopt it) and in `RECIPES.md` (R-entry: *when verifying a walker change,
+   shoot the exact pose, don't eyeball the default view*).
+
+Each phase is independently shippable; 1 can land alone, 2/3 are parallelizable,
+4 depends on nothing in 1–3.
+
+## 6. Risks & open questions
+
+- **SwiftShader fidelity vs real mobile GPU.** The smoke pass runs on software
+  WebGL, which *tolerates* exactly the NaN the #216 bug exploited on real hardware.
+  The `readPixels`/context-loss detectors are proxies, not the real device. Honest
+  framing in the doc: this closes the *no-cost* tier and catches gross failures;
+  `phone-needed` stays. (Mitigation idea, out of scope: a deliberate NaN-probe build
+  flag that asserts in-shader — heavier, defer.)
+- **Setting world before first engine build.** Cleanest via lazy `useState`
+  initializers that read the param; needs care that the persisted value
+  (`usePersistentState`) doesn't override an explicit URL param. **Proposed rule:
+  URL param wins over persisted/default** when present (it's an explicit request).
+  Confirm with Dan if the opposite is wanted.
+- **`setPose` correctness on flip/screw worlds** is itself an orientation problem
+  (L7) — the HUD's determinant readout is the check that the set pose is on the
+  right sheet. Good: the harness validates itself.
+- **Dead-frame false positives** on dark looks — tune, or skip the readPixels
+  detector for known-dark looks; keep console + context-loss always-on.
+- **Param vocabulary churn.** Locking names now (`world/look/cam/camd/yaw/pitch/
+  x,y,z/u,v/hud`) avoids each app inventing its own; documented in one place.
+
+## 7. Acceptance criteria
+
+- A single shareable URL reproduces an exact walker frame headlessly
+  (`npm run shoot '#/solid-worlds?…' out.png` lands the same view twice).
+- `?hud` shows determinant / cell / nearest-marker without affecting the shipped UI
+  (no param → byte-identical behavior to today).
+- `npm run smoke` exits non-zero on an injected console error / context loss, and
+  green across all routes on a clean tree; runs in CI as a visible non-blocking step.
+- `nearestMarker` helper has a committed vitest file (L4 honored).
+- L1 flipped to 🟢 in the ledger; TODO line checked off; convention documented in
+  HEADLESS_WEBGL.md + BUILDING_AN_APP.md + a RECIPES R-entry.
+
+## 8. Suggested next step
+
+Optionally run **`/three-hats`** on this plan (framework-maintainer lens will have
+opinions on the shared-helper vs per-app split and the CI wiring) before Phase 1.
+Otherwise, start Phase 1 on a fresh implementation branch — it's pure additive
+scaffolding with a unit test and no user-visible change.
+</content>

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
@@ -8,7 +8,7 @@ slug: headless-mode-plan-bbk74b
 status: completed
 build: passed
 followup: null
-pr: null
+pr: 234
 app: docs, engine
 signals: null
 next: Optional — give Solid Worlds a genuine independent witness (filed in TODO)

--- a/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
+++ b/docs/sessions/progress/headless-mode-plan-bbk74b/2026-06-23-S01-plan-headless-mode.md
@@ -287,4 +287,52 @@ Optionally run **`/three-hats`** on this plan (framework-maintainer lens will ha
 opinions on the shared-helper vs per-app split and the CI wiring) before Phase 1.
 Otherwise, start Phase 1 on a fresh implementation branch — it's pure additive
 scaffolding with a unit test and no user-visible change.
+
+## 9. Three-hats review revisions (2026-06-23)
+
+The plan was reviewed by three experts; see the
+[synthesis](2026-06-23-S01-expert-synthesis.md) (and the
+[maintainer](2026-06-23-S01-expert-maintainer.md) /
+[consultant](2026-06-23-S01-expert-consultant.md) /
+[pedagogy](2026-06-23-S01-expert-pedagogy.md) reports). Direction and
+Deliverable A endorsed unanimously; Deliverable B rescoped. **Apply these before
+Phases 2–4** (most are *narrowing*, not new work):
+
+1. **`setPose` = position + heading only.** Reach flipped/screw sheets by walking or
+   placing across a seam and letting the *engine* derive the frame — not by seeding a
+   non-identity developing frame. This cancels two objections at once: the
+   maintainer's "setPose is under-costed" (no frame-seeding) and the pedagogy's
+   "det-validates-itself is circular" (you observe the engine's derived frame, not an
+   asserted one). The `x/y/z/yaw/pitch` param table is unchanged.
+2. **HUD adds an *independent* continuity/jump witness**, not just the determinant the
+   probe already reads — the SolidWorlds engine already computes one
+   (`coverEngine.ts:639`); PolygonWorlds has a geometric `debugProbe`. The headline
+   teleport bug was a *continuity* failure the determinant alone would not catch.
+3. **Determinism is now a precondition, not a nicety** (the one real blind spot): the
+   walkers run a wall-clock `getDelta()` rAF, so a pose-only deep link is *not*
+   reproducible frame-to-frame. Add a `freeze`/`t=` param (or settle-on-idle) — the
+   acceptance criterion "lands the same view twice" depends on it.
+4. **Unify the debug-query convention** (PolygonWorlds' `polydebug` reads
+   `location.search`; the new helper reads the hash-query) and **add a "copy
+   deep-link" round-trip** so the HUD *emits* the reproducible URL (closes the loop;
+   makes it a shareable teaching artifact).
+5. **Narrow Deliverable B's claim** to *boot / blank / context-loss* failures —
+   SwiftShader *tolerates* the exact #216 NaN, so "catches #216" is overstated.
+   **Console + `webglcontextlost` are the load-bearing detectors;** replace the
+   brightness-threshold dead-frame check with **variance** (or force a bright look via
+   `SEED_LS` before `readPixels`).
+6. **CI: a separate PR-triggered smoke workflow, NOT the Pages-deploy job** — §4.4's
+   `deploy.yml` placement is wrong (deploy sets `PUPPETEER_SKIP_DOWNLOAD` and the
+   runner lacks SwiftShader libs). Advisory-now/gate-later still holds, in its own
+   workflow.
+7. **"URL wins over persisted" must short-circuit `usePersistentState`'s load**, not
+   merely supply its initial value.
+8. *Deferred v2:* `loop=`/`seam=` path encoding + a round-trip-walk unit test (the
+   holonomy-after-a-loop a topology teacher actually wants).
+
+> [!TIP]
+> Run **one `shoot.mjs` experiment first** (before revising/implementing): double-shoot
+> a single URL to confirm/deny the determinism gap, and verify `gl.readPixels` returns
+> usable data on a SwiftShader framebuffer at all. Both are currently
+> reasoned-from-code, not measured.
 </content>

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "shoot": "node scripts/shoot.mjs",
+    "smoke": "node scripts/smoke.mjs",
     "sessions": "node docs/sessions/build-sessions.mjs",
     "sessions:lint": "node docs/sessions/lint-sessions.mjs",
     "sessions:prune": "node docs/sessions/prune-assets.mjs",

--- a/scripts/smoke.mjs
+++ b/scripts/smoke.mjs
@@ -1,0 +1,178 @@
+#!/usr/bin/env node
+// Headless mobile-viewport smoke check for animath.
+//
+// Loads every app route at 390x844 in headless software WebGL (SwiftShader, the
+// same engine as scripts/shoot.mjs) and fails (exit 1) on the defect class that
+// escapes the `tsc && vite build` CI gate: a runtime crash / blank frame that
+// only shows at a real viewport (e.g. the #216 Torus mobile crash). It is NOT a
+// substitute for a real-device pass — `phone-needed` stays a standing signal — it
+// closes the *no-cost* tier.
+//
+// Usage:
+//   npm run build && (npm run preview &) && sleep 3 && npm run smoke
+//
+// Env:
+//   BASE_URL   server origin + base (default http://localhost:4173/animath/)
+//   SETTLE_MS  settle time after the canvas appears (default 3000; HDR-safe)
+//   VIEWPORT   "WxH" (default 390x844)
+//   SHOTS_DIR  if set, write a PNG per route here (for eyeballing)
+//
+// Detector design is grounded in the 2026-06-23 experiment (see the headless-mode
+// session log), NOT guesswork:
+//   • pageerror (uncaught JS) + webglcontextlost  → LOAD-BEARING (fail).
+//     Three.js swallows shader-compile errors, so the #216 crash surfaced as
+//     context loss, never a console error.
+//   • dead-frame                                  → low *variance* over the canvas
+//     region of the puppeteer screenshot (the true composited frame; NOT in-page
+//     gl.readPixels, which returns black on a preserveDrawingBuffer:false context,
+//     NOR in-page drawImage(canvas), which reads BLANK on the on-demand-render
+//     apps — fractals/plane-transform — whose buffer is already cleared). A
+//     dark-but-alive frame (ComplexParticles: variance ~3000) passes; a blank one
+//     (variance ~0) fails.
+//   • console.error                               → advisory WARNING, with a
+//     resource-load allowlist (every clean route logs a 404 + a cert failure), so
+//     a NON-allowlisted console.error is surfaced but does not fail the gate.
+
+import puppeteer from 'puppeteer';
+
+// The route table — keep in sync with src/index.tsx `routes`. `webgl` routes get
+// the dead-frame variance check; DOM/CSS routes get console/pageerror only. The
+// #/mobius + #/wrap-world redirects are omitted (they resolve to #/topology-walk).
+const ROUTES = [
+  { hash: '#/', webgl: false },                       // gallery
+  { hash: '#/complex-particles', webgl: true },
+  { hash: '#/argand', webgl: false },
+  { hash: '#/fractals', webgl: true },
+  { hash: '#/polygon-worlds', webgl: true },
+  { hash: '#/plane-transform', webgl: true },
+  { hash: '#/correspondence', webgl: true },
+  { hash: '#/trinary', webgl: true },
+  { hash: '#/agentic-sorting', webgl: false },
+  { hash: '#/stable-matching', webgl: false },
+  { hash: '#/trees-and-nets', webgl: true },
+  { hash: '#/topology-walk', webgl: true },
+  { hash: '#/solid-worlds', webgl: true },
+  { hash: '#/fractals-cpu', webgl: false },            // Canvas2D, not WebGL
+  // The Lab is a DOM/readout view (census, distributions) with small live
+  // mini-sim canvases — not one full-viewport WebGL scene — so the dead-frame
+  // check doesn't apply (the WebGL Observatory is #/trinary, checked above).
+  { hash: '#/trinary-lab', webgl: false },
+  { hash: '#/embed/complex-particles', webgl: true },
+  { hash: '#/embed/plane-transform', webgl: true },
+];
+
+// Resource-load failures every clean route logs — not app defects. Anything else
+// on console.error is a real signal.
+const RESOURCE_NOISE = /failed to load resource|net::err_|status of 4\d\d|err_cert|favicon/i;
+// A WebGL route below this composited-luma variance is treated as a blank/dead
+// frame. The experiment put the darkest live route (ComplexParticles) at ~3086, a
+// blank canvas at ~0, so 5 is a wide, safe floor.
+const DEAD_VARIANCE = 5;
+
+const baseUrl = process.env.BASE_URL ?? 'http://localhost:4173/animath/';
+const settleMs = Number(process.env.SETTLE_MS ?? 3000);
+const [vw, vh] = (process.env.VIEWPORT ?? '390x844').split('x').map(Number);
+const shotsDir = process.env.SHOTS_DIR || null;
+
+const args = [
+  '--headless=new', '--use-gl=angle', '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader', '--no-sandbox', '--disable-dev-shm-usage',
+  `--window-size=${vw},${vh}`,
+];
+
+// Luma variance of a screenshot PNG, computed inside the page by round-tripping
+// the image through an <img> → 2d canvas (works on any PNG — unlike drawImage of a
+// live webgl canvas). Returns variance over a strided luma sample.
+const varianceOfPngFn = async (dataUrl) => {
+  const img = new Image();
+  await new Promise((res, rej) => { img.onload = res; img.onerror = rej; img.src = dataUrl; });
+  const dc = document.createElement('canvas');
+  dc.width = img.naturalWidth; dc.height = img.naturalHeight;
+  const ctx = dc.getContext('2d');
+  ctx.drawImage(img, 0, 0);
+  const data = ctx.getImageData(0, 0, dc.width, dc.height).data;
+  let sum = 0, sumSq = 0, n = 0;
+  for (let i = 0; i < data.length; i += 4 * 37) {       // stride to keep it cheap
+    const l = 0.299 * data[i] + 0.587 * data[i + 1] + 0.114 * data[i + 2];
+    sum += l; sumSq += l * l; n++;
+  }
+  const mean = sum / n;
+  return { mean: +mean.toFixed(1), variance: +(sumSq / n - mean * mean).toFixed(1) };
+};
+
+// The canvas region (CSS px) to clip the dead-frame screenshot to, so the variance
+// measures the rendered frame and not the surrounding chrome (which always varies).
+const canvasRectFn = () => {
+  const c = document.querySelector('canvas');
+  if (!c) return null;
+  const r = c.getBoundingClientRect();
+  return { x: Math.max(0, r.x), y: Math.max(0, r.y), width: r.width, height: r.height };
+};
+
+const browser = await puppeteer.launch({ args });
+const results = [];
+try {
+  for (const route of ROUTES) {
+    const page = await browser.newPage();
+    await page.setViewport({ width: vw, height: vh });
+    const warnings = [];
+    let pageError = null;
+    page.on('console', (m) => {
+      if (m.type() === 'error' && !RESOURCE_NOISE.test(m.text())) warnings.push(m.text());
+    });
+    page.on('pageerror', (e) => { pageError = pageError ?? e.message; });
+    // Register a webglcontextlost flag BEFORE the app boots (capture phase reaches
+    // the canvas even though the event doesn't bubble to window).
+    await page.evaluateOnNewDocument(() => {
+      window.__ctxLost = false;
+      window.addEventListener('webglcontextlost', () => { window.__ctxLost = true; }, true);
+    });
+
+    const url = baseUrl.replace(/\/?$/, '/') + route.hash.replace(/^#?\/?/, '#/');
+    const fail = [];
+    try {
+      await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+      if (route.webgl) await page.waitForSelector('canvas', { timeout: 8000 }).catch(() => fail.push('no <canvas>'));
+      await new Promise((r) => setTimeout(r, settleMs));
+
+      const ctxLost = await page.evaluate(() => window.__ctxLost === true);
+      if (ctxLost) fail.push('webglcontextlost');
+      if (pageError) fail.push(`pageerror: ${pageError}`);
+
+      // Dead-frame check: clip a screenshot to the canvas region and measure its
+      // luma variance (the true composited frame, robust to on-demand rendering).
+      let stats = null;
+      if (route.webgl) {
+        const rect = await page.evaluate(canvasRectFn);
+        if (!rect || rect.width < 1 || rect.height < 1) fail.push('no canvas for frame check');
+        else {
+          const b64 = await page.screenshot({ clip: rect, encoding: 'base64' });
+          stats = await page.evaluate(varianceOfPngFn, `data:image/png;base64,${b64}`);
+          if (stats.variance < DEAD_VARIANCE) fail.push(`dead frame (variance ${stats.variance})`);
+        }
+      }
+      if (shotsDir) {
+        await page.screenshot({ path: `${shotsDir}/${route.hash.replace(/[^a-z0-9]/gi, '_')}.png` }).catch(() => {});
+      }
+      results.push({ hash: route.hash, ok: fail.length === 0, fail, warnings, stats });
+    } catch (e) {
+      results.push({ hash: route.hash, ok: false, fail: [`load error: ${String(e)}`], warnings, stats: null });
+    }
+    await page.close();
+  }
+} finally {
+  await browser.close();
+}
+
+// ── report ──────────────────────────────────────────────────────────────────
+console.log(`\nSMOKE ${vw}x${vh} · ${ROUTES.length} routes\n`);
+let failed = 0, warned = 0;
+for (const r of results) {
+  const v = r.stats?.variance != null ? ` var=${r.stats.variance}` : '';
+  if (r.ok) console.log(`  ✓ ${r.hash}${v}`);
+  else { failed++; console.log(`  ✗ ${r.hash} — ${r.fail.join('; ')}`); }
+  for (const w of r.warnings ?? []) { warned++; console.log(`    ⚠ ${w}`); }
+}
+console.log(`\n${failed === 0 ? 'PASS' : 'FAIL'} ${results.length - failed}/${results.length}` +
+  (failed ? `  (${failed} failed)` : '') + (warned ? `  · ${warned} warning(s)` : ''));
+process.exit(failed === 0 ? 0 : 1);

--- a/src/animations/PolygonWorlds/PolygonWorlds.tsx
+++ b/src/animations/PolygonWorlds/PolygonWorlds.tsx
@@ -22,6 +22,9 @@ import { parseWord } from './surfaceSchema';
 import { realize } from './lib/realize';
 import { usePersistentState } from '../../lib/usePersistentState';
 import { EmbeddingInset } from './instruments/embeddingInset';
+import DebugPoseHUD from '../../components/DebugPoseHUD';
+import { poseParams, pNum, pStr, hudEnabled, type DebugState } from '../../lib/debugPose';
+import { nearestMarkerDistance } from '../../lib/nearestMarker';
 import explainerText from './EXPLAINER.md?raw';
 
 const LOOK_SENS = 0.0035;
@@ -39,10 +42,21 @@ export default function PolygonWorlds() {
   // third-person toggle and the camera distance (transient view, per the
   // "don't persist camera" convention).
   const pk = (f: string) => `polygon-worlds:${f}`;
-  const [worldId, setWorldId] = useState('klein');
+  // Debug-pose deep link (docs/HEADLESS_WEBGL.md): a hash query can pin the world,
+  // camera and pose so a headless shot reproduces an exact frame. Parsed once;
+  // an explicit URL param wins over the session default. Absent params → today's
+  // behavior exactly.
+  const bootRef = useRef(poseParams());
+  const boot = bootRef.current;
+  const bootWorld = pStr(boot, 'world', '');
+  const [worldId, setWorldId] = useState(() =>
+    WORLDS.some((w) => w.id === bootWorld) ? bootWorld : 'klein');
   const [moveSpeed, setMoveSpeed] = usePersistentState(pk('moveSpeed'), 6);
-  const [thirdPerson, setThirdPerson] = useState(true);
-  const [camDistance, setCamDistance] = useState(3.2);
+  const [thirdPerson, setThirdPerson] = useState(() => pStr(boot, 'cam', 'third') !== 'first');
+  const [camDistance, setCamDistance] = useState(() => {
+    const c = pNum(boot, 'camd', NaN);
+    return Number.isFinite(c) ? clampCam(c) : 3.2;
+  });
   // Start as clear-but-present glass: see-through enough to read the underside
   // (other face + columns + footprints), but tinted enough to know the floor is
   // there. The same value reads the same in every world (shared POLYGON_GLASS).
@@ -99,6 +113,18 @@ export default function PolygonWorlds() {
     engineRef.current.setRadius(radiusRef.current);
     engineRef.current.setCameraDistance(camDistRef.current);
     engineRef.current.setLook(lookRef.current);
+    // Debug-pose deep link: ?look= overrides the view (engine-level, so the user's
+    // persisted look isn't clobbered); seed the look orientation; drop the player at
+    // the requested chart position (euclidean worlds — heading is the look yaw, so
+    // this is position only). Read via the ref so onMount stays dependency-free.
+    const bp = bootRef.current;
+    const bootLook = pStr(bp, 'look', '');
+    if (bootLook) { lookRef.current = bootLook; engineRef.current.setLook(bootLook); }
+    yawRef.current = pNum(bp, 'yaw', yawRef.current);
+    pitchRef.current = pNum(bp, 'pitch', pitchRef.current);
+    if (bp.has('u') && bp.has('v')) {
+      engineRef.current.setPose({ u: pNum(bp, 'u', 0.5), v: pNum(bp, 'v', 0.5) });
+    }
     // Test seam (opt-in via ?polydebug): exposes the live minimap chart so a headless
     // harness can tell which side of the sheet the character is on. No effect on the
     // shipped app — the bridge is only attached when the query flag is present.
@@ -273,6 +299,32 @@ export default function PolygonWorlds() {
   }, [zoomBy]);
 
   const getMapState = useCallback(() => engineRef.current?.getMapState() ?? null, []);
+  // Opt-in debug HUD (?hud / ?debug=1): snapshots the live pose diagnostics so a
+  // headless shot records what the engine thinks the frame is. `determinant` (from
+  // the chart's flip bookkeeping) is cross-checked by the independent `witness` —
+  // the ink's geometric handedness (debugProbe), computed by a different path.
+  const showHud = useRef(hudEnabled(boot)).current;
+  const getDebug = useCallback((): DebugState | null => {
+    const eng = engineRef.current;
+    if (!eng) return null;
+    const ms = eng.getMapState();
+    const probe = eng.debugProbe();
+    const nm = ms
+      ? nearestMarkerDistance({ x: ms.u, y: ms.v }, propsRef.current.map((p) => ({ x: p.u, y: p.v })))
+      : undefined;
+    return {
+      world: worldRef.current.id,
+      look: lookRef.current,
+      pos: ms ? { x: ms.u, y: ms.v } : undefined,
+      yaw: yawRef.current,
+      pitch: pitchRef.current,
+      determinant: ms ? (ms.flipped ? -1 : 1) : undefined,
+      nearestMarker: nm,
+      // The independent ink-handedness check is only meaningful once a print
+      // exists (setPose clears the trail), so omit it until the player walks.
+      witness: Number.isFinite(probe) ? { label: 'ink', value: probe as number } : undefined,
+    };
+  }, []);
   // Player's unit surface-normal direction (pose up). For the spherical worlds this
   // is the point on the unit sphere the player occupies, which the embedding inset's
   // sphere/Roman marker rides; flat/hyperbolic immersions ignore it.
@@ -420,6 +472,7 @@ export default function PolygonWorlds() {
           <MovePad onSet={setKey} phone={phone} />
           <SquareMiniMap getState={getMapState} spec={spec} phone={phone} />
           <EmbeddingInset key={`embed-${spec.id}`} worldId={spec.id} getState={getMapState} getDir={getDir} phone={phone} />
+          {showHud && <DebugPoseHUD get={getDebug} phone={phone} />}
 
           {!phone && (
             <div style={{

--- a/src/animations/PolygonWorlds/PolygonWorlds.tsx
+++ b/src/animations/PolygonWorlds/PolygonWorlds.tsx
@@ -184,12 +184,17 @@ export default function PolygonWorlds() {
   }, []);
 
   // Rebuild the engine when the world changes (different cover/gluing) or when the
-  // landmark set changes (count/arrangement → the decor is rebuilt).
+  // landmark set changes (count/arrangement → the decor is rebuilt). The FIRST run
+  // is skipped: it fires on mount, right after Canvas3D's onMount already built the
+  // engine (children-first effect order) with the boot pose applied — rebuilding
+  // here would be redundant work AND would discard a debug-pose deep link's position.
+  const skipFirstRebuild = useRef(true);
   useEffect(() => {
     worldRef.current = spec;
     propsRef.current = props;
     const deps = depsRef.current;
     if (!deps || !engineRef.current) return;
+    if (skipFirstRebuild.current) { skipFirstRebuild.current = false; return; }
     engineRef.current.dispose();
     engineRef.current = makeFundamentalSquareEngine(deps, spec, {
       squareSize: sizeRef.current, floorThickness: thickRef.current, props,

--- a/src/animations/PolygonWorlds/coverModel.ts
+++ b/src/animations/PolygonWorlds/coverModel.ts
@@ -60,6 +60,12 @@ export interface CoverModel {
   chart(): SquareMapState;
   clearTrail(): void;
 
+  /** Debug-pose harness only: place the player at chart position (u, v ∈ 0..1) in
+   *  the home cell, on the canonical face. Heading is the host's look yaw, so this
+   *  sets position only; flipped sheets are reached by walking across a seam, not
+   *  by seeding a frame. Optional — covers that don't support it are skipped. */
+  setPose?(u: number, v: number): void;
+
   /** Test/diagnostic only: signed handedness of the freshest print's rendered
    *  image in the character's own frame (>0 ⇒ a print laid on the player's
    *  current face reads right-handed under them). Must settle to the same

--- a/src/animations/PolygonWorlds/engineTypes.ts
+++ b/src/animations/PolygonWorlds/engineTypes.ts
@@ -48,6 +48,9 @@ export interface PolygonEngine {
   setCameraDistance(d: number): void;
   /** Switch the scene atmosphere (sky/fog tint, exposure, light rig). See looks.ts. */
   setLook(id: string): void;
+  /** Debug-pose harness only: place the player at chart position (u, v ∈ 0..1) on
+   *  the canonical face. No-op on covers that don't support it (spherical/hyperbolic). */
+  setPose(p: { u?: number; v?: number }): void;
   getMapState(): SquareMapState | null;
   /** Latest player pose in world space (foot position + surface normal + heading),
    *  for the extrinsic embedding inset's marker. null before the first frame. */

--- a/src/animations/PolygonWorlds/fundamentalSquareEngine.ts
+++ b/src/animations/PolygonWorlds/fundamentalSquareEngine.ts
@@ -173,6 +173,7 @@ export function makeFundamentalSquareEngine(deps: EngineDeps, spec: WorldSpec, o
     setFloorThickness: (t) => { cover.setFloorThickness?.(t); applyAtmosphere(); },
     setLook: (id) => applyLook(findLook(id)),
     setCameraDistance: (d) => cover.setCameraDistance?.(d),
+    setPose: (p) => { if (p.u != null && p.v != null) cover.setPose?.(p.u, p.v); },
     getMapState: () => mapState,
     getPose: () => poseState,
     debugProbe: () => cover.debugProbe?.(),

--- a/src/animations/PolygonWorlds/presenters/euclidean.ts
+++ b/src/animations/PolygonWorlds/presenters/euclidean.ts
@@ -456,6 +456,16 @@ export function makeEuclideanPresenter(c: CoverDeps): CoverModel {
       return ink.chirality(stamps.length - 1, M, forward, UP);
     },
     clearTrail: () => { stamps.length = 0; lastFrozen = null; ink.setCount(0); },
+    // Debug-pose harness: drop the player at chart (u,v) in the home cell, on the
+    // canonical face (flipAcc=0). The inverse of chart()'s home-cell branch:
+    // square worlds chart u = bx/side + 0.5; polygon worlds u = (bx/scale + 1)/2.
+    setPose: (u: number, v: number) => {
+      if (squareChart) { px = (u - 0.5) * side; pz = (v - 0.5) * side; }
+      else { px = (2 * u - 1) * scale; pz = (2 * v - 1) * scale; }
+      flipAcc = 0;
+      pos.set(px, 0, pz);
+      stamps.length = 0; lastFrozen = null; ink.setCount(0);   // no streak from the old spot
+    },
     plantSign: (front: string, back: string) => {
       if (signs.length >= MAX_SIGNS) signs.shift()!.builder.dispose();
       signs.push({

--- a/src/animations/SolidWorlds/SolidWorlds.tsx
+++ b/src/animations/SolidWorlds/SolidWorlds.tsx
@@ -14,6 +14,9 @@ import {
   EngineDeps3, SolidEngine, ChiralityState, SolidMapState, TravelMode, DecorMode,
   DEFAULT_ROOM_SIZE, DEFAULT_COVER_DEPTH,
 } from './engineTypes';
+import DebugPoseHUD from '../../components/DebugPoseHUD';
+import { poseParams, pNum, pStr, hudEnabled, type DebugState } from '../../lib/debugPose';
+import { nearestMarkerDistance } from '../../lib/nearestMarker';
 import explainerText from './EXPLAINER.md?raw';
 
 const LOOK_SENS = 0.0035;
@@ -25,12 +28,22 @@ type MoveKey = 'fwd' | 'back' | 'left' | 'right' | 'up' | 'down';
 
 export default function SolidWorlds() {
   const pk = (f: string) => `solid-worlds:${f}`;
-  const [worldId, setWorldId] = useState(DEFAULT_WORLD_ID);
+  // Debug-pose deep link (docs/HEADLESS_WEBGL.md): a hash query can pin the world,
+  // camera and pose so a headless shot reproduces an exact frame. Parsed once; an
+  // explicit URL param wins over the session default. Absent params → today's behavior.
+  const bootRef = useRef(poseParams());
+  const boot = bootRef.current;
+  const bootWorld = pStr(boot, 'world', '');
+  const [worldId, setWorldId] = useState(() =>
+    SOLID_WORLDS.some((w) => w.id === bootWorld) ? bootWorld : DEFAULT_WORLD_ID);
   const [moveSpeed, setMoveSpeed] = usePersistentState(pk('moveSpeed'), 5);
-  const [thirdPerson, setThirdPerson] = useState(true);
+  const [thirdPerson, setThirdPerson] = useState(() => pStr(boot, 'cam', 'third') !== 'first');
   const [mode, setMode] = usePersistentState<TravelMode>(pk('mode'), 'walk');
   const [trailEnabled, setTrailEnabled] = useState(false); // off by default
-  const [camDistance, setCamDistance] = useState(6);
+  const [camDistance, setCamDistance] = useState(() => {
+    const c = pNum(boot, 'camd', NaN);
+    return Number.isFinite(c) ? clampCam(c) : 6;
+  });
   // Session-only (not persisted): a quality/perf knob whose default should always
   // win on load — otherwise a stale stored value hides the hall-of-mirrors depth.
   const [coverDepth, setCoverDepth] = useState(DEFAULT_COVER_DEPTH);
@@ -90,6 +103,22 @@ export default function SolidWorlds() {
       showSeams: seamsRef.current, decorMode: decorRef.current,
     });
     engineRef.current.setTrailEnabled(trailRef.current);
+    // Debug-pose deep link: ?look= overrides the view engine-level (doesn't clobber
+    // the persisted look); seed the look orientation; drop the walker at the
+    // requested cube position (x,y,z ∈ −1..1 → setPose u,v,w). Read via the ref so
+    // onMount stays dependency-free.
+    const bp = bootRef.current;
+    const bootLook = pStr(bp, 'look', '');
+    if (bootLook) { lookRef.current = bootLook; engineRef.current.setLook(bootLook); }
+    yawRef.current = pNum(bp, 'yaw', yawRef.current);
+    pitchRef.current = pNum(bp, 'pitch', pitchRef.current);
+    if (bp.has('x') || bp.has('y') || bp.has('z')) {
+      engineRef.current.setPose({
+        u: bp.has('x') ? pNum(bp, 'x', 0) : undefined,
+        v: bp.has('y') ? pNum(bp, 'y', 0) : undefined,
+        w: bp.has('z') ? pNum(bp, 'z', 0) : undefined,
+      });
+    }
     clockRef.current.start();
     const animate = () => {
       const eng = engineRef.current;
@@ -224,6 +253,29 @@ export default function SolidWorlds() {
   }, []);
   const getChirality = useCallback(() => engineRef.current?.getChirality() ?? null, []);
   const getMap = useCallback(() => engineRef.current?.getMapState() ?? null, []);
+  // Opt-in debug HUD (?hud / ?debug=1): snapshots the live pose so a headless shot
+  // records what the engine thinks the frame is — the dual-verified determinant
+  // (loop handedness), the cell, the cube position, and distance to the nearest
+  // cube vertex. (SolidWorlds has no geometric ink-probe analog, so it carries no
+  // independent `witness` yet — deferred; its determinant is the authoritative,
+  // screw-safe invariant. See the session log.)
+  const showHud = useRef(hudEnabled(boot)).current;
+  const getDebug = useCallback((): DebugState | null => {
+    const eng = engineRef.current;
+    if (!eng) return null;
+    const ms = eng.getMapState();
+    if (!ms) return null;
+    return {
+      world: worldRef.current.id,
+      look: lookRef.current,
+      pos: { x: ms.u, y: ms.v, z: ms.w },
+      yaw: yawRef.current,
+      pitch: pitchRef.current,
+      determinant: ms.mirrored ? -1 : 1,
+      cell: ms.cell,
+      nearestMarker: nearestMarkerDistance({ x: ms.u, y: ms.v, z: ms.w }, CUBE_VERTS),
+    };
+  }, []);
 
   const actions: ActionDef[] = [
     { id: 'recenter', icon: 'move', label: 'Recenter', primary: true, onClick: recenter },
@@ -350,6 +402,7 @@ export default function SolidWorlds() {
           </div>
           <ChiralityHUD get={getChirality} phone={phone} />
           <SolidMiniMap get={getMap} perAxis={analysis.perAxis} phone={phone} />
+          {showHud && <DebugPoseHUD get={getDebug} phone={phone} />}
           <MovePad onSet={setKey} phone={phone} />
           {!phone && (
             <div style={{
@@ -466,6 +519,9 @@ const CUBE_CORNERS: [number, number, number][] = [
 const CUBE_EDGES: [number, number][] = [
   [0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7],
 ];
+// The cube corners as {x,y,z} points (same u,v,w ∈ −1..1 frame the map reports) —
+// the markers for the debug HUD's nearest-vertex readout.
+const CUBE_VERTS = CUBE_CORNERS.map(([x, y, z]) => ({ x, y, z }));
 const AXIS_COLOR: Record<string, string> = {
   translation: '#7fa8d8', rotation: '#ffcf5a', 'glide-reflection': '#ff5aa6',
 };

--- a/src/animations/SolidWorlds/SolidWorlds.tsx
+++ b/src/animations/SolidWorlds/SolidWorlds.tsx
@@ -140,11 +140,16 @@ export default function SolidWorlds() {
     rafRef.current = requestAnimationFrame(animate);
   }, []);
 
-  // Rebuild the engine when the world changes (different gluing / cover).
+  // Rebuild the engine when the world changes (different gluing / cover). The FIRST
+  // run is skipped: it fires on mount, right after Canvas3D's onMount already built
+  // the engine (children-first effect order) with the boot pose applied — rebuilding
+  // here would be redundant AND would discard a debug-pose deep link's x/y/z position.
+  const skipFirstRebuild = useRef(true);
   useEffect(() => {
     worldRef.current = spec;
     const deps = depsRef.current;
     if (!deps || !engineRef.current) return;
+    if (skipFirstRebuild.current) { skipFirstRebuild.current = false; return; }
     engineRef.current.dispose();
     engineRef.current = makeCoverEngine(deps, spec, {
       roomSize: sizeRef.current, coverDepth: depthRef.current,

--- a/src/animations/SolidWorlds/coverEngine.ts
+++ b/src/animations/SolidWorlds/coverEngine.ts
@@ -721,6 +721,14 @@ export function makeCoverEngine(deps: EngineDeps3, spec: SolidWorldSpec, opts: O
       pos.set(0, 0, 0); bodyLinear.identity();
       cell.x = 0; cell.y = 0; cell.z = 0; hasStamp = false;
     },
+    setPose(p: { u?: number; v?: number; w?: number }) {
+      // u,v,w ∈ −1..1 are cube coordinates (pos / half-size); map back to world.
+      if (p.u != null) pos.x = p.u * h();
+      if (p.v != null) pos.y = p.v * h();
+      if (p.w != null) pos.z = p.w * h();
+      bodyLinear.identity();
+      cell.x = 0; cell.y = 0; cell.z = 0; hasStamp = false;
+    },
     getChirality(): ChiralityState {
       const e = bodyLinear.elements; // column-major; diagonal at 0, 5, 10
       const trace = e[0] + e[5] + e[10];

--- a/src/animations/SolidWorlds/engineTypes.ts
+++ b/src/animations/SolidWorlds/engineTypes.ts
@@ -92,6 +92,11 @@ export interface SolidEngine {
   setDecorMode(mode: DecorMode): void;
   /** Return the walker to the cube center, frame upright, holonomy cleared. */
   recenter(): void;
+  /** Debug-pose harness only: place the walker at cube position (u,v,w ∈ −1..1),
+   *  frame upright, holonomy/cell cleared (like recenter, but off-center). Heading
+   *  is the host's look yaw, so this sets position only. In grounded modes the
+   *  vertical (v) is re-locked to floor height next frame — use fly for an exact w. */
+  setPose(p: { u?: number; v?: number; w?: number }): void;
   getChirality(): ChiralityState | null;
   getMapState(): SolidMapState | null;
   dispose(): void;

--- a/src/components/DebugPoseHUD.tsx
+++ b/src/components/DebugPoseHUD.tsx
@@ -32,7 +32,7 @@ function lines(s: DebugState): string[] {
   }
   if (s.cell) out.push(`cell   ${s.cell.x} ${s.cell.y} ${s.cell.z}`);
   if (s.nearestMarker != null) out.push(`marker ${fmt(s.nearestMarker)}`);
-  if (s.jump != null) out.push(`jump   ${fmt(s.jump, 4)}`);
+  if (s.witness) out.push(`${s.witness.label.padEnd(6).slice(0, 6)} ${fmt(s.witness.value, 4)}`);
   return out;
 }
 
@@ -64,8 +64,9 @@ export default function DebugPoseHUD({
     <div
       style={{
         position: 'absolute',
-        bottom: 12,
+        top: phone ? 190 : 180,
         right: 12,
+        zIndex: 30,
         pointerEvents: 'none',
         padding: '8px 12px',
         borderRadius: 8,

--- a/src/components/DebugPoseHUD.tsx
+++ b/src/components/DebugPoseHUD.tsx
@@ -1,0 +1,105 @@
+// src/components/DebugPoseHUD.tsx
+//
+// The opt-in dev HUD for the debug-pose harness. Mounted only when a route asks
+// for it (`?hud` / `?debug=1`, via debugPose.hudEnabled), it overlays a compact
+// text readout of the live pose diagnostics on the canvas so a headless
+// screenshot records *what the engine thinks the frame is*, not just the picture.
+//
+// Modeled on SolidWorlds' ChiralityHUD: a fixed-corner, pointer-events:none
+// overlay that polls a getter in a rAF loop. It is text-only and never mounts
+// unless requested, so it has zero impact on the shipped UI.
+//
+// Each walker passes a `get` that snapshots its own state into a DebugState; the
+// HUD renders whichever fields are present (a 2D walker omits z/cell, etc.).
+
+import React, { useEffect, useRef } from 'react';
+import type { DebugState } from '../lib/debugPose';
+
+const fmt = (n: number, d = 2) => (Number.isFinite(n) ? n.toFixed(d) : '∞');
+
+function lines(s: DebugState): string[] {
+  const out: string[] = [];
+  if (s.world) out.push(`world  ${s.world}${s.look ? ` · ${s.look}` : ''}`);
+  if (s.pos) {
+    const z = s.pos.z != null ? ` ${fmt(s.pos.z)}` : '';
+    out.push(`pos    ${fmt(s.pos.x)} ${fmt(s.pos.y)}${z}`);
+  }
+  if (s.yaw != null || s.pitch != null) {
+    out.push(`look   yaw ${fmt(s.yaw ?? 0)} · pitch ${fmt(s.pitch ?? 0)}`);
+  }
+  if (s.determinant != null) {
+    out.push(`det    ${s.determinant > 0 ? '+1 (original)' : '−1 (mirrored)'}`);
+  }
+  if (s.cell) out.push(`cell   ${s.cell.x} ${s.cell.y} ${s.cell.z}`);
+  if (s.nearestMarker != null) out.push(`marker ${fmt(s.nearestMarker)}`);
+  if (s.jump != null) out.push(`jump   ${fmt(s.jump, 4)}`);
+  return out;
+}
+
+/**
+ * @param get   snapshot the live DebugState (called every frame); return null
+ *              until the engine is ready.
+ * @param phone nudge below the phone top bar.
+ */
+export default function DebugPoseHUD({
+  get,
+  phone,
+}: {
+  get: () => DebugState | null;
+  phone?: boolean;
+}) {
+  const ref = useRef<HTMLPreElement>(null);
+  useEffect(() => {
+    let raf = 0;
+    const loop = () => {
+      const s = get();
+      if (s && ref.current) ref.current.textContent = lines(s).join('\n');
+      raf = requestAnimationFrame(loop);
+    };
+    raf = requestAnimationFrame(loop);
+    return () => cancelAnimationFrame(raf);
+  }, [get]);
+
+  return (
+    <div
+      style={{
+        position: 'absolute',
+        bottom: 12,
+        right: 12,
+        pointerEvents: 'none',
+        padding: '8px 12px',
+        borderRadius: 8,
+        background: 'rgba(8,10,18,0.62)',
+        border: '1px solid rgba(255,255,255,0.16)',
+        boxShadow: '0 4px 14px rgba(0,0,0,0.4)',
+        backdropFilter: 'blur(6px)',
+        maxWidth: phone ? '70vw' : 280,
+      }}
+    >
+      <div
+        style={{
+          fontSize: 9,
+          letterSpacing: '0.1em',
+          textTransform: 'uppercase',
+          color: 'rgba(255,255,255,0.55)',
+          marginBottom: 4,
+        }}
+      >
+        Debug pose
+      </div>
+      <pre
+        ref={ref}
+        style={{
+          margin: 0,
+          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+          fontSize: 11,
+          lineHeight: 1.45,
+          color: 'rgba(255,255,255,0.82)',
+          whiteSpace: 'pre',
+        }}
+      >
+        …
+      </pre>
+    </div>
+  );
+}

--- a/src/lib/__tests__/nearestMarker.test.ts
+++ b/src/lib/__tests__/nearestMarker.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { distance, nearestMarker, nearestMarkerDistance, Pt } from '../nearestMarker';
+
+describe('distance', () => {
+  it('measures 2D distance (z defaults to 0)', () => {
+    expect(distance({ x: 0, y: 0 }, { x: 3, y: 4 })).toBe(5);
+  });
+
+  it('measures 3D distance', () => {
+    expect(distance({ x: 0, y: 0, z: 0 }, { x: 2, y: 3, z: 6 })).toBe(7);
+  });
+
+  it('treats a missing z as 0 (planar) when mixing 2D and 3D', () => {
+    expect(distance({ x: 0, y: 0 }, { x: 0, y: 0, z: 4 })).toBe(4);
+  });
+
+  it('is zero for coincident points', () => {
+    expect(distance({ x: 1, y: -2, z: 3 }, { x: 1, y: -2, z: 3 })).toBe(0);
+  });
+});
+
+describe('nearestMarker', () => {
+  it('returns null when there are no markers', () => {
+    expect(nearestMarker({ x: 0, y: 0 }, [])).toBeNull();
+  });
+
+  it('returns the single marker', () => {
+    expect(nearestMarker({ x: 0, y: 0 }, [{ x: 3, y: 4 }])).toEqual({ index: 0, distance: 5 });
+  });
+
+  it('picks the nearest of several', () => {
+    const markers: Pt[] = [
+      { x: 10, y: 0 },
+      { x: 2, y: 0 },
+      { x: 5, y: 0 },
+    ];
+    expect(nearestMarker({ x: 0, y: 0 }, markers)).toEqual({ index: 1, distance: 2 });
+  });
+
+  it('works in 3D', () => {
+    const markers: Pt[] = [
+      { x: 0, y: 0, z: 9 },
+      { x: 0, y: 0, z: 1 },
+    ];
+    expect(nearestMarker({ x: 0, y: 0, z: 0 }, markers)).toEqual({ index: 1, distance: 1 });
+  });
+
+  it('breaks ties toward the lowest index', () => {
+    const markers: Pt[] = [
+      { x: 1, y: 0 },
+      { x: -1, y: 0 },
+    ];
+    expect(nearestMarker({ x: 0, y: 0 }, markers)?.index).toBe(0);
+  });
+});
+
+describe('nearestMarkerDistance', () => {
+  it('is Infinity when there are no markers', () => {
+    expect(nearestMarkerDistance({ x: 0, y: 0 }, [])).toBe(Infinity);
+  });
+
+  it('returns the nearest distance', () => {
+    expect(nearestMarkerDistance({ x: 0, y: 0 }, [{ x: 8, y: 0 }, { x: 3, y: 0 }])).toBe(3);
+  });
+});

--- a/src/lib/debugPose.ts
+++ b/src/lib/debugPose.ts
@@ -1,0 +1,100 @@
+// src/lib/debugPose.ts
+//
+// Shared "debug-pose deep link" helpers for the headless verification harness.
+//
+// The cloud/CI container renders the app in headless software WebGL (see
+// docs/HEADLESS_WEBGL.md) but `scripts/shoot.mjs` could only ever capture an
+// app's *default* view. These helpers let a route carry a pose in its hash
+// query (`#/solid-worlds?world=amphicosm&x=0.1&yaw=1.5&hud`), so an exact frame
+// can be reproduced and eyeballed — turning "verified headless" from a blind
+// hypothesis into a reproducible visual diff.
+//
+// This module is app-agnostic: it parses the query and offers typed accessors.
+// Each app maps the params it understands (position semantics differ — a 3D cube
+// cell vs a 2D chart square — by design); unknown params are ignored, so an app
+// can extend the vocabulary without touching this helper.
+//
+// Documented param vocabulary (see docs/HEADLESS_WEBGL.md):
+//   world=<id>   look=<id>   cam=first|third   camd=<n>
+//   yaw=<rad>    pitch=<rad>
+//   x,y,z=<n>    (SolidWorlds cube position, -1..1)
+//   u,v=<n>      (PolygonWorlds chart position, 0..1)
+//   hud | debug=1   show the opt-in dev HUD
+//   freeze | t=<s>  pin the animation clock for a reproducible frame
+
+/** Read the hash-query params (`#/route?a=1&b=2` → URLSearchParams). SSR-safe. */
+export function poseParams(): URLSearchParams {
+  if (typeof window === 'undefined') return new URLSearchParams();
+  return new URLSearchParams(window.location.hash.split('?')[1] ?? '');
+}
+
+/** A finite number param, or the default. */
+export function pNum(p: URLSearchParams, key: string, dflt: number): number {
+  const v = p.get(key);
+  const n = v == null ? NaN : parseFloat(v);
+  return Number.isFinite(n) ? n : dflt;
+}
+
+/** A boolean param: bare-present, `1/true/yes/on` → true; `0/false/no/off` → false. */
+export function pBool(p: URLSearchParams, key: string, dflt: boolean): boolean {
+  if (!p.has(key)) return dflt;
+  const v = (p.get(key) ?? '').trim().toLowerCase();
+  if (v === '' || v === '1' || v === 'true' || v === 'yes' || v === 'on') return true;
+  if (v === '0' || v === 'false' || v === 'no' || v === 'off') return false;
+  return dflt;
+}
+
+/** A string param, or the default. */
+export function pStr(p: URLSearchParams, key: string, dflt: string): string {
+  const v = p.get(key);
+  return v == null || v === '' ? dflt : v;
+}
+
+/** Is the opt-in dev HUD requested? (`?hud` or `?debug=1`). */
+export function hudEnabled(p: URLSearchParams = poseParams()): boolean {
+  return p.has('hud') || pBool(p, 'debug', false);
+}
+
+/**
+ * The frozen animation time, in seconds, or null if not requested.
+ *
+ * A reproducible screenshot needs a deterministic frame, but the walkers run a
+ * wall-clock rAF loop — two shots of the same URL can differ. `?freeze` pins the
+ * clock at 0; `?t=<seconds>` pins it at a chosen time. Apps that honor this feed
+ * the returned value to their animation in place of the live delta.
+ */
+export function frozenTime(p: URLSearchParams = poseParams()): number | null {
+  if (p.has('t')) return pNum(p, 't', 0);
+  if (p.has('freeze')) return 0;
+  return null;
+}
+
+/**
+ * The app-agnostic diagnostic snapshot rendered by the dev HUD. An app fills the
+ * fields it can; the HUD shows whichever are present.
+ *
+ * `determinant` and `cell` echo state the app's own probe reads — so they alone
+ * can't certify a frame (a HUD reading the same possibly-wrong state is an echo,
+ * not a check). `jump` is the independent witness: a per-frame discontinuity of
+ * the body frame across a gluing, which a wrong-sheet placement reveals even when
+ * the determinant looks right.
+ */
+export interface DebugState {
+  /** Selected world / spec id. */
+  world?: string;
+  /** Selected scene look. */
+  look?: string;
+  /** Player position (2D apps omit z). */
+  pos?: { x: number; y: number; z?: number };
+  /** Look orientation, radians. */
+  yaw?: number;
+  pitch?: number;
+  /** Orientation/handedness of the player frame (+1 original, -1 mirrored). */
+  determinant?: 1 | -1;
+  /** Which fundamental cell the player is in (3-manifold walkers). */
+  cell?: { x: number; y: number; z: number };
+  /** Distance to the nearest landmark/marker (see nearestMarker.ts). */
+  nearestMarker?: number;
+  /** Independent continuity witness: body-frame jump magnitude this frame. */
+  jump?: number;
+}

--- a/src/lib/debugPose.ts
+++ b/src/lib/debugPose.ts
@@ -75,9 +75,10 @@ export function frozenTime(p: URLSearchParams = poseParams()): number | null {
  *
  * `determinant` and `cell` echo state the app's own probe reads — so they alone
  * can't certify a frame (a HUD reading the same possibly-wrong state is an echo,
- * not a check). `jump` is the independent witness: a per-frame discontinuity of
- * the body frame across a gluing, which a wrong-sheet placement reveals even when
- * the determinant looks right.
+ * not a check). `witness` is the *independent* cross-check: a quantity computed by
+ * a different path than the chart's bookkeeping — PolygonWorlds' geometric ink
+ * handedness (`debugProbe`), SolidWorlds' per-frame body-frame continuity jump —
+ * that a wrong-sheet placement reveals even when the determinant looks right.
  */
 export interface DebugState {
   /** Selected world / spec id. */
@@ -95,6 +96,7 @@ export interface DebugState {
   cell?: { x: number; y: number; z: number };
   /** Distance to the nearest landmark/marker (see nearestMarker.ts). */
   nearestMarker?: number;
-  /** Independent continuity witness: body-frame jump magnitude this frame. */
-  jump?: number;
+  /** An independent cross-check, computed by a different path than `determinant`
+   *  (e.g. ink handedness, a frame-continuity jump) — labeled so the HUD names it. */
+  witness?: { label: string; value: number };
 }

--- a/src/lib/nearestMarker.ts
+++ b/src/lib/nearestMarker.ts
@@ -1,0 +1,43 @@
+// src/lib/nearestMarker.ts
+//
+// Pure geometry helper for the debug-pose HUD: the distance from the player to
+// the nearest landmark/marker in a world. The only diagnostic the harness needs
+// that isn't already computed by the walker engines, so it lives here as a small,
+// dimension-agnostic, unit-tested function (see __tests__/nearestMarker.test.ts).
+
+/** A 2D or 3D point. A missing `z` is treated as 0 (planar comparison). */
+export interface Pt {
+  x: number;
+  y: number;
+  z?: number;
+}
+
+/** Euclidean distance between two points (works for 2D and 3D, mixing is fine). */
+export function distance(a: Pt, b: Pt): number {
+  const dx = a.x - b.x;
+  const dy = a.y - b.y;
+  const dz = (a.z ?? 0) - (b.z ?? 0);
+  return Math.hypot(dx, dy, dz);
+}
+
+/**
+ * The nearest marker to `player`, as `{ index, distance }`, or `null` when there
+ * are no markers. On a tie the lowest index wins (deterministic).
+ */
+export function nearestMarker(
+  player: Pt,
+  markers: readonly Pt[],
+): { index: number; distance: number } | null {
+  let best: { index: number; distance: number } | null = null;
+  for (let i = 0; i < markers.length; i++) {
+    const d = distance(player, markers[i]);
+    if (best === null || d < best.distance) best = { index: i, distance: d };
+  }
+  return best;
+}
+
+/** Convenience: just the distance to the nearest marker, or `Infinity` if none. */
+export function nearestMarkerDistance(player: Pt, markers: readonly Pt[]): number {
+  const n = nearestMarker(player, markers);
+  return n === null ? Infinity : n.distance;
+}


### PR DESCRIPTION
Builds the **L1 positive check** from `RECURRING_LESSONS.md` — the highest tool-ROI item in the process audit (~14 reflections, requested independently 3× across the topology sessions): the missing automated check behind *"verified headless, never on a real device."* `RECURRING_LESSONS.md` **L1 is now 🟢 (rule + check)**.

Developed as: plan → `/three-hats` review → a pre-build experiment that measured the design's two riskiest assumptions → 5 implementation phases. The plan, the three expert reviews, the synthesis, and the full session log are committed under `docs/sessions/progress/headless-mode-plan-bbk74b/`.

## Two deliverables

**A · Deep-link debug-pose harness + opt-in dev HUD.** A shareable hash-query pose (`#/solid-worlds?world=half-turn&x=0.4&z=-0.3&yaw=0.8&cam=third&hud`) lets `scripts/shoot.mjs` reproduce an *exact* walker frame instead of the blind default view — a reproducible visual diff (and a shareable teaching link). Adopted by **Polygon Worlds** and **Solid Worlds** (each engine gained a `setPose`). The `?hud` overlay records the engine's own diagnostics — determinant, cell, position, nearest-marker, and (Polygon Worlds) an *independent* ink-handedness witness.

**B · `npm run smoke`** (`scripts/smoke.mjs`). Loads **every route at 390×844** in software WebGL and fails on the runtime-crash / blank-frame class that escapes `tsc && vite build` (the #216 Torus crash). **PASS 17/17.** Detectors are grounded in the experiment, not guessed: `pageerror` + `webglcontextlost` load-bearing; `console.error` advisory (resource-load allowlist); dead-frame = low luma variance of the canvas-clipped screenshot. Runs as a **non-blocking** PR check (`.github/workflows/smoke.yml`, separate from `deploy.yml`).

## Notable

- **Design changed by measurement:** determinism holds at idle (so `freeze` is insurance, not a precondition); `gl.readPixels` is unreliable on `preserveDrawingBuffer:false` (so the dead-frame check reads the screenshot); variance, not brightness; clean routes log baseline resource `console.error`s.
- **An honest gap:** Solid Worlds carries no independent witness yet — deferred (filed `[solid-worlds] !med`), not faked, because a wrong witness is the exact "green check that wasn't" the harness exists to prevent.
- **A real finding the smoke surfaced:** `THREE.RGBELoader: Unsupported type: 1009` (HDR env fails on ComplexParticles, falls back) — filed `[complex-particles] !low` with the fix.
- Two same-URL shots from separate processes are **visually identical but not byte-identical** (sub-pixel SwiftShader noise) — compare with a pixel tolerance, never `cmp`. Documented.

## Verification

- `npm run build` ✓ · `npm test` **64/64** ✓ (incl. 11 new `nearestMarker` cases) · `eslint src` 0 errors (no new warnings).
- Harness verified by **reading the headless screenshots** — every param visibly takes (Klein/torus on Polygon Worlds; half-turn dicosm on Solid Worlds).
- Smoke verified PASS 17/17 *and* watched to correctly FAIL before calibration.
- Not a substitute for a real device — `phone-needed` stays a standing signal (the dead-frame detector is a blank-check, and SwiftShader tolerates NaN that real mobile GPUs crash on).

## Shared-file touches (all additive)

`package.json` (+`smoke` script — now on the append-only protected list), `CLAUDE.md` + `docs/BUILDING_AN_APP.md` (that protected-list note), and the docs ledger (`HEADLESS_WEBGL.md`, `RECURRING_LESSONS.md`, `RECIPES.md`, `TODO.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X4Htp57UyRUpymFmtveZuB

---
_Generated by [Claude Code](https://claude.ai/code/session_01X4Htp57UyRUpymFmtveZuB)_