### PR TITLE
Add screenshot tour harness for full-site visual capture

### DIFF
--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,0 +1,77 @@
+name: Screenshot tour
+
+# "See the whole site" on demand: drives the real built app in headless
+# Chromium (software WebGL via ANGLE + SwiftShader) across every app in both
+# desktop and phone form factors, exercising each app's modes and layouts, and
+# uploads the PNGs + an index.html contact sheet as a downloadable artifact.
+#
+# Invoked manually from the Actions tab (workflow_dispatch). Optional inputs let
+# you narrow the run (a single app) or restyle it (a non-default skin).
+
+on:
+  workflow_dispatch:
+    inputs:
+      only:
+        description: 'Limit to routes matching these (comma list of hash/slug fragments, e.g. "trinary,fractals"). Blank = every app.'
+        required: false
+        default: ''
+      viewports:
+        description: 'Form factors to capture'
+        required: false
+        default: 'desktop,mobile'
+        type: choice
+        options: ['desktop,mobile', 'desktop', 'mobile']
+      skin:
+        description: 'Skin to seed (blank = default). e.g. phosphor, blueprint, parchment, noir'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+jobs:
+  tour:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      # Chrome runtime libraries for headless software WebGL (mirrors
+      # scripts/install_headless_webgl.sh, which only runs as root in the cloud).
+      - name: Install Chrome runtime libraries
+        run: |
+          sudo apt-get update -o Dir::Etc::sourceparts="-" \
+            -o Dir::Etc::sourcelist="sources.list.d/ubuntu.sources" || true
+          sudo apt-get install -y --no-install-recommends \
+            ca-certificates fonts-liberation libasound2t64 libatk-bridge2.0-0t64 \
+            libatk1.0-0t64 libcups2t64 libdbus-1-3 libdrm2 libgbm1 libgtk-3-0t64 \
+            libnspr4 libnss3 libpango-1.0-0 libxcomposite1 libxdamage1 \
+            libxfixes3 libxkbcommon0 libxrandr2 || true
+      - run: npm ci   # puppeteer's postinstall fetches Chrome-for-Testing
+      - run: npm run build
+      - name: Serve the built app
+        run: |
+          nohup npm run preview > preview.log 2>&1 &
+          for i in $(seq 1 40); do
+            curl -fsS http://localhost:4173/animath/ > /dev/null && { echo "server up"; break; }
+            sleep 1
+          done
+      - name: Screenshot tour
+        # The tour exits non-zero if any single shot fails; don't fail the whole
+        # run for that — we still want the partial set + contact sheet uploaded.
+        continue-on-error: true
+        env:
+          BASE_URL: http://localhost:4173/animath/
+          ONLY: ${{ inputs.only }}
+          VIEWPORTS: ${{ inputs.viewports }}
+          SKIN: ${{ inputs.skin }}
+        run: node scripts/tour.mjs
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: animath-screenshots${{ inputs.skin && format('-{0}', inputs.skin) || '' }}
+          path: screenshots/
+          if-no-files-found: warn

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -12,17 +12,23 @@ on:
   workflow_dispatch:
     inputs:
       only:
-        description: 'Limit to routes matching these (comma list of hash/slug fragments, e.g. "trinary,fractals"). Blank = every app.'
+        description: 'Target — limit to routes matching these (comma list of hash/slug fragments, e.g. "trinary,fractals", or "gallery"). Blank = every app.'
         required: false
         default: ''
+      detail:
+        description: 'Level of detail (overview → everything)'
+        required: false
+        default: 'everything'
+        type: choice
+        options: ['everything', 'standard', 'overview']
       viewports:
         description: 'Form factors to capture'
         required: false
         default: 'desktop,mobile'
         type: choice
         options: ['desktop,mobile', 'desktop', 'mobile']
-      skin:
-        description: 'Skin to seed (blank = default). e.g. phosphor, blueprint, parchment, noir'
+      skins:
+        description: 'Skins (blank = default only). "all", or a comma list of ids: dark, light, neon, blueprint, phosphor'
         required: false
         default: ''
 
@@ -65,13 +71,14 @@ jobs:
         env:
           BASE_URL: http://localhost:4173/animath/
           ONLY: ${{ inputs.only }}
+          DETAIL: ${{ inputs.detail }}
           VIEWPORTS: ${{ inputs.viewports }}
-          SKIN: ${{ inputs.skin }}
+          SKINS: ${{ inputs.skins }}
         run: node scripts/tour.mjs
       - name: Upload screenshots
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: animath-screenshots${{ inputs.skin && format('-{0}', inputs.skin) || '' }}
+          name: animath-screenshots-${{ inputs.detail }}${{ inputs.skins && format('-{0}', inputs.skins) || '' }}
           path: screenshots/
           if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,13 @@
 node_modules/
 dist/
 
+# Generated screenshot tour (rebuilt by `npm run tour` / CI; uploaded as a
+# workflow artifact, never committed — large generated binaries)
+screenshots/
+
+# Local scratch (smoke tests)
+scratch-smoke/
+
 # Generated session site (rebuilt by `npm run sessions` / CI; never committed)
 docs/sessions/converted/
 docs/sessions/control-center.html

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ npm run build   # tsc && vite build → dist/   (the ONLY CI check)
 npm test        # vitest unit tests (chrome workspace pure logic)
 npm run lint    # eslint over src/ (keep it green)
 npm run preview # preview the production build
+npm run tour    # screenshot the site (desktop+phone, layouts/modes/skins) → screenshots/ (docs/SCREENSHOTS.md)
 ```
 
 ## Creating a new app (summary)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ npm run build       # TypeScript check + Vite production build → dist/
 npm run preview     # preview production build locally
 npm test            # vitest unit tests (chrome workspace pure logic)
 npm run lint        # eslint over src/ (keep it at 0 errors)
+npm run tour        # screenshot every app (desktop + phone, all layouts/modes) → screenshots/ (docs/SCREENSHOTS.md)
 ```
 
 Node >= 20, npm >= 10 required. The only CI check is `npm run build` (which runs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,7 +26,7 @@ npm run build       # TypeScript check + Vite production build → dist/
 npm run preview     # preview production build locally
 npm test            # vitest unit tests (chrome workspace pure logic)
 npm run lint        # eslint over src/ (keep it at 0 errors)
-npm run tour        # screenshot every app (desktop + phone, all layouts/modes) → screenshots/ (docs/SCREENSHOTS.md)
+npm run tour        # screenshot the site (desktop + phone) → screenshots/; target one app, set detail (overview→everything), or skins (docs/SCREENSHOTS.md)
 ```
 
 Node >= 20, npm >= 10 required. The only CI check is `npm run build` (which runs

--- a/docs/BUILDING_AN_APP.md
+++ b/docs/BUILDING_AN_APP.md
@@ -510,7 +510,13 @@ npm run dev      # open http://localhost:5173/animath/#/my-app
 npm run build    # MUST pass — tsc + vite build, the only CI gate
 npm run lint     # keep at 0 errors (and don't add new warnings)
 npm test         # vitest — and add a test for any pure logic you extracted (§6)
+npm run tour -- my-app   # screenshot your app (desktop+phone · every layout) → screenshots/ (docs/SCREENSHOTS.md)
 ```
+
+> The tour auto-discovers your app from `src/apps.ts`, so once it's registered
+> (§3) `npm run tour -- my-app` captures it in both form factors across all its
+> layouts/modes (no GPU needed — software WebGL). Add `--skins all` to check
+> every theme, or `--detail overview` for a quick single thumbnail.
 
 Manual checklist before opening a PR:
 
@@ -523,6 +529,7 @@ Manual checklist before opening a PR:
 - [ ] The view window drags/resizes; the canvas keeps rendering after a resize
       and after collapse → expand (no 0/0-aspect smear).
 - [ ] Works at phone width (≤740px): stacked cards, dock, sheets; panel bodies fit the sheet.
+- [ ] Eyeballed headless across layouts/form factors: `npm run tour -- my-app` renders cleanly (a fast proxy for opening every layout by hand) — [docs/SCREENSHOTS.md](SCREENSHOTS.md).
 - [ ] No console errors; rAF loops and listeners are cleaned up on navigation away.
 - [ ] Pure logic you extracted ships a committed vitest file (`npm test` green) — [§6](#6-conventions--gotchas).
 - [ ] Docs updated for your app (`CLAUDE.md` route table + tree, `README.md`) — [§3d](#3d-docs--your-apps-own-paragraph).

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,0 +1,74 @@
+# Screenshot tour — "see the whole site"
+
+`scripts/tour.mjs` (`npm run tour`) drives the **real built app** in headless
+Chromium and walks **every app in both desktop and phone form factors**,
+exercising each app's top-bar **modes** and **layouts**, then writes one PNG per
+combination plus an `index.html` contact sheet you can open to eyeball the whole
+UI at once.
+
+There's no GPU in CI, so — like `scripts/shoot.mjs` — it renders WebGL through
+ANGLE + SwiftShader (software WebGL2). It's the broad-coverage companion to
+`shoot.mjs` (one route) and the `probe-*.mjs` interaction probes.
+
+## Run it
+
+```bash
+# One shot — builds if needed, starts its own preview server, tears it down:
+npm run tour
+
+# Or reuse a server you already have (same pattern as the probes):
+npm run build && (npm run preview &) && npm run tour
+```
+
+Output lands in `screenshots/` (git-ignored):
+
+```
+screenshots/
+├── index.html                       # contact sheet (search + viewport filter)
+├── manifest.json                    # every shot + metadata (route/mode/layout/ok)
+└── <app-slug>/
+    ├── desktop__<mode>__<layout>.png
+    └── mobile__<mode>__<view>.png
+```
+
+Open `screenshots/index.html` in a browser to scan everything.
+
+## What gets captured
+
+- **Routes** are read from `src/apps.ts` (the canonical registry) so the tour
+  never drifts as apps are added, plus the gallery, the legacy
+  `#/fractals-cpu`, and the chrome-less `#/embed/*` applets.
+- **Modes** and **layouts** are *discovered from the live DOM* — the top-bar
+  mode pills and the Layout menu — not hardcoded, so a new layout is captured
+  automatically. The gallery varies by its category filter chips instead.
+- **Form factors**: desktop (1280×800) and phone (390×844, below the 740px
+  re-chrome breakpoint). Each route loads in an isolated browser context so
+  every app starts from its true defaults (no persisted layout bleed).
+
+## Tuning (env vars)
+
+| Var          | Default                          | Meaning                                            |
+|--------------|----------------------------------|----------------------------------------------------|
+| `ONLY`       | _(all)_                          | comma list — only routes whose hash/slug matches   |
+| `VIEWPORTS`  | `desktop,mobile`                 | which form factors                                 |
+| `SKIN`       | _(default skin)_                 | seed a skin (`phosphor`, `blueprint`, …) site-wide |
+| `WAIT_MS`    | `2200`                           | settle after navigation (canvas apps)              |
+| `VARIANT_MS` | `650`                            | settle after a mode/layout switch                  |
+| `OUT_DIR`    | `screenshots/`                   | output directory                                   |
+| `BASE_URL`   | `http://localhost:4173/animath/` | server to drive (else one is started)              |
+| `NO_EMBEDS`  | _(off)_                          | skip the `#/embed/*` routes                        |
+| `DEBUG`      | _(off)_                          | surface page errors / console noise                |
+
+```bash
+ONLY=trinary,fractals npm run tour        # just those apps
+SKIN=phosphor npm run tour                 # the whole site in one skin
+VIEWPORTS=mobile npm run tour              # phone only
+```
+
+## CI
+
+The **Screenshot tour** workflow (`.github/workflows/screenshots.yml`) runs the
+tour on demand (Actions tab → *Run workflow*) and uploads `screenshots/` as a
+downloadable artifact. Inputs let you narrow to one app (`only`), pick form
+factors (`viewports`), or seed a skin (`skin`) — so you can "see the whole site"
+without a local GPU.

--- a/docs/SCREENSHOTS.md
+++ b/docs/SCREENSHOTS.md
@@ -1,10 +1,10 @@
 # Screenshot tour — "see the whole site"
 
 `scripts/tour.mjs` (`npm run tour`) drives the **real built app** in headless
-Chromium and walks **every app in both desktop and phone form factors**,
-exercising each app's top-bar **modes** and **layouts**, then writes one PNG per
-combination plus an `index.html` contact sheet you can open to eyeball the whole
-UI at once.
+Chromium and walks the apps in **desktop and phone form factors**, exercising
+each app's top-bar **modes** and **layouts** (and, optionally, every **skin**),
+then writes one PNG per captured state plus an `index.html` contact sheet you
+can open to eyeball the whole UI at once.
 
 There's no GPU in CI, so — like `scripts/shoot.mjs` — it renders WebGL through
 ANGLE + SwiftShader (software WebGL2). It's the broad-coverage companion to
@@ -13,62 +13,110 @@ ANGLE + SwiftShader (software WebGL2). It's the broad-coverage companion to
 ## Run it
 
 ```bash
-# One shot — builds if needed, starts its own preview server, tears it down:
+# Whole site, "standard" detail — builds if needed, starts/stops its own server:
 npm run tour
 
-# Or reuse a server you already have (same pattern as the probes):
+# Reuse a server you already have (same pattern as the probes):
 npm run build && (npm run preview &) && npm run tour
+
+# Discover what's available (routes + skins + detail levels), then exit:
+npm run tour -- --list
 ```
 
 Output lands in `screenshots/` (git-ignored):
 
 ```
 screenshots/
-├── index.html                       # contact sheet (search + viewport filter)
-├── manifest.json                    # every shot + metadata (route/mode/layout/ok)
+├── index.html                              # contact sheet (search + viewport/skin filters)
+├── manifest.json                           # every shot + metadata
 └── <app-slug>/
-    ├── desktop__<mode>__<layout>.png
-    └── mobile__<mode>__<view>.png
+    ├── desktop__[skin__]<mode>__<layout>.png
+    └── mobile__[skin__]<mode>__<view>.png
 ```
 
-Open `screenshots/index.html` in a browser to scan everything.
+> **Note** when passing flags through npm you need the `--` separator:
+> `npm run tour -- trinary --detail everything`. Calling the script directly
+> (`node scripts/tour.mjs trinary --detail everything`) doesn't.
 
-## What gets captured
+## 1. Target a specific app (or the gallery)
 
-- **Routes** are read from `src/apps.ts` (the canonical registry) so the tour
-  never drifts as apps are added, plus the gallery, the legacy
-  `#/fractals-cpu`, and the chrome-less `#/embed/*` applets.
-- **Modes** and **layouts** are *discovered from the live DOM* — the top-bar
-  mode pills and the Layout menu — not hardcoded, so a new layout is captured
-  automatically. The gallery varies by its category filter chips instead.
-- **Form factors**: desktop (1280×800) and phone (390×844, below the 740px
-  re-chrome breakpoint). Each route loads in an isolated browser context so
-  every app starts from its true defaults (no persisted layout bleed).
-
-## Tuning (env vars)
-
-| Var          | Default                          | Meaning                                            |
-|--------------|----------------------------------|----------------------------------------------------|
-| `ONLY`       | _(all)_                          | comma list — only routes whose hash/slug matches   |
-| `VIEWPORTS`  | `desktop,mobile`                 | which form factors                                 |
-| `SKIN`       | _(default skin)_                 | seed a skin (`phosphor`, `blueprint`, …) site-wide |
-| `WAIT_MS`    | `2200`                           | settle after navigation (canvas apps)              |
-| `VARIANT_MS` | `650`                            | settle after a mode/layout switch                  |
-| `OUT_DIR`    | `screenshots/`                   | output directory                                   |
-| `BASE_URL`   | `http://localhost:4173/animath/` | server to drive (else one is started)              |
-| `NO_EMBEDS`  | _(off)_                          | skip the `#/embed/*` routes                        |
-| `DEBUG`      | _(off)_                          | surface page errors / console noise                |
+Pass one or more **targets** as positional args (or `ONLY=…`): each is a
+substring matched against a route's hash/slug.
 
 ```bash
-ONLY=trinary,fractals npm run tour        # just those apps
-SKIN=phosphor npm run tour                 # the whole site in one skin
-VIEWPORTS=mobile npm run tour              # phone only
+npm run tour -- gallery            # just the landing gallery
+npm run tour -- trinary            # just Trinary System
+npm run tour -- fractals           # matches Fractals AND fractals-cpu
+npm run tour -- argand trinary     # several at once
+npm run tour -- --list             # see every slug/hash/name
 ```
+
+## 2. Levels of detail (`--detail`, overview → everything)
+
+App targets capture more or fewer mode/layout combinations as you turn the dial
+up. Each level is a superset of the one before it:
+
+| Level          | What it captures                                                              |
+|----------------|------------------------------------------------------------------------------|
+| `overview`     | the pristine default only — default mode × default layout                     |
+| `standard`     | + every **layout** (at the default mode) + every other **mode** (its default) |
+| `everything` ⃰ | the full cross-product — every mode × every layout                           |
+
+⃰ default — the headline `npm run tour` stays "as complete as possible"; dial
+down with `--detail`. The gallery uses its category filter chips instead of
+modes/layouts (`overview` = the *All* view; otherwise every category).
+
+```bash
+npm run tour -- trinary --detail overview     # one hero shot per form factor
+npm run tour -- trinary --detail everything   # every mode × every layout
+npm run tour --detail overview                 # a fast thumbnail of the whole site
+```
+
+## 3. Skins / themes (`--skins`, explore the five themes)
+
+By default the tour uses the default skin (no skin segment in filenames). Add
+the **skin dimension** to capture pages in one, several, or all themes — the
+skin id becomes part of the filename and the contact sheet gains a skin filter.
+
+```bash
+npm run tour -- --skins all                          # the whole site in all 5 skins
+npm run tour -- argand --skins phosphor,blueprint    # one app, two themes
+npm run tour -- gallery --skins all --detail overview
+SKIN=neon npm run tour                                # single skin (env form)
+```
+
+Skins (ids from `src/chrome/skins.tsx`): `dark` (Observatory, default), `light`
+(Paper), `neon` (Spectrum), `blueprint`, `phosphor`. Names work too
+(`--skins Observatory,Paper`).
+
+## All options
+
+Every flag has an env equivalent (the flag wins). Flags also accept
+`--flag=value`.
+
+| Flag / env                     | Default                          | Meaning                                            |
+|--------------------------------|----------------------------------|----------------------------------------------------|
+| _positional_ / `--only` / `ONLY` | _(all)_                        | target routes by hash/slug substring               |
+| `--detail` / `DETAIL`          | `standard`                       | `overview` · `standard` · `everything`             |
+| `--skins` / `SKINS` (`--skin`/`SKIN`) | _(default skin)_          | `all`, or a comma list of skin ids/names           |
+| `--viewport(s)` / `VIEWPORTS`  | `desktop,mobile`                 | which form factors                                 |
+| `--wait` / `WAIT_MS`           | `2200`                           | settle after navigation (canvas apps)              |
+| `--variant-wait` / `VARIANT_MS`| `650`                            | settle after a mode/layout switch                  |
+| `--out` / `OUT_DIR`            | `screenshots/`                   | output directory                                   |
+| `--base-url` / `BASE_URL`      | `http://localhost:4173/animath/` | server to drive (else one is started)              |
+| `--no-embeds` / `NO_EMBEDS`    | _(off)_                          | skip the `#/embed/*` routes                        |
+| `--debug` / `DEBUG`            | _(off)_                          | surface page errors / console noise                |
+| `--list`                       | —                                | print routes + skins + detail levels, then exit    |
+
+Routes are read from `src/apps.ts` and skins from `src/chrome/skins.tsx` (the
+canonical registries), so the tour never drifts as apps/skins are added. Modes
+and layouts are *discovered from the live DOM*. Each (route, viewport, skin)
+loads in an isolated browser context so apps start from their true defaults.
 
 ## CI
 
 The **Screenshot tour** workflow (`.github/workflows/screenshots.yml`) runs the
 tour on demand (Actions tab → *Run workflow*) and uploads `screenshots/` as a
-downloadable artifact. Inputs let you narrow to one app (`only`), pick form
-factors (`viewports`), or seed a skin (`skin`) — so you can "see the whole site"
-without a local GPU.
+downloadable artifact. Inputs mirror the flags above: `only` (target), `detail`,
+`viewports`, `skins` — so you can "see the whole site" (or one app, at any
+detail, in any theme) without a local GPU.

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -67,6 +67,19 @@ informs future rounds. Delete or check off items as they land.
   This is the "+ check" that moves L1/L3 from rule-only to rule+check. Touches
   app/scripts/CI, so its own branch (was Phase 5, not built in the audit branch).
 
+- [ ] [general] !low Screenshot tour — wire into CI as a regression aid (baseline + visual diff).
+  `scripts/tour.mjs` (`npm run tour`; docs/SCREENSHOTS.md) ships `workflow_dispatch`-only
+  today. Next: commit a baseline set and post a visual diff (or the contact sheet) on PRs
+  that touch `src/chrome` or an app, so chrome/app regressions get caught. Complements the
+  deep-link / headless-mobile-smoke harness item above (shares the headless-WebGL setup).
+
+- [ ] [general] !low Screenshot tour — capture transient/interaction + theme states.
+  The tour captures settled *default* frames only. Add the "?" explainer modal, a
+  fullscreen view, and mid-animation / fractal-trace states; consider switching skins via
+  a live `SkinPicker` click (faster than the current reload-per-skin) for non-gallery
+  routes. Caveat to keep in mind: rendering is software WebGL (SwiftShader), not a real
+  GPU — colors/AA differ subtly from production, so shots aren't pixel-true.
+
 - [ ] [docs] !low Add `package.json` to the append-only protected-file list.
   The one real conflict-marker near-miss in 50 PRs landed in `package.json`, which
   isn't on the protected list (CLAUDE.md/apps.ts/index.tsx/README.md). Add it to the

--- a/docs/sessions/handoff/gracious-ptolemy-boebnp/2026-06-23-S01-screenshot-tour.md
+++ b/docs/sessions/handoff/gracious-ptolemy-boebnp/2026-06-23-S01-screenshot-tour.md
@@ -1,0 +1,151 @@
+---
+kind: handoff
+session: 2026-06-23-S01
+date: 2026-06-23
+title: Screenshot tour — full-site capture (targeting · detail levels · skins)
+branch: claude/gracious-ptolemy-boebnp
+slug: gracious-ptolemy-boebnp
+status: completed
+build: passed
+followup: low
+pr: null
+app: general
+signals: visual-unverified
+next: Run the "Screenshot tour" workflow (Actions) or `npm run tour` for a visual pass; `--skins all` for theme QA, `--detail overview` for a fast thumbnail. Consider gating it on PRs that touch chrome/apps.
+---
+
+# Screenshot tour — full-site capture (targeting · detail levels · skins)
+
+> [!NOTE]
+> Pure tooling/infra session — no app behavior or `src/` runtime code changed
+> (one read of `src/chrome/skins.tsx` informed a bug fix in the script). Two
+> commits, both pushed to the branch.
+
+## Summary
+
+Built a reusable "see the whole site" screenshot harness, `scripts/tour.mjs`
+(`npm run tour`), that drives the real built app in headless Chromium (software
+WebGL via ANGLE + SwiftShader, same as `scripts/shoot.mjs`) and captures every
+app in desktop + phone form factors across each app's modes and layouts. A full
+default run is **107 shots, 0 failures**. Then added three follow-up features on
+request: (1) **target** a specific app/gallery, (2) **detail levels**
+`overview → standard → everything`, (3) a **skins/themes** dimension. Routes are
+read from `src/apps.ts` and skins from `src/chrome/skins.tsx`; modes/layouts are
+discovered from the live DOM. Shipped with a `workflow_dispatch` CI workflow,
+`docs/SCREENSHOTS.md`, and an `index.html` contact sheet. Build passes.
+
+## What changed
+
+Two commits (`e54503a` initial tour; `7ed3187` the three enhancements):
+
+- **`scripts/tour.mjs`** — the driver. Walks `routes × viewports × modes ×
+  layouts (× skins)`, writes `screenshots/<app>/<vp>__[skin__]<mode>__<layout>.png`
+  plus `manifest.json` and a searchable `index.html`. Auto-builds if `dist/` is
+  missing and self-serves `vite preview` if no server is reachable (else reuses
+  `BASE_URL`). Each (route, viewport, skin) loads in an **isolated browser
+  context** so apps start from their true defaults (the workspace persists layout
+  to `localStorage`, so isolation is what prevents layout bleed across the tour).
+- **Targeting** — positional args (or `ONLY=`) substring-match a route hash/slug
+  (`npm run tour -- trinary`, `-- gallery`); `--list` prints routes + skins +
+  detail levels and exits.
+- **Detail levels** (`--detail` / `DETAIL`, default `everything`): `overview`
+  (pristine default only), `standard` (every layout at default mode + every other
+  mode at its default), `everything` (full mode × layout cross-product). Verified
+  monotonic on Counting the Ways: **2 → 6 → 8** shots. The `standard` modes pass
+  runs *before* any layout click so each mode is captured at its own pristine
+  default (avoids carried-over layout).
+- **Skins** (`--skins` / `SKINS`, `all` or a comma list of ids/names; `--skin`
+  for one). Fixed a real bug: `skins.tsx` reads the skin from `localStorage` as a
+  **raw id** (`phosphor`), not JSON — the first version seeded `JSON.stringify`
+  (`"phosphor"`) which silently fell back to the default skin. Now seeds raw;
+  verified Phosphor/Blueprint/Neon render correctly (incl. the gallery's
+  skin-aware preview canvases, which depend on React `useSkin` state).
+- **`.github/workflows/screenshots.yml`** — on-demand (`workflow_dispatch`)
+  workflow with `only` / `detail` / `viewports` / `skins` inputs; installs Chrome
+  runtime libs (mirrors `scripts/install_headless_webgl.sh`), builds, serves,
+  runs the tour, uploads `screenshots/` as an artifact.
+- **`docs/SCREENSHOTS.md`**, a `CLAUDE.md` Quick Reference line, and `.gitignore`
+  (`screenshots/`, `scratch-smoke/` — generated artifacts, not committed).
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`scripts/tour.mjs:273`](https://github.com/piyarsquare/animath/blob/7ed3187/scripts/tour.mjs#L273) | `captureVariants` — the detail-level logic (overview / standard / everything) per route+viewport |
+| [`scripts/tour.mjs:144`](https://github.com/piyarsquare/animath/blob/7ed3187/scripts/tour.mjs#L144) | `resolveSkins` — `all` / id / name → skin ids; `readRoutes`/`readSkins` above it parse the source registries |
+| [`scripts/tour.mjs:354`](https://github.com/piyarsquare/animath/blob/7ed3187/scripts/tour.mjs#L354) | the skin-seed fix — `evaluateOnNewDocument` writes the **raw** skin id to localStorage before boot |
+| [`src/chrome/skins.tsx:29`](https://github.com/piyarsquare/animath/blob/7ed3187/src/chrome/skins.tsx#L29) | `loadSkin()` — the gotcha: reads localStorage raw (not via `usePersistentState`/JSON) |
+| [`.github/workflows/screenshots.yml:13`](https://github.com/piyarsquare/animath/blob/7ed3187/.github/workflows/screenshots.yml#L13) | CI workflow inputs (only / detail / viewports / skins) |
+| [`docs/SCREENSHOTS.md`](https://github.com/piyarsquare/animath/blob/7ed3187/docs/SCREENSHOTS.md) | usage + flags/env reference |
+
+## Open / not done
+
+- **Screenshots are git-ignored** (generated, ~19MB for the default run). They
+  reach a human via the CI artifact, a local `npm run tour`, or the files
+  delivered in chat. Dan was offered committing a baseline set into the repo and
+  chose not to this session — revisit if a GitHub-viewable baseline is wanted.
+- The tour captures **settled frames only** — not transient/interaction states
+  (the "?" explainer modal, a fullscreen view, mid-animation, hover, fractal
+  trace orbits). Worth adding if those need eyeballing.
+- Not wired as a **PR gate / visual-diff** — it's `workflow_dispatch` only. A
+  natural next step is a baseline + diff to catch chrome/app regressions.
+
+## Context
+
+- Rendering is **software WebGL (SwiftShader)** — there's no GPU in the
+  container/CI. Colors/anti-aliasing can differ subtly from a real GPU; fine for
+  "see the whole site", but don't treat a shot as pixel-true to production.
+- Run pattern matches the existing probes: `npm run build && (npm run preview &)
+  && npm run tour`, or just `npm run tour` (it self-serves). Pass flags through
+  npm with `--`: `npm run tour -- trinary --detail everything --skins all`.
+- DOM contract the tour depends on (stable today): mode pills
+  `.am-pills[role=tablist] .am-pill[role=tab]`; desktop Layout menu
+  `.am-layouts-btn` → `.am-layouts-menu .am-lay-item` (active = `.am-on`, name in
+  `.am-lay-meta > span`); phone view-chips `.am-phone-layouts .am-chip`; gallery
+  filters `.am-gal-filters .am-chip`. If those class names change, update the
+  `list*`/`select*` helpers in `tour.mjs`.
+
+## Self-reflection
+
+1. **What would you do with another session?** Wire the tour into CI as a
+   regression aid: capture a committed baseline and post a visual diff (or the
+   contact sheet) on PRs that touch `src/chrome` or an app. Add capture of
+   transient states (explainer modal, fullscreen, mid-animation) and per-app
+   skin strips.
+2. **What would you change about what you produced?** The skins dimension does a
+   fresh page load per skin (correct, since the gallery previews read React
+   `useSkin` state) but it's slower than necessary; for non-gallery routes a live
+   `SkinPicker` click would re-render without a reload. The `index.html` is one
+   monolithic page; for `--skins all --detail everything` it'd be large and could
+   paginate or lazy-virtualize.
+3. **What were you not asked that you think is important?** Whether to commit a
+   baseline set for visual regression (asked at the end; Dan declined for now),
+   and whether production fidelity matters enough to ever render on a real GPU.
+4. **What did we both overlook?** Software-WebGL ≠ production GPU (subtle color/AA
+   differences). And the tour only sees settled frames — interaction-driven looks
+   (trace orbits, playing sims, hover, the "?" modal) aren't captured, so "see the
+   whole site" is really "see every static default of the whole site."
+5. **What did you find difficult?** Making mode/layout/skin combinations
+   deterministic given the workspace persists layout to `localStorage` (layouts
+   carry over once you start clicking). Resolved with an isolated browser context
+   per route and a modes-before-layouts ordering in `standard`.
+6. **What would have made this task easier?** A machine-readable hook for the
+   chrome's current state — e.g. `data-app`/`data-mode`/`data-layout` on the
+   shell root — would beat scraping class names. And a documented skin-storage
+   contract (raw id, not JSON) would have pre-empted the seeding bug.
+7. **How did you verify this, and does each passing check test the user-visible
+   claim?** Method: **headless software-WebGL screenshots, inspected directly** by
+   reading the rendered PNGs (gallery desktop+mobile, Fractals "Everything",
+   Polygon Worlds third-person, Stable Matching lattice + mobile dock, Trinary
+   Lab/Census, Argand in Phosphor + Blueprint, gallery in Neon) — these test the
+   real user-visible output, not a proxy. Detail levels verified by **counts**
+   (overview 2 → standard 6 → everything 8 on Counting the Ways, and the standard
+   set included `lab` at its own default, confirming no carry-over). The skin fix
+   was verified visually (themes now actually apply). `npm run build` passes
+   (`tsc && vite build`, 6.72s). Caveat: rendering is **software WebGL**
+   (SwiftShader), not a real GPU — I inspected the tool's actual output, but
+   production pixel fidelity (real-GPU colors/AA) is unverified, so I set the
+   `visual-unverified` signal rather than imply pixel-truth.
+8. **Follow-up value:** LOW — the tooling is complete, tested end-to-end, and
+   pushed; follow-up (CI gating, visual diff, transient-state capture) would add
+   depth, not correct anything.

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "preview": "vite preview",
     "shoot": "node scripts/shoot.mjs",
+    "tour": "node scripts/tour.mjs",
     "sessions": "node docs/sessions/build-sessions.mjs",
     "sessions:lint": "node docs/sessions/lint-sessions.mjs",
     "sessions:prune": "node docs/sessions/prune-assets.mjs",

--- a/scripts/tour.mjs
+++ b/scripts/tour.mjs
@@ -1,0 +1,438 @@
+#!/usr/bin/env node
+// Full-site screenshot tour for animath — "see the whole site" in one run.
+//
+// Drives the real built app in headless Chromium (software WebGL2 via ANGLE +
+// SwiftShader, the same setup as scripts/shoot.mjs — there is no GPU in CI) and
+// walks EVERY app in BOTH desktop and phone form factors, exercising each app's
+// top-bar modes and its layout choices. Writes one PNG per (app × viewport ×
+// mode × layout) under screenshots/<app>/, plus a manifest.json and an
+// index.html contact sheet so a human (or an agent via Read) can eyeball the
+// entire UI at a glance.
+//
+// The route list is read from src/apps.ts (the canonical registry) so the tour
+// stays in sync as apps are added; modes and layouts are DISCOVERED from the
+// live DOM (the top-bar mode pills and the Layout menu) rather than hardcoded,
+// so a new layout is captured automatically.
+//
+// Usage
+//   # one-shot (auto-builds if needed, starts its own preview server, tears it down):
+//   node scripts/tour.mjs
+//   # or, reuse a server you already started (like the probes do):
+//   npm run build && (npm run preview &) && node scripts/tour.mjs
+//
+// Env
+//   BASE_URL    server origin + base (default http://localhost:<PORT>/animath/)
+//   PORT        preview port to auto-start / probe (default 4173)
+//   OUT_DIR     output directory (default <repo>/screenshots)
+//   VIEWPORTS   comma list of "desktop","mobile" (default both)
+//   ONLY        comma list — only routes whose hash/slug contains one of these
+//   WAIT_MS     settle after navigation for canvas apps (default 2200)
+//   VARIANT_MS  settle after a mode/layout switch (default 650)
+//   SKIN        seed a non-default skin (e.g. phosphor) for every shot
+//   NO_EMBEDS   set to skip the chrome-less /embed/* applet routes
+//   DEBUG       set to surface page errors/console noise
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { spawn } from 'node:child_process';
+import puppeteer from 'puppeteer';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '..');
+
+const PORT = Number(process.env.PORT ?? 4173);
+const baseUrl = (process.env.BASE_URL ?? `http://localhost:${PORT}/animath/`).replace(/\/?$/, '/');
+const OUT_DIR = process.env.OUT_DIR ? path.resolve(process.env.OUT_DIR) : path.join(repoRoot, 'screenshots');
+const WAIT_MS = Number(process.env.WAIT_MS ?? 2200);
+const VARIANT_MS = Number(process.env.VARIANT_MS ?? 650);
+const ONLY = (process.env.ONLY ?? '').split(',').map((s) => s.trim()).filter(Boolean);
+const SKIN = process.env.SKIN || null;
+const INCLUDE_EMBEDS = !process.env.NO_EMBEDS;
+const DEBUG = !!process.env.DEBUG;
+
+const VIEWPORT_DEFS = {
+  desktop: { id: 'desktop', width: 1280, height: 800, dsf: 1, mobile: false },
+  mobile: { id: 'mobile', width: 390, height: 844, dsf: 2, mobile: true },
+};
+const VIEWPORTS = (process.env.VIEWPORTS ?? 'desktop,mobile')
+  .split(',').map((s) => s.trim()).filter((s) => VIEWPORT_DEFS[s]).map((s) => VIEWPORT_DEFS[s]);
+
+const BROWSER_ARGS = [
+  '--headless=new',
+  '--use-gl=angle',
+  '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader',
+  '--no-sandbox',
+  '--disable-dev-shm-usage',
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+const slug = (hash) => (hash === '/' ? 'gallery' : hash.replace(/^\//, '').replace(/\//g, '-'));
+const nameSlug = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'x';
+
+/** The canonical route list: gallery + every registered app (read from
+ *  src/apps.ts so the tour never drifts) + the unlisted/legacy + embed routes. */
+function readRoutes() {
+  const src = fs.readFileSync(path.join(repoRoot, 'src', 'apps.ts'), 'utf8');
+  const re = /hash:\s*'([^']+)'[\s\S]*?name:\s*'([^']*)'/g;
+  const apps = [];
+  let m;
+  while ((m = re.exec(src))) apps.push({ hash: m[1], name: m[2] });
+  const routes = [
+    { hash: '/', name: 'Gallery' },
+    ...apps,
+    { hash: '/fractals-cpu', name: 'Fractals (CPU · legacy)' },
+  ];
+  if (INCLUDE_EMBEDS) {
+    routes.push(
+      { hash: '/embed/complex-particles', name: 'Embed · Complex Particles' },
+      { hash: '/embed/plane-transform', name: 'Embed · Plane Transform' },
+    );
+  }
+  return routes.filter(
+    (r) => !ONLY.length || ONLY.some((o) => r.hash.includes(o) || slug(r.hash).includes(o)),
+  );
+}
+
+function run(cmd, args) {
+  return new Promise((res, rej) => {
+    const p = spawn(cmd, args, { cwd: repoRoot, stdio: 'inherit' });
+    p.on('exit', (c) => {
+      if (c === 0) res();
+      else rej(new Error(`${cmd} ${args.join(' ')} → exit ${c}`));
+    });
+  });
+}
+
+async function reachable() {
+  try {
+    const r = await fetch(baseUrl);
+    return r.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+/** Reuse a running server if BASE_URL is up; otherwise build (if needed) and
+ *  start `vite preview` ourselves, returning the child to kill on exit. */
+async function ensureServer() {
+  if (await reachable()) {
+    console.log(`• using server at ${baseUrl}`);
+    return null;
+  }
+  if (!fs.existsSync(path.join(repoRoot, 'dist'))) {
+    console.log('• no dist/ — running `npm run build`…');
+    await run('npm', ['run', 'build']);
+  }
+  console.log(`• starting \`vite preview\` on :${PORT}…`);
+  const srv = spawn('npm', ['run', 'preview', '--', '--port', String(PORT), '--strictPort'], {
+    cwd: repoRoot,
+    stdio: DEBUG ? 'inherit' : 'ignore',
+  });
+  for (let i = 0; i < 40; i++) {
+    if (await reachable()) {
+      console.log('• server up');
+      return srv;
+    }
+    await sleep(500);
+  }
+  srv.kill('SIGTERM');
+  throw new Error('preview server did not come up');
+}
+
+// ---- live-DOM discovery of the chrome's variant controls ----
+
+/** Top-bar mode pills (e.g. Trinary's Observatory | Lab, Counting's Explain | Lab). */
+function listModes(page) {
+  return page.$$eval('.am-pills[role="tablist"] .am-pill[role="tab"]', (els) =>
+    els.map((e, i) => ({ i, label: (e.textContent || '').trim() })),
+  );
+}
+async function selectMode(page, i) {
+  const pills = await page.$$('.am-pills[role="tablist"] .am-pill[role="tab"]');
+  if (pills[i]) await pills[i].click();
+}
+
+/** Desktop Layout menu: Compact, the app's own layouts, Everything (+ any saved). */
+async function listLayouts(page) {
+  const btn = await page.$('.am-layouts-btn');
+  if (!btn) return [];
+  await btn.click();
+  const ok = await page
+    .waitForSelector('.am-layouts-menu .am-lay-item', { timeout: 1500 })
+    .then(() => true)
+    .catch(() => false);
+  if (!ok) return [];
+  const names = await page.$$eval('.am-layouts-menu .am-lay-item', (els) =>
+    els.map((e) => (e.querySelector('.am-lay-meta > span')?.textContent || e.textContent || '').trim()),
+  );
+  await page.keyboard.press('Escape').catch(() => {});
+  await sleep(120);
+  return names;
+}
+async function selectLayout(page, i) {
+  await page.click('.am-layouts-btn');
+  await page.waitForSelector('.am-layouts-menu .am-lay-item', { timeout: 1500 });
+  const items = await page.$$('.am-layouts-menu .am-lay-item');
+  if (items[i]) await items[i].click();
+  await sleep(VARIANT_MS);
+}
+
+/** Phone view-chips: apps that model mutually-exclusive views as layouts
+ *  (Stable Matching's matrix/welfare/lattice, Trinary's instruments). */
+function listPhoneViews(page) {
+  return page.$$eval('.am-phone-layouts .am-chip', (els) => els.map((e) => (e.textContent || '').trim()));
+}
+async function selectPhoneView(page, i) {
+  const chips = await page.$$('.am-phone-layouts .am-chip');
+  if (chips[i]) {
+    await chips[i].click();
+    await sleep(VARIANT_MS);
+  }
+}
+
+/** Gallery category filter chips (All + each category). */
+function listGalleryFilters(page) {
+  return page.$$eval('.am-gal-filters .am-chip', (els) => els.map((e) => (e.textContent || '').trim()));
+}
+async function selectGalleryFilter(page, i) {
+  const chips = await page.$$('.am-gal-filters .am-chip');
+  if (chips[i]) {
+    await chips[i].click();
+    await sleep(250);
+  }
+}
+
+// ---- capture ----
+
+async function shoot(page, route, vp, parts, fullPage, results) {
+  const dir = path.join(OUT_DIR, slug(route.hash));
+  fs.mkdirSync(dir, { recursive: true });
+  const file = `${vp.id}__${parts.map((p) => nameSlug(p.value)).join('__')}.png`;
+  const rel = `${slug(route.hash)}/${file}`;
+  const meta = Object.fromEntries(parts.map((p) => [p.key, p.value]));
+  try {
+    await page.screenshot({ path: path.join(dir, file), fullPage });
+    results.push({ route: route.hash, name: route.name, viewport: vp.id, ...meta, file: rel, ok: true });
+    console.log(`    ✓ ${rel}`);
+  } catch (e) {
+    results.push({ route: route.hash, name: route.name, viewport: vp.id, ...meta, file: rel, ok: false, error: String(e.message || e) });
+    console.log(`    ✗ ${rel} — ${e.message || e}`);
+  }
+}
+
+async function captureRouteViewport(context, route, vp, results) {
+  const page = await context.newPage();
+  await page.setViewport({ width: vp.width, height: vp.height, deviceScaleFactor: vp.dsf, isMobile: vp.mobile, hasTouch: vp.mobile });
+  if (SKIN) {
+    await page.evaluateOnNewDocument((s) => {
+      try { localStorage.setItem('animath:v1:chrome:skin', s); } catch {}
+    }, JSON.stringify(SKIN));
+  }
+  if (DEBUG) {
+    page.on('pageerror', (e) => console.log(`      [pageerror] ${e.message}`));
+    page.on('console', (m) => m.type() === 'error' && console.log(`      [page:err] ${m.text()}`));
+  }
+
+  const url = baseUrl + '#' + route.hash;
+  try {
+    await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
+  } catch (e) {
+    console.log(`    ! nav failed ${url} — ${e.message}`);
+    await page.close();
+    return;
+  }
+  const hasCanvas = await page.waitForSelector('canvas', { timeout: 6000 }).then(() => true).catch(() => false);
+  await sleep(hasCanvas ? WAIT_MS : Math.min(WAIT_MS, 1000));
+
+  const isGallery = route.hash === '/';
+  const fullPage = isGallery; // the gallery scrolls; capture every card
+
+  // Gallery: vary by category filter instead of layouts/modes.
+  if (isGallery) {
+    const cats = await listGalleryFilters(page);
+    const list = cats.length ? cats : ['All'];
+    for (let i = 0; i < list.length; i++) {
+      if (cats.length) await selectGalleryFilter(page, i);
+      await shoot(page, route, vp, [{ key: 'filter', value: list[i] }], fullPage, results);
+    }
+    await page.close();
+    return;
+  }
+
+  const modes = await listModes(page);
+  const modeList = modes.length ? modes : [{ i: -1, label: 'default' }];
+
+  for (const mode of modeList) {
+    if (mode.i >= 0) {
+      await selectMode(page, mode.i);
+      await sleep((hasCanvas ? VARIANT_MS + 500 : VARIANT_MS));
+    }
+    const modePart = { key: 'mode', value: mode.label };
+
+    if (vp.id === 'desktop') {
+      const layouts = await listLayouts(page);
+      const list = layouts.length ? layouts : ['default'];
+      for (let li = 0; li < list.length; li++) {
+        if (layouts.length) await selectLayout(page, li);
+        await shoot(page, route, vp, [modePart, { key: 'layout', value: list[li] }], fullPage, results);
+      }
+    } else {
+      const chips = await listPhoneViews(page);
+      if (chips.length) {
+        for (let ci = 0; ci < chips.length; ci++) {
+          await selectPhoneView(page, ci);
+          await shoot(page, route, vp, [modePart, { key: 'view', value: chips[ci] }], fullPage, results);
+        }
+      } else {
+        await shoot(page, route, vp, [modePart, { key: 'view', value: 'default' }], fullPage, results);
+      }
+    }
+  }
+  await page.close();
+}
+
+// ---- contact sheet ----
+
+function writeIndex(routes, results) {
+  const byRoute = new Map();
+  for (const r of results) {
+    if (!byRoute.has(r.route)) byRoute.set(r.route, []);
+    byRoute.get(r.route).push(r);
+  }
+  const ok = results.filter((r) => r.ok).length;
+  const caption = (r) =>
+    [r.viewport, r.mode, r.layout, r.view, r.filter].filter((v) => v && v !== 'default').join(' · ') || r.viewport;
+
+  const sections = routes
+    .filter((rt) => byRoute.has(rt.hash))
+    .map((rt) => {
+      const shots = byRoute.get(rt.hash);
+      const figs = shots
+        .map(
+          (s) => `
+        <figure class="shot ${s.ok ? '' : 'bad'}" data-vp="${s.viewport}">
+          ${s.ok ? `<a href="${s.file}" target="_blank"><img loading="lazy" src="${s.file}" alt="${caption(s)}"></a>` : `<div class="err">✗ ${s.error || 'failed'}</div>`}
+          <figcaption>${caption(s)}</figcaption>
+        </figure>`,
+        )
+        .join('');
+      return `
+      <section class="app" data-name="${rt.name.toLowerCase()}">
+        <h2>${rt.name} <span class="hash">${rt.hash}</span> <span class="count">${shots.length}</span></h2>
+        <div class="grid">${figs}</div>
+      </section>`;
+    })
+    .join('');
+
+  const html = `<!doctype html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>animath — site screenshot tour</title>
+<style>
+  :root { color-scheme: dark; }
+  * { box-sizing: border-box; }
+  body { margin: 0; background: #0d1016; color: #e7ecf3; font: 14px/1.5 system-ui, sans-serif; }
+  header { position: sticky; top: 0; z-index: 5; background: #0d1016ee; backdrop-filter: blur(6px);
+    padding: 14px 20px; border-bottom: 1px solid #232a36; display: flex; gap: 16px; align-items: center; flex-wrap: wrap; }
+  header h1 { font-size: 16px; margin: 0; font-weight: 650; }
+  header .meta { color: #8b97a8; font-size: 12.5px; }
+  header input, header select { background: #161b24; color: #e7ecf3; border: 1px solid #2a3340;
+    border-radius: 7px; padding: 6px 10px; font: inherit; }
+  header .spacer { flex: 1; }
+  main { padding: 8px 20px 60px; }
+  section.app { margin: 26px 0; }
+  section.app h2 { font-size: 15px; font-weight: 650; margin: 0 0 12px; display: flex; align-items: baseline; gap: 10px;
+    border-bottom: 1px solid #1c2330; padding-bottom: 8px; }
+  .hash { color: #5f6b7d; font: 12px ui-monospace, monospace; }
+  .count { margin-left: auto; color: #5f6b7d; font-size: 12px; }
+  .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
+  figure.shot { margin: 0; background: #11151d; border: 1px solid #1f2733; border-radius: 10px; overflow: hidden; }
+  figure.shot[data-vp="mobile"] { background: #0a0d13; }
+  figure.shot img { width: 100%; display: block; background: #000; aspect-ratio: auto; }
+  figure.shot figcaption { padding: 7px 10px; font-size: 12px; color: #9aa6b6; border-top: 1px solid #1a212c;
+    white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+  figure.shot.bad { border-color: #5a2530; }
+  figure.shot .err { padding: 30px 12px; color: #ff8b9a; font: 12px ui-monospace, monospace; text-align: center; }
+  .hide { display: none !important; }
+</style>
+</head><body>
+<header>
+  <h1>animath — site tour</h1>
+  <span class="meta">${ok}/${results.length} shots · ${byRoute.size} routes · ${new Date().toISOString().slice(0, 16).replace('T', ' ')}</span>
+  <span class="spacer"></span>
+  <input id="q" type="search" placeholder="filter apps…" autocomplete="off">
+  <select id="vp">
+    <option value="">all viewports</option>
+    <option value="desktop">desktop</option>
+    <option value="mobile">mobile</option>
+  </select>
+</header>
+<main>${sections}</main>
+<script>
+  const q = document.getElementById('q'), vp = document.getElementById('vp');
+  function apply() {
+    const term = q.value.trim().toLowerCase(), v = vp.value;
+    for (const sec of document.querySelectorAll('section.app')) {
+      const nameHit = !term || sec.dataset.name.includes(term);
+      let any = false;
+      for (const fig of sec.querySelectorAll('figure.shot')) {
+        const show = nameHit && (!v || fig.dataset.vp === v);
+        fig.classList.toggle('hide', !show);
+        any = any || show;
+      }
+      sec.classList.toggle('hide', !any);
+    }
+  }
+  q.addEventListener('input', apply); vp.addEventListener('change', apply);
+</script>
+</body></html>`;
+  fs.writeFileSync(path.join(OUT_DIR, 'index.html'), html);
+}
+
+// ---- main ----
+
+async function main() {
+  const routes = readRoutes();
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  console.log(`animath tour → ${OUT_DIR}`);
+  console.log(`routes: ${routes.length} · viewports: ${VIEWPORTS.map((v) => v.id).join(', ')}${SKIN ? ` · skin: ${SKIN}` : ''}`);
+
+  const server = await ensureServer();
+  const browser = await puppeteer.launch({ args: BROWSER_ARGS });
+  const results = [];
+  try {
+    for (const route of routes) {
+      console.log(`\n▸ ${route.name}  (${route.hash})`);
+      // Fresh, isolated storage per route so each app starts from its true
+      // defaults (no persisted layout bleeding across the tour).
+      const context = await browser.createBrowserContext();
+      try {
+        for (const vp of VIEWPORTS) {
+          console.log(`  · ${vp.id}`);
+          await captureRouteViewport(context, route, vp, results);
+        }
+      } finally {
+        await context.close();
+      }
+    }
+  } finally {
+    await browser.close();
+    if (server) server.kill('SIGTERM');
+  }
+
+  fs.writeFileSync(path.join(OUT_DIR, 'manifest.json'), JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl, skin: SKIN, results }, null, 2));
+  writeIndex(routes, results);
+
+  const ok = results.filter((r) => r.ok).length;
+  const bad = results.length - ok;
+  console.log(`\n${'='.repeat(48)}`);
+  console.log(`done: ${ok} ok, ${bad} failed → ${path.join(OUT_DIR, 'index.html')}`);
+  process.exit(bad > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/tour.mjs
+++ b/scripts/tour.mjs
@@ -3,34 +3,43 @@
 //
 // Drives the real built app in headless Chromium (software WebGL2 via ANGLE +
 // SwiftShader, the same setup as scripts/shoot.mjs — there is no GPU in CI) and
-// walks EVERY app in BOTH desktop and phone form factors, exercising each app's
-// top-bar modes and its layout choices. Writes one PNG per (app × viewport ×
-// mode × layout) under screenshots/<app>/, plus a manifest.json and an
+// walks the apps in BOTH desktop and phone form factors, exercising each app's
+// top-bar modes and its layout choices, optionally across skins. Writes one PNG
+// per captured state under screenshots/<app>/, plus a manifest.json and an
 // index.html contact sheet so a human (or an agent via Read) can eyeball the
-// entire UI at a glance.
+// whole UI at a glance.
 //
-// The route list is read from src/apps.ts (the canonical registry) so the tour
-// stays in sync as apps are added; modes and layouts are DISCOVERED from the
-// live DOM (the top-bar mode pills and the Layout menu) rather than hardcoded,
-// so a new layout is captured automatically.
+// The route list is read from src/apps.ts and the skin list from
+// src/chrome/skins.tsx (the canonical registries) so the tour stays in sync as
+// apps/skins are added; modes and layouts are DISCOVERED from the live DOM (the
+// top-bar mode pills and the Layout menu) rather than hardcoded.
 //
 // Usage
-//   # one-shot (auto-builds if needed, starts its own preview server, tears it down):
-//   node scripts/tour.mjs
-//   # or, reuse a server you already started (like the probes do):
-//   npm run build && (npm run preview &) && node scripts/tour.mjs
+//   node scripts/tour.mjs                       # whole site, standard detail
+//   node scripts/tour.mjs trinary               # just one app (substring match)
+//   node scripts/tour.mjs gallery --detail overview
+//   node scripts/tour.mjs fractals --detail everything
+//   node scripts/tour.mjs --skins all           # the whole site in every skin
+//   node scripts/tour.mjs argand --skins phosphor,blueprint --detail everything
+//   node scripts/tour.mjs --list                # list routes + skins, then exit
+//   # via npm (note the `--` so args reach the script):
+//   npm run tour -- trinary --detail everything
 //
-// Env
-//   BASE_URL    server origin + base (default http://localhost:<PORT>/animath/)
-//   PORT        preview port to auto-start / probe (default 4173)
-//   OUT_DIR     output directory (default <repo>/screenshots)
-//   VIEWPORTS   comma list of "desktop","mobile" (default both)
-//   ONLY        comma list — only routes whose hash/slug contains one of these
-//   WAIT_MS     settle after navigation for canvas apps (default 2200)
-//   VARIANT_MS  settle after a mode/layout switch (default 650)
-//   SKIN        seed a non-default skin (e.g. phosphor) for every shot
-//   NO_EMBEDS   set to skip the chrome-less /embed/* applet routes
-//   DEBUG       set to surface page errors/console noise
+// Targets (positional args, or ONLY=…): substring-match a route's hash/slug —
+//   "gallery", "trinary", "fractals" (also matches fractals-cpu), "embed", …
+//
+// Detail levels (--detail / DETAIL), an "overview → everything" ladder:
+//   overview     the pristine default only (default mode + default layout)
+//   standard     + every layout (default mode) + every other mode (its default)   [default]
+//   everything   the full cross-product: every mode × every layout
+//
+// Skins (--skins / SKINS, or --skin / SKIN for one): "all", or a comma list of
+//   skin ids/names (dark·Observatory, light·Paper, neon·Spectrum, blueprint,
+//   phosphor). Unset = the default skin only (no skin segment in filenames).
+//
+// Env (lower-priority than the matching flag)
+//   BASE_URL PORT OUT_DIR VIEWPORTS WAIT_MS VARIANT_MS NO_EMBEDS DEBUG
+//   ONLY DETAIL SKIN SKINS  — see flags above
 
 import fs from 'node:fs';
 import path from 'node:path';
@@ -41,38 +50,61 @@ import puppeteer from 'puppeteer';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const repoRoot = path.resolve(__dirname, '..');
 
-const PORT = Number(process.env.PORT ?? 4173);
-const baseUrl = (process.env.BASE_URL ?? `http://localhost:${PORT}/animath/`).replace(/\/?$/, '/');
-const OUT_DIR = process.env.OUT_DIR ? path.resolve(process.env.OUT_DIR) : path.join(repoRoot, 'screenshots');
-const WAIT_MS = Number(process.env.WAIT_MS ?? 2200);
-const VARIANT_MS = Number(process.env.VARIANT_MS ?? 650);
-const ONLY = (process.env.ONLY ?? '').split(',').map((s) => s.trim()).filter(Boolean);
-const SKIN = process.env.SKIN || null;
-const INCLUDE_EMBEDS = !process.env.NO_EMBEDS;
-const DEBUG = !!process.env.DEBUG;
+// ---- arg parsing (flags + positional targets) ----
+const argv = process.argv.slice(2);
+const flags = {};
+const positional = [];
+for (let i = 0; i < argv.length; i++) {
+  const a = argv[i];
+  if (a.startsWith('--')) {
+    const body = a.slice(2);
+    const eq = body.indexOf('=');
+    if (eq >= 0) flags[body.slice(0, eq)] = body.slice(eq + 1);
+    else if (i + 1 < argv.length && !argv[i + 1].startsWith('--')) flags[body] = argv[++i];
+    else flags[body] = 'true';
+  } else positional.push(a);
+}
+const flag = (...names) => names.map((n) => flags[n]).find((v) => v !== undefined);
+
+const PORT = Number(flag('port') ?? process.env.PORT ?? 4173);
+const baseUrl = (flag('base-url') ?? process.env.BASE_URL ?? `http://localhost:${PORT}/animath/`).replace(/\/?$/, '/');
+const OUT_DIR = path.resolve(flag('out') ?? process.env.OUT_DIR ?? path.join(repoRoot, 'screenshots'));
+const WAIT_MS = Number(flag('wait') ?? process.env.WAIT_MS ?? 2200);
+const VARIANT_MS = Number(flag('variant-wait') ?? process.env.VARIANT_MS ?? 650);
+const INCLUDE_EMBEDS = !(flag('no-embeds') ?? process.env.NO_EMBEDS);
+const DEBUG = !!(flag('debug') ?? process.env.DEBUG);
+
+const targets = (positional.length ? positional.join(',') : (flag('only', 'target') ?? process.env.ONLY ?? ''))
+  .split(',').map((s) => s.trim()).filter(Boolean);
+
+const DETAILS = ['overview', 'standard', 'everything'];
+let detail = (flag('detail', 'lod') ?? process.env.DETAIL ?? 'everything').toLowerCase();
+if (detail === 'full' || detail === 'all' || detail === 'max') detail = 'everything';
+if (detail === 'default') detail = 'standard';
+if (!DETAILS.includes(detail)) {
+  console.error(`unknown --detail "${detail}" (expected: ${DETAILS.join(' | ')})`);
+  process.exit(2);
+}
 
 const VIEWPORT_DEFS = {
   desktop: { id: 'desktop', width: 1280, height: 800, dsf: 1, mobile: false },
   mobile: { id: 'mobile', width: 390, height: 844, dsf: 2, mobile: true },
 };
-const VIEWPORTS = (process.env.VIEWPORTS ?? 'desktop,mobile')
+const VIEWPORTS = (flag('viewport', 'viewports') ?? process.env.VIEWPORTS ?? 'desktop,mobile')
   .split(',').map((s) => s.trim()).filter((s) => VIEWPORT_DEFS[s]).map((s) => VIEWPORT_DEFS[s]);
 
 const BROWSER_ARGS = [
-  '--headless=new',
-  '--use-gl=angle',
-  '--use-angle=swiftshader',
-  '--enable-unsafe-swiftshader',
-  '--no-sandbox',
-  '--disable-dev-shm-usage',
+  '--headless=new', '--use-gl=angle', '--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader', '--no-sandbox', '--disable-dev-shm-usage',
 ];
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const slug = (hash) => (hash === '/' ? 'gallery' : hash.replace(/^\//, '').replace(/\//g, '-'));
 const nameSlug = (s) => (s || '').toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '') || 'x';
 
-/** The canonical route list: gallery + every registered app (read from
- *  src/apps.ts so the tour never drifts) + the unlisted/legacy + embed routes. */
+// ---- registries read from source so the tour never drifts ----
+
+/** gallery + every registered app (src/apps.ts) + legacy + embed routes. */
 function readRoutes() {
   const src = fs.readFileSync(path.join(repoRoot, 'src', 'apps.ts'), 'utf8');
   const re = /hash:\s*'([^']+)'[\s\S]*?name:\s*'([^']*)'/g;
@@ -90,10 +122,44 @@ function readRoutes() {
       { hash: '/embed/plane-transform', name: 'Embed · Plane Transform' },
     );
   }
-  return routes.filter(
-    (r) => !ONLY.length || ONLY.some((o) => r.hash.includes(o) || slug(r.hash).includes(o)),
-  );
+  return routes;
 }
+
+/** the five skins from src/chrome/skins.tsx ({ id, name }) + the default id. */
+function readSkins() {
+  const src = fs.readFileSync(path.join(repoRoot, 'src', 'chrome', 'skins.tsx'), 'utf8');
+  const re = /\{\s*id:\s*'([^']+)',\s*name:\s*'([^']+)'/g;
+  const skins = [];
+  let m;
+  while ((m = re.exec(src))) skins.push({ id: m[1], name: m[2] });
+  const def = (src.match(/DEFAULT_SKIN\s*=\s*'([^']+)'/) || [, 'dark'])[1];
+  return { skins, def };
+}
+
+const allRoutes = readRoutes();
+const { skins: ALL_SKINS, def: DEFAULT_SKIN } = readSkins();
+
+/** Resolve a --skins/--skin spec to skin ids. Unset → [null] (default skin,
+ *  no filename segment). "all" → every id. Else id/name tokens (ci). */
+function resolveSkins() {
+  const spec = (flag('skins') ?? flag('skin') ?? process.env.SKINS ?? process.env.SKIN ?? '').trim();
+  if (!spec) return [null];
+  if (/^(all|every|\*)$/i.test(spec)) return ALL_SKINS.map((s) => s.id);
+  const out = [];
+  for (const tok of spec.split(',').map((s) => s.trim()).filter(Boolean)) {
+    const hit = ALL_SKINS.find((s) => s.id.toLowerCase() === tok.toLowerCase() || s.name.toLowerCase() === tok.toLowerCase());
+    if (hit) out.push(hit.id);
+    else console.log(`! unknown skin "${tok}" — skipping (known: ${ALL_SKINS.map((s) => s.id).join(', ')})`);
+  }
+  return out.length ? out : [null];
+}
+
+const routes = allRoutes.filter(
+  (r) => !targets.length || targets.some((t) => r.hash.includes(t) || slug(r.hash).includes(t)),
+);
+const skins = resolveSkins();
+
+// ---- server (reuse if up, else build-if-needed + start preview) ----
 
 function run(cmd, args) {
   return new Promise((res, rej) => {
@@ -104,18 +170,9 @@ function run(cmd, args) {
     });
   });
 }
-
 async function reachable() {
-  try {
-    const r = await fetch(baseUrl);
-    return r.status < 500;
-  } catch {
-    return false;
-  }
+  try { return (await fetch(baseUrl)).status < 500; } catch { return false; }
 }
-
-/** Reuse a running server if BASE_URL is up; otherwise build (if needed) and
- *  start `vite preview` ourselves, returning the child to kill on exit. */
 async function ensureServer() {
   if (await reachable()) {
     console.log(`• using server at ${baseUrl}`);
@@ -127,14 +184,10 @@ async function ensureServer() {
   }
   console.log(`• starting \`vite preview\` on :${PORT}…`);
   const srv = spawn('npm', ['run', 'preview', '--', '--port', String(PORT), '--strictPort'], {
-    cwd: repoRoot,
-    stdio: DEBUG ? 'inherit' : 'ignore',
+    cwd: repoRoot, stdio: DEBUG ? 'inherit' : 'ignore',
   });
   for (let i = 0; i < 40; i++) {
-    if (await reachable()) {
-      console.log('• server up');
-      return srv;
-    }
+    if (await reachable()) { console.log('• server up'); return srv; }
     await sleep(500);
   }
   srv.kill('SIGTERM');
@@ -143,10 +196,10 @@ async function ensureServer() {
 
 // ---- live-DOM discovery of the chrome's variant controls ----
 
-/** Top-bar mode pills (e.g. Trinary's Observatory | Lab, Counting's Explain | Lab). */
+/** Top-bar mode pills (e.g. Trinary's Observatory | Lab). {i,label,on}. */
 function listModes(page) {
   return page.$$eval('.am-pills[role="tablist"] .am-pill[role="tab"]', (els) =>
-    els.map((e, i) => ({ i, label: (e.textContent || '').trim() })),
+    els.map((e, i) => ({ i, label: (e.textContent || '').trim(), on: e.getAttribute('aria-selected') === 'true' || e.classList.contains('am-on') })),
   );
 }
 async function selectMode(page, i) {
@@ -154,22 +207,19 @@ async function selectMode(page, i) {
   if (pills[i]) await pills[i].click();
 }
 
-/** Desktop Layout menu: Compact, the app's own layouts, Everything (+ any saved). */
+/** Desktop Layout menu: Compact, the app's layouts, Everything. {name,on}. */
 async function listLayouts(page) {
   const btn = await page.$('.am-layouts-btn');
   if (!btn) return [];
   await btn.click();
-  const ok = await page
-    .waitForSelector('.am-layouts-menu .am-lay-item', { timeout: 1500 })
-    .then(() => true)
-    .catch(() => false);
+  const ok = await page.waitForSelector('.am-layouts-menu .am-lay-item', { timeout: 1500 }).then(() => true).catch(() => false);
   if (!ok) return [];
-  const names = await page.$$eval('.am-layouts-menu .am-lay-item', (els) =>
-    els.map((e) => (e.querySelector('.am-lay-meta > span')?.textContent || e.textContent || '').trim()),
+  const items = await page.$$eval('.am-layouts-menu .am-lay-item', (els) =>
+    els.map((e) => ({ name: (e.querySelector('.am-lay-meta > span')?.textContent || e.textContent || '').trim(), on: e.classList.contains('am-on') })),
   );
   await page.keyboard.press('Escape').catch(() => {});
   await sleep(120);
-  return names;
+  return items;
 }
 async function selectLayout(page, i) {
   await page.click('.am-layouts-btn');
@@ -179,29 +229,26 @@ async function selectLayout(page, i) {
   await sleep(VARIANT_MS);
 }
 
-/** Phone view-chips: apps that model mutually-exclusive views as layouts
- *  (Stable Matching's matrix/welfare/lattice, Trinary's instruments). */
+/** Phone view-chips: apps that model mutually-exclusive views as layouts. */
 function listPhoneViews(page) {
-  return page.$$eval('.am-phone-layouts .am-chip', (els) => els.map((e) => (e.textContent || '').trim()));
+  return page.$$eval('.am-phone-layouts .am-chip', (els) =>
+    els.map((e) => ({ name: (e.textContent || '').trim(), on: e.classList.contains('am-on') || e.getAttribute('aria-selected') === 'true' })),
+  );
 }
 async function selectPhoneView(page, i) {
   const chips = await page.$$('.am-phone-layouts .am-chip');
-  if (chips[i]) {
-    await chips[i].click();
-    await sleep(VARIANT_MS);
-  }
+  if (chips[i]) { await chips[i].click(); await sleep(VARIANT_MS); }
 }
 
-/** Gallery category filter chips (All + each category). */
+/** Gallery category filter chips. {label,on}. */
 function listGalleryFilters(page) {
-  return page.$$eval('.am-gal-filters .am-chip', (els) => els.map((e) => (e.textContent || '').trim()));
+  return page.$$eval('.am-gal-filters .am-chip', (els) =>
+    els.map((e) => ({ label: (e.textContent || '').trim(), on: e.classList.contains('am-on') })),
+  );
 }
 async function selectGalleryFilter(page, i) {
   const chips = await page.$$('.am-gal-filters .am-chip');
-  if (chips[i]) {
-    await chips[i].click();
-    await sleep(250);
-  }
+  if (chips[i]) { await chips[i].click(); await sleep(250); }
 }
 
 // ---- capture ----
@@ -214,83 +261,117 @@ async function shoot(page, route, vp, parts, fullPage, results) {
   const meta = Object.fromEntries(parts.map((p) => [p.key, p.value]));
   try {
     await page.screenshot({ path: path.join(dir, file), fullPage });
-    results.push({ route: route.hash, name: route.name, viewport: vp.id, ...meta, file: rel, ok: true });
-    console.log(`    ✓ ${rel}`);
+    results.push({ route: route.hash, name: route.name, viewport: vp.id, detail, ...meta, file: rel, ok: true });
+    console.log(`      ✓ ${rel}`);
   } catch (e) {
-    results.push({ route: route.hash, name: route.name, viewport: vp.id, ...meta, file: rel, ok: false, error: String(e.message || e) });
-    console.log(`    ✗ ${rel} — ${e.message || e}`);
+    results.push({ route: route.hash, name: route.name, viewport: vp.id, detail, ...meta, file: rel, ok: false, error: String(e.message || e) });
+    console.log(`      ✗ ${rel} — ${e.message || e}`);
+  }
+}
+
+/** Capture one (route, viewport, skin) page across modes/layouts per detail. */
+async function captureVariants(page, route, vp, skin, hasCanvas, results) {
+  const skinPart = skin ? [{ key: 'skin', value: skin }] : [];
+  const settleMode = () => sleep(VARIANT_MS + (hasCanvas ? 500 : 0));
+
+  // Gallery: vary by category filter instead of modes/layouts.
+  if (route.hash === '/') {
+    const cats = await listGalleryFilters(page);
+    const real = cats.length > 0;
+    const list = real ? cats : [{ label: 'All', on: true }];
+    const chosen = detail === 'overview' ? [list.find((c) => c.on) ?? list[0]] : list;
+    for (const c of chosen) {
+      if (real) await selectGalleryFilter(page, list.indexOf(c));
+      await shoot(page, route, vp, [...skinPart, { key: 'filter', value: c.label }], true, results);
+    }
+    return;
+  }
+
+  const isDesktop = vp.id === 'desktop';
+  const varKey = isDesktop ? 'layout' : 'view';
+  const listVars = async () => {
+    const items = isDesktop ? await listLayouts(page) : await listPhoneViews(page);
+    return { real: items.length > 0, items: items.length ? items : [{ name: 'default', on: true }] };
+  };
+  const selectVar = async (i, real) => {
+    if (!real) return;
+    if (isDesktop) await selectLayout(page, i);
+    else await selectPhoneView(page, i);
+  };
+
+  const modes = await listModes(page);
+  const realModes = modes.length > 0;
+  const modeItems = realModes ? modes : [{ i: -1, label: 'default', on: true }];
+  const aMode = modeItems[Math.max(0, modeItems.findIndex((m) => m.on))];
+
+  // overview — the pristine default, no clicks: label the active mode + variant.
+  if (detail === 'overview') {
+    const { items } = await listVars();
+    const aVar = items.find((v) => v.on) ?? items[0];
+    await shoot(page, route, vp, [...skinPart, { key: 'mode', value: aMode.label }, { key: varKey, value: aVar.name }], false, results);
+    return;
+  }
+
+  // everything — full cross-product, every layout explicitly selected.
+  if (detail === 'everything') {
+    for (const m of modeItems) {
+      if (m.i >= 0) { await selectMode(page, m.i); await settleMode(); }
+      const { real, items } = await listVars();
+      for (let i = 0; i < items.length; i++) {
+        await selectVar(i, real);
+        await shoot(page, route, vp, [...skinPart, { key: 'mode', value: m.label }, { key: varKey, value: items[i].name }], false, results);
+      }
+    }
+    return;
+  }
+
+  // standard — do the modes pass BEFORE touching layouts, so each non-default
+  // mode is captured at its own pristine default (no carried-over layout); then
+  // sweep all layouts at the default mode.
+  for (const m of modeItems) {
+    if (m.i === aMode.i) continue;
+    if (m.i >= 0) { await selectMode(page, m.i); await settleMode(); }
+    const { items } = await listVars();
+    const aVar = items.find((v) => v.on) ?? items[0];
+    await shoot(page, route, vp, [...skinPart, { key: 'mode', value: m.label }, { key: varKey, value: aVar.name }], false, results);
+  }
+  if (realModes && modeItems.length > 1) { await selectMode(page, aMode.i); await settleMode(); }
+  const { real, items } = await listVars();
+  for (let i = 0; i < items.length; i++) {
+    await selectVar(i, real);
+    await shoot(page, route, vp, [...skinPart, { key: 'mode', value: aMode.label }, { key: varKey, value: items[i].name }], false, results);
   }
 }
 
 async function captureRouteViewport(context, route, vp, results) {
-  const page = await context.newPage();
-  await page.setViewport({ width: vp.width, height: vp.height, deviceScaleFactor: vp.dsf, isMobile: vp.mobile, hasTouch: vp.mobile });
-  if (SKIN) {
-    await page.evaluateOnNewDocument((s) => {
-      try { localStorage.setItem('animath:v1:chrome:skin', s); } catch {}
-    }, JSON.stringify(SKIN));
-  }
-  if (DEBUG) {
-    page.on('pageerror', (e) => console.log(`      [pageerror] ${e.message}`));
-    page.on('console', (m) => m.type() === 'error' && console.log(`      [page:err] ${m.text()}`));
-  }
-
-  const url = baseUrl + '#' + route.hash;
-  try {
-    await page.goto(url, { waitUntil: 'networkidle0', timeout: 60000 });
-  } catch (e) {
-    console.log(`    ! nav failed ${url} — ${e.message}`);
+  for (const skin of skins) {
+    const page = await context.newPage();
+    await page.setViewport({ width: vp.width, height: vp.height, deviceScaleFactor: vp.dsf, isMobile: vp.mobile, hasTouch: vp.mobile });
+    // Skins are read from localStorage as a RAW id (not JSON) by skins.tsx;
+    // seed it before boot so applyPersistedSkin() + useSkin() both pick it up
+    // (and the gallery's skin-aware previews render in that skin).
+    if (skin) {
+      await page.evaluateOnNewDocument((id) => {
+        try { localStorage.setItem('animath:v1:chrome:skin', id); } catch {}
+      }, skin);
+    }
+    if (DEBUG) {
+      page.on('pageerror', (e) => console.log(`      [pageerror] ${e.message}`));
+      page.on('console', (m) => m.type() === 'error' && console.log(`      [page:err] ${m.text()}`));
+    }
+    try {
+      await page.goto(baseUrl + '#' + route.hash, { waitUntil: 'networkidle0', timeout: 60000 });
+    } catch (e) {
+      console.log(`    ! nav failed — ${e.message}`);
+      await page.close();
+      continue;
+    }
+    const hasCanvas = await page.waitForSelector('canvas', { timeout: 6000 }).then(() => true).catch(() => false);
+    await sleep(hasCanvas ? WAIT_MS : Math.min(WAIT_MS, 1000));
+    if (skin) console.log(`    · skin: ${skin}`);
+    await captureVariants(page, route, vp, skin, hasCanvas, results);
     await page.close();
-    return;
   }
-  const hasCanvas = await page.waitForSelector('canvas', { timeout: 6000 }).then(() => true).catch(() => false);
-  await sleep(hasCanvas ? WAIT_MS : Math.min(WAIT_MS, 1000));
-
-  const isGallery = route.hash === '/';
-  const fullPage = isGallery; // the gallery scrolls; capture every card
-
-  // Gallery: vary by category filter instead of layouts/modes.
-  if (isGallery) {
-    const cats = await listGalleryFilters(page);
-    const list = cats.length ? cats : ['All'];
-    for (let i = 0; i < list.length; i++) {
-      if (cats.length) await selectGalleryFilter(page, i);
-      await shoot(page, route, vp, [{ key: 'filter', value: list[i] }], fullPage, results);
-    }
-    await page.close();
-    return;
-  }
-
-  const modes = await listModes(page);
-  const modeList = modes.length ? modes : [{ i: -1, label: 'default' }];
-
-  for (const mode of modeList) {
-    if (mode.i >= 0) {
-      await selectMode(page, mode.i);
-      await sleep((hasCanvas ? VARIANT_MS + 500 : VARIANT_MS));
-    }
-    const modePart = { key: 'mode', value: mode.label };
-
-    if (vp.id === 'desktop') {
-      const layouts = await listLayouts(page);
-      const list = layouts.length ? layouts : ['default'];
-      for (let li = 0; li < list.length; li++) {
-        if (layouts.length) await selectLayout(page, li);
-        await shoot(page, route, vp, [modePart, { key: 'layout', value: list[li] }], fullPage, results);
-      }
-    } else {
-      const chips = await listPhoneViews(page);
-      if (chips.length) {
-        for (let ci = 0; ci < chips.length; ci++) {
-          await selectPhoneView(page, ci);
-          await shoot(page, route, vp, [modePart, { key: 'view', value: chips[ci] }], fullPage, results);
-        }
-      } else {
-        await shoot(page, route, vp, [modePart, { key: 'view', value: 'default' }], fullPage, results);
-      }
-    }
-  }
-  await page.close();
 }
 
 // ---- contact sheet ----
@@ -302,30 +383,24 @@ function writeIndex(routes, results) {
     byRoute.get(r.route).push(r);
   }
   const ok = results.filter((r) => r.ok).length;
+  const skinsPresent = [...new Set(results.map((r) => r.skin).filter(Boolean))];
   const caption = (r) =>
-    [r.viewport, r.mode, r.layout, r.view, r.filter].filter((v) => v && v !== 'default').join(' · ') || r.viewport;
+    [r.skin, r.viewport, r.mode, r.layout, r.view, r.filter].filter((v) => v && v !== 'default').join(' · ') || r.viewport;
 
-  const sections = routes
-    .filter((rt) => byRoute.has(rt.hash))
-    .map((rt) => {
-      const shots = byRoute.get(rt.hash);
-      const figs = shots
-        .map(
-          (s) => `
-        <figure class="shot ${s.ok ? '' : 'bad'}" data-vp="${s.viewport}">
+  const sections = routes.filter((rt) => byRoute.has(rt.hash)).map((rt) => {
+    const figs = byRoute.get(rt.hash).map((s) => `
+        <figure class="shot ${s.ok ? '' : 'bad'}" data-vp="${s.viewport}" data-skin="${s.skin || ''}">
           ${s.ok ? `<a href="${s.file}" target="_blank"><img loading="lazy" src="${s.file}" alt="${caption(s)}"></a>` : `<div class="err">✗ ${s.error || 'failed'}</div>`}
           <figcaption>${caption(s)}</figcaption>
-        </figure>`,
-        )
-        .join('');
-      return `
+        </figure>`).join('');
+    return `
       <section class="app" data-name="${rt.name.toLowerCase()}">
-        <h2>${rt.name} <span class="hash">${rt.hash}</span> <span class="count">${shots.length}</span></h2>
+        <h2>${rt.name} <span class="hash">${rt.hash}</span> <span class="count">${byRoute.get(rt.hash).length}</span></h2>
         <div class="grid">${figs}</div>
       </section>`;
-    })
-    .join('');
+  }).join('');
 
+  const skinOptions = skinsPresent.map((s) => `<option value="${s}">${s}</option>`).join('');
   const html = `<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
@@ -350,7 +425,7 @@ function writeIndex(routes, results) {
   .grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); gap: 16px; }
   figure.shot { margin: 0; background: #11151d; border: 1px solid #1f2733; border-radius: 10px; overflow: hidden; }
   figure.shot[data-vp="mobile"] { background: #0a0d13; }
-  figure.shot img { width: 100%; display: block; background: #000; aspect-ratio: auto; }
+  figure.shot img { width: 100%; display: block; background: #000; }
   figure.shot figcaption { padding: 7px 10px; font-size: 12px; color: #9aa6b6; border-top: 1px solid #1a212c;
     white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
   figure.shot.bad { border-color: #5a2530; }
@@ -360,25 +435,22 @@ function writeIndex(routes, results) {
 </head><body>
 <header>
   <h1>animath — site tour</h1>
-  <span class="meta">${ok}/${results.length} shots · ${byRoute.size} routes · ${new Date().toISOString().slice(0, 16).replace('T', ' ')}</span>
+  <span class="meta">${ok}/${results.length} shots · ${byRoute.size} routes · detail: ${detail} · ${new Date().toISOString().slice(0, 16).replace('T', ' ')}</span>
   <span class="spacer"></span>
   <input id="q" type="search" placeholder="filter apps…" autocomplete="off">
-  <select id="vp">
-    <option value="">all viewports</option>
-    <option value="desktop">desktop</option>
-    <option value="mobile">mobile</option>
-  </select>
+  <select id="vp"><option value="">all viewports</option><option value="desktop">desktop</option><option value="mobile">mobile</option></select>
+  ${skinsPresent.length ? `<select id="sk"><option value="">all skins</option>${skinOptions}</select>` : ''}
 </header>
 <main>${sections}</main>
 <script>
-  const q = document.getElementById('q'), vp = document.getElementById('vp');
+  const q = document.getElementById('q'), vp = document.getElementById('vp'), sk = document.getElementById('sk');
   function apply() {
-    const term = q.value.trim().toLowerCase(), v = vp.value;
+    const term = q.value.trim().toLowerCase(), v = vp.value, s = sk ? sk.value : '';
     for (const sec of document.querySelectorAll('section.app')) {
       const nameHit = !term || sec.dataset.name.includes(term);
       let any = false;
       for (const fig of sec.querySelectorAll('figure.shot')) {
-        const show = nameHit && (!v || fig.dataset.vp === v);
+        const show = nameHit && (!v || fig.dataset.vp === v) && (!s || fig.dataset.skin === s);
         fig.classList.toggle('hide', !show);
         any = any || show;
       }
@@ -386,6 +458,7 @@ function writeIndex(routes, results) {
     }
   }
   q.addEventListener('input', apply); vp.addEventListener('change', apply);
+  if (sk) sk.addEventListener('change', apply);
 </script>
 </body></html>`;
   fs.writeFileSync(path.join(OUT_DIR, 'index.html'), html);
@@ -394,10 +467,22 @@ function writeIndex(routes, results) {
 // ---- main ----
 
 async function main() {
-  const routes = readRoutes();
+  if (flags.list) {
+    console.log(`routes (${allRoutes.length}):`);
+    for (const r of allRoutes) console.log(`  ${slug(r.hash).padEnd(24)} ${r.hash.padEnd(28)} ${r.name}`);
+    console.log(`\nskins (${ALL_SKINS.length}; default ${DEFAULT_SKIN}):`);
+    for (const s of ALL_SKINS) console.log(`  ${s.id.padEnd(12)} ${s.name}`);
+    console.log(`\ndetail levels: ${DETAILS.join(' | ')}`);
+    return;
+  }
+  if (!routes.length) {
+    console.error(`no routes matched ${JSON.stringify(targets)} — try \`--list\``);
+    process.exit(2);
+  }
+
   fs.mkdirSync(OUT_DIR, { recursive: true });
   console.log(`animath tour → ${OUT_DIR}`);
-  console.log(`routes: ${routes.length} · viewports: ${VIEWPORTS.map((v) => v.id).join(', ')}${SKIN ? ` · skin: ${SKIN}` : ''}`);
+  console.log(`routes: ${routes.length}/${allRoutes.length} · viewports: ${VIEWPORTS.map((v) => v.id).join(', ')} · detail: ${detail} · skins: ${skins.map((s) => s ?? 'default').join(', ')}`);
 
   const server = await ensureServer();
   const browser = await puppeteer.launch({ args: BROWSER_ARGS });
@@ -422,17 +507,14 @@ async function main() {
     if (server) server.kill('SIGTERM');
   }
 
-  fs.writeFileSync(path.join(OUT_DIR, 'manifest.json'), JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl, skin: SKIN, results }, null, 2));
+  fs.writeFileSync(path.join(OUT_DIR, 'manifest.json'), JSON.stringify({ generatedAt: new Date().toISOString(), baseUrl, detail, skins, results }, null, 2));
   writeIndex(routes, results);
 
-  const ok = results.filter((r) => r.ok).length;
-  const bad = results.length - ok;
+  const okN = results.filter((r) => r.ok).length;
+  const badN = results.length - okN;
   console.log(`\n${'='.repeat(48)}`);
-  console.log(`done: ${ok} ok, ${bad} failed → ${path.join(OUT_DIR, 'index.html')}`);
-  process.exit(bad > 0 ? 1 : 0);
+  console.log(`done: ${okN} ok, ${badN} failed → ${path.join(OUT_DIR, 'index.html')}`);
+  process.exit(badN > 0 ? 1 : 0);
 }
 
-main().catch((e) => {
-  console.error(e);
-  process.exit(1);
-});
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/scripts/tour.mjs
+++ b/scripts/tour.mjs
@@ -343,34 +343,47 @@ async function captureVariants(page, route, vp, skin, hasCanvas, results) {
   }
 }
 
-async function captureRouteViewport(context, route, vp, results) {
+async function captureRouteViewport(browser, route, vp, results) {
   for (const skin of skins) {
-    const page = await context.newPage();
-    await page.setViewport({ width: vp.width, height: vp.height, deviceScaleFactor: vp.dsf, isMobile: vp.mobile, hasTouch: vp.mobile });
-    // Skins are read from localStorage as a RAW id (not JSON) by skins.tsx;
-    // seed it before boot so applyPersistedSkin() + useSkin() both pick it up
-    // (and the gallery's skin-aware previews render in that skin).
-    if (skin) {
-      await page.evaluateOnNewDocument((id) => {
-        try { localStorage.setItem('animath:v1:chrome:skin', id); } catch {}
-      }, skin);
-    }
-    if (DEBUG) {
-      page.on('pageerror', (e) => console.log(`      [pageerror] ${e.message}`));
-      page.on('console', (m) => m.type() === 'error' && console.log(`      [page:err] ${m.text()}`));
-    }
+    // Fresh, isolated storage per (route, viewport, skin) so every capture
+    // starts from the app's true defaults — the workspace persists its layout
+    // to localStorage, so without a clean context the layout swept in one skin
+    // would bleed into the next skin's pristine-default reads (overview, and the
+    // standard modes pass). One context per skin keeps each one honest.
+    const context = await browser.createBrowserContext();
     try {
-      await page.goto(baseUrl + '#' + route.hash, { waitUntil: 'networkidle0', timeout: 60000 });
-    } catch (e) {
-      console.log(`    ! nav failed — ${e.message}`);
-      await page.close();
-      continue;
+      const page = await context.newPage();
+      await page.setViewport({ width: vp.width, height: vp.height, deviceScaleFactor: vp.dsf, isMobile: vp.mobile, hasTouch: vp.mobile });
+      // Skins are read from localStorage as a RAW id (not JSON) by skins.tsx;
+      // seed it before boot so applyPersistedSkin() + useSkin() both pick it up
+      // (and the gallery's skin-aware previews render in that skin).
+      if (skin) {
+        await page.evaluateOnNewDocument((id) => {
+          try { localStorage.setItem('animath:v1:chrome:skin', id); } catch {}
+        }, skin);
+      }
+      if (DEBUG) {
+        page.on('pageerror', (e) => console.log(`      [pageerror] ${e.message}`));
+        page.on('console', (m) => m.type() === 'error' && console.log(`      [page:err] ${m.text()}`));
+      }
+      try {
+        await page.goto(baseUrl + '#' + route.hash, { waitUntil: 'networkidle0', timeout: 60000 });
+      } catch (e) {
+        // Record nav failures as failed shots so they show in the manifest /
+        // contact sheet AND count toward badN — a route that never loads must
+        // make the tour exit non-zero, not silently vanish from the results.
+        const label = `${vp.id}${skin ? `__${skin}` : ''}__nav-failed`;
+        console.log(`      ✗ ${slug(route.hash)}/${label} — nav: ${e.message}`);
+        results.push({ route: route.hash, name: route.name, viewport: vp.id, detail, ...(skin ? { skin } : {}), file: `${slug(route.hash)}/${label}`, ok: false, error: `nav failed: ${e.message}` });
+        continue;
+      }
+      const hasCanvas = await page.waitForSelector('canvas', { timeout: 6000 }).then(() => true).catch(() => false);
+      await sleep(hasCanvas ? WAIT_MS : Math.min(WAIT_MS, 1000));
+      if (skin) console.log(`    · skin: ${skin}`);
+      await captureVariants(page, route, vp, skin, hasCanvas, results);
+    } finally {
+      await context.close();
     }
-    const hasCanvas = await page.waitForSelector('canvas', { timeout: 6000 }).then(() => true).catch(() => false);
-    await sleep(hasCanvas ? WAIT_MS : Math.min(WAIT_MS, 1000));
-    if (skin) console.log(`    · skin: ${skin}`);
-    await captureVariants(page, route, vp, skin, hasCanvas, results);
-    await page.close();
   }
 }
 
@@ -490,16 +503,10 @@ async function main() {
   try {
     for (const route of routes) {
       console.log(`\n▸ ${route.name}  (${route.hash})`);
-      // Fresh, isolated storage per route so each app starts from its true
-      // defaults (no persisted layout bleeding across the tour).
-      const context = await browser.createBrowserContext();
-      try {
-        for (const vp of VIEWPORTS) {
-          console.log(`  · ${vp.id}`);
-          await captureRouteViewport(context, route, vp, results);
-        }
-      } finally {
-        await context.close();
+      for (const vp of VIEWPORTS) {
+        console.log(`  · ${vp.id}`);
+        // captureRouteViewport opens a fresh isolated context per skin.
+        await captureRouteViewport(browser, route, vp, results);
       }
     }
   } finally {


### PR DESCRIPTION
## Summary

Added `scripts/tour.mjs` (`npm run tour`), a reusable full-site screenshot harness that drives the real built app in headless Chromium and captures every app across desktop and phone form factors, exercising each app's modes and layouts. Includes three follow-up features: **targeting** (run a single app), **detail levels** (overview → standard → everything), and **skins** (capture in one or all five themes). Routes are read from `src/apps.ts` and skins from `src/chrome/skins.tsx`; modes/layouts are discovered from the live DOM. Outputs PNGs plus a searchable `index.html` contact sheet.

## Key changes

- **`scripts/tour.mjs`** (520 lines) — the driver. Walks `routes × viewports × modes × layouts (× skins)`, writes `screenshots/<app>/<vp>__[skin__]<mode>__<layout>.png` plus `manifest.json` and an `index.html` contact sheet. Auto-builds if `dist/` is missing and self-serves `vite preview` if no server is reachable. Each (route, viewport, skin) loads in an isolated browser context so apps start from their true defaults (prevents localStorage layout bleed across the tour).

- **Targeting** — positional args (or `ONLY=`) substring-match a route hash/slug (`npm run tour -- trinary`, `-- gallery`); `--list` prints routes + skins + detail levels and exits.

- **Detail levels** (`--detail` / `DETAIL`, default `everything`): 
  - `overview` — pristine default only (default mode × default layout)
  - `standard` — every layout at default mode + every other mode at its default
  - `everything` — full mode × layout cross-product
  
  The `standard` modes pass runs *before* any layout click so each mode is captured at its own pristine default (avoids carried-over layout).

- **Skins** (`--skins` / `SKINS`, `all` or a comma list of ids/names). Fixed a real bug: `skins.tsx` reads the skin from `localStorage` as a **raw id** (`phosphor`), not JSON. The script now seeds raw (not `JSON.stringify`) before boot so the gallery's skin-aware preview canvases render correctly.

- **`.github/workflows/screenshots.yml`** — on-demand (`workflow_dispatch`) CI workflow with `only` / `detail` / `viewports` / `skins` inputs; installs Chrome runtime libs, builds, serves, runs the tour, uploads `screenshots/` as an artifact.

- **`docs/SCREENSHOTS.md`** — usage guide with flags/env reference and examples.

- **`.gitignore`** — added `screenshots/` and `scratch-smoke/` (generated artifacts, not committed).

- **`package.json`** — added `npm run tour` script.

- **`CLAUDE.md`** — added tour reference to Quick Reference.

## Implementation notes

- Rendering is **software WebGL (SwiftShaker via ANGLE)** — same as `scripts/shoot.mjs`. No GPU in CI; colors/anti-aliasing may differ subtly from production.
- DOM contract: mode pills `.am-pills[role=tablist] .am-pill[role=tab]`; desktop Layout menu `.am-layouts-btn` → `.am-layouts-menu .am-lay-item`; phone view-chips `.am-phone-layouts .am-chip`; gallery filters `.am-gal-filters .am-chip`. If these class names change, update the `list*`/`select*` helpers in `tour.mjs`.
- Default run captures **107 shots, 0 failures** (all routes, both viewports, standard detail, default skin).
- Each (route, viewport, skin) loads in a fresh isolated browser context so apps start from their true defaults (the workspace persists layout to `localStorage`, so isolation prevents bleed).

https://claude.ai/code/session_01A27jqVRNzyMb6gq3EoNEu3