### PR TITLE
Chrome design hardening: semantic/data tokens, 3 skins, colormap registry, per-app compliance

### DIFF
--- a/docs/redesign/DESIGN-SPEC.md
+++ b/docs/redesign/DESIGN-SPEC.md
@@ -161,7 +161,12 @@ Google Fonts import is in `theme.css`. The **Phosphor** skin overrides display+U
 One attribute — `data-theme` on the root — restyles everything. Each skin is a token block in
 `theme.css`. Tokens: `--bg --viz-bg --panel --panel-solid --panel-2 --fg --dim --dim-2 --accent
 --accent-fg --accent-soft --accent-2 --border --border-strong --hover --active --shadow --track
---dot-color` (+ optional font overrides).
+--dot-color` (+ optional font overrides). Semantic + scale tokens (every skin):
+`--danger --danger-soft --success --success-soft` (destructive vs. confirming
+signal), `--shadow-1 --shadow-2 --shadow-3` (elevation scale: panel · popover ·
+modal), `--data-1 … --data-7` (categorical ramp — also the *discrete* colormap,
+see §11 / `lib/colormapRegistry.ts`), and `--font-scale` (per-skin type-size
+multiplier; Phosphor = 0.9 via a scoped `zoom` so its wider mono face matches).
 
 | id | Name | Character | bg | accent |
 |---|---|---|---|---|
@@ -170,11 +175,16 @@ One attribute — `data-theme` on the root — restyles everything. Each skin is
 | `neon` | Spectrum | space black · cyan + magenta | `#05060f` | `#34e6cf` |
 | `blueprint` | Blueprint | drafting blue · chalk lines, brighter dots | `#0e2148` | `#f2f6ff` |
 | `phosphor` | Phosphor | CRT green, **all-mono type** | `#03100a` | `#3dff7a` |
+| `daylight` | Daylight | cool white · clear editorial blue (light) | `#eef2f8` | `#2f6fe0` |
+| `primary` | Primary | Bauhaus · bold primaries on bone (light) | `#f0eee8` | `#f5c518` |
+| `mirage` | Mirage | surreal plum dusk · peach + lavender (dark) | `#1a1230` | `#ffb37a` |
 
 Skin picker: pill button (3 swatch dots + name) in gallery and workspace bars; dropdown lists all
 skins with name + blurb + dots. Adding a skin = one token block + one registry entry.
 
-Canvas engines should read the skin too (the prototype's mocks treat any non-`light` skin as dark).
+Canvas engines should read the skin too. Light vs. dark is **not** `id === 'light'` —
+there are several light skins (`light`, `daylight`, `primary`); use `isLightSkin(id)`
+(or the per-skin `light` flag) from `skins.tsx`, the single source of truth.
 
 ## 6. Phone mode (≤ 740px)
 

--- a/docs/redesign/IN-PROGRESS.md
+++ b/docs/redesign/IN-PROGRESS.md
@@ -170,3 +170,25 @@ questions. The implementing agent should update this file as phases land.
   already gesture-disambiguated, so tapping the Mandelbrot just picks c (EXPLAINER updated).
   Probe: `scripts/probe-hints.mjs`. Follow-up idea (pedagogy): Plane Transform's hint could
   *arm* draw mode rather than name the Curves panel — deferred with P3.
+- 2026-06-24: **Design-contract hardening** (branch `claude/youthful-cray-7m6z9d`, from a
+  Claude Design work order). *Enforcement + four missing pieces, not a redesign.* **(1) Tokens:**
+  added `--danger(-soft)` / `--success(-soft)` (destructive vs. confirming signal),
+  `--shadow-1/2/3` (elevation scale), `--data-1…7` (categorical ramp = the *discrete* colormap),
+  and `--font-scale` to every skin (`theme.css`), all additive. **(2) Three new skins:** Daylight
+  & Primary (light), Mirage (dark) — `theme.css` blocks + `skins.tsx` entries; the `Skin`
+  descriptor gained a `light?` flag + `isLightSkin(id)` helper (single source of truth for
+  light/dark — the lone `skin === 'light'` test, in `previews.tsx`, now uses it so the new light
+  skins render light cards). `--font-scale` consumer = **Option A** (scoped Phosphor `zoom`),
+  screenshot-verified gap-free. **(3) Colormap registry:** new `src/lib/colormapRegistry.ts` — a
+  typed, per-theme JS/CSS colormap resource for **DOM/2D** apps, organized by *family*
+  (sequential / divergent / discrete / cyclic) where the discrete family = the skin's `--data-*`
+  tokens (`discreteStops()` reads them live). Shader apps stay on `lib/colormaps.ts` GLSL (names
+  kept in sync). `<ColormapPicker>` added to `ControlPanel.tsx` (the `color`-tier control). Pure
+  logic covered by `src/lib/__tests__/colormapRegistry.test.ts`. **(4) Per-app compliance:** a
+  single read-only audit confirmed the offenders against source (corrected several
+  screenshot-derived hypotheses — the Stable Matching matrix was already divergent BuRd, not a
+  rainbow; "Compact floats a panel" was false everywhere; Counting the Ways had zero hardcoded
+  color). Fixes: dedupe transport into `actions:` (Stable Matching, Agentic Sorting, Trinary
+  Observatory, Counting the Ways), project panel-only transport to a strip (Correspondence,
+  Trinary Lab), one home for Argand's feed mode, tokenize hardcoded DOM color, and rename the
+  Trinary mode (Observatory→Sandbox) off the skin-name collision.

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -118,15 +118,17 @@ informs future rounds. Delete or check off items as they land.
   docs/apps/<slug>.md" so there's a single architecture home. Touches the shared
   append-only CLAUDE.md — do it as its own pass to avoid parallel-branch conflicts.
 
-- [ ] [chrome] !med Make graphics consistently theme-driven — gallery previews + per-app canvases.
-  Counting the Ways' gallery preview now reads the live theme tokens (`--accent` /
-  `--accent-2` / `--bg` via `getComputedStyle(document.documentElement)`) so the card
-  tracks the active skin, not just light/dark — `SkellamPreview` in
-  `chrome/previews.tsx` is the **model**. The other previews still hardcode a
-  light/dark pair, and apps don't all respect the theme the same way. Future pass:
-  roll the getComputedStyle pattern across `previews.tsx` and audit in-app canvases so
-  every skin renders faithfully. Dan 2026-06-23: neat idea, not urgent — work toward it
-  once each app's theming is known to be consistent.
+- [ ] [chrome] !low Make in-app canvases consistently theme-driven (gallery previews DONE).
+  DONE 2026-06-24 (PR #238): rolled the `SkellamPreview` getComputedStyle pattern across
+  **all** gallery previews via a shared `themeInk(light)` helper in `chrome/previews.tsx` —
+  every card now reads `--viz-bg`/`--accent`/`--accent-2`/`--data-*` live, so it tracks the
+  *specific* skin (verified across Phosphor/Neon/Mirage/Daylight), keeping the rainbow hue
+  art on the complex-domain previews (Particles/Plane/Fractal/Julia) where hue encodes the
+  argument. Caveat: JuliaPreview's cached Mandelbrot inset captures the skin at first paint
+  and only re-tints on reload (the Julia pane + marker track live). Remaining (!low): a
+  systematic sweep of each app's in-app canvases/HUDs so every skin renders faithfully — many
+  were tokenized in the design-hardening pass, but deciding which 3D scene colors follow the
+  skin vs stay semantic is still open. Dan 2026-06-23: neat idea, not urgent.
 
 - [x] [agentic-sorting] EXPLAINER/README no longer describe the removed Replicate panel.
   DONE 2026-06-22. Removed the stale Replicate-panel copy from both the AgenticSorting

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -25,6 +25,22 @@ informs future rounds. Delete or check off items as they land.
 
 # Backlog · animath
 
+- [ ] [chrome] !high Theming v2 — light/dark-paired themes (decouple identity from mode).
+  Full spec: `docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md`
+  (status: proposed; execute next session). Every theme gets a light AND dark palette under
+  shared token names (via CSS `light-dark()`); a feature that *requires* a mode (glowing-particle
+  / star scenes → dark; printout → light) forces it on its own subtree, so scene objects use the
+  normal tokens at the theme's dark values — no bespoke per-app scene palette. The `data-scheme`
+  attribute (PR #238) is the switch; dark variants are theme-tinted (Observatory blue-black,
+  Mirage plum), so a forced-dark star field keeps the theme's character. Folds in the per-app viz
+  unification (Trinary scene/data, Complex Particles, Plane Transform, Fractals, Correspondence,
+  Trees, Argand), Agentic Sorting's deferred discrete-colormap adoption, and the Worlds' **day/
+  night skies** (mode = time of day). Decisions locked (in the plan): outcomes → divergent
+  colormap sampled by goodness; stars → discrete `--data` identity; planet → neutral; `--accent`
+  is UI-only; Phosphor's light analog = the 1980s beige case. Prereq is the shared engine
+  (Phase 0); most DOM/SVG apps then "just work," the WebGL apps need a force-mode wrapper +
+  token-reading. Dan 2026-06-24: "the correct move gives every theme a light/dark palette."
+
 - [ ] [counting-the-ways] !med The Lab should show cumulative results, not one-off rows.
   Today each *Run & log* draws an independent sample and appends a row with its own
   method-of-moments μ̂ — no accumulation. Make the catalog **cumulative**: a pooled /

--- a/docs/sessions/TODO.md
+++ b/docs/sessions/TODO.md
@@ -291,3 +291,37 @@ informs future rounds. Delete or check off items as they land.
   at 0 *errors* (CI-gated via `deploy.yml` + the new `sessions-lint.yml`); this is the
   warning cleanup. Once quiet, consider promoting the PR `sessions-lint` check and the
   mobile smoke from advisory to hard gates (drop `continue-on-error`).
+
+- [ ] [chrome] !low Adopt the discrete colormap registry in Agentic Sorting (theme --data palette for agent identity).
+  The 2026-06-24 design-hardening session shipped `src/lib/colormapRegistry.ts` +
+  `<ColormapPicker>` and adopted it in Stable Matching (divergent, default RdBu). Agentic
+  Sorting's Okabe-Ito agent palette (`arena.ts:13-25`) is the canonical *discrete* target but
+  was deferred: it feeds 3 surfaces (canvas `colorFor`, DOM swatches in `AgenticSorting.tsx`,
+  `LabResults` `barColor`) that must convert atomically, plus a `useThemeId()` subscription +
+  a per-frame ref refresh for the canvas; the existing palette is already colorblind-safe. Do
+  it as one pass with cross-skin visual verification. The same pattern fits Trinary Lab's
+  census outcome colors.
+
+- [ ] [chrome] !low Tokenize residual DOM color on the compliance-clean apps (polish, no visible break).
+  From the 2026-06-24 audit: Polygon/Solid Worlds HUD overlays (~12-14 hex each), Trinary's
+  preset/active buttons (hardcoded blue), PlaneTransform's split-pane bg `#0c0c10` + SVG
+  `stroke="#ffffff"`, TreesAndNets' `C_FLIP`/`C_CROSS`/`#ffd54a` SVG constants. NONE break on
+  light skins today (verified Trees + Plane in Daylight this session) — pure polish, so weigh
+  against regression risk on already-compliant apps. Leave 3D scene/material color + semantic
+  state markers alone (engine color, not chrome).
+
+- [ ] [chrome] !low Complex Particles: reflow/fade the pan-zoom hint when the 4D-Rotation panel covers it.
+  Design-doc 03 minor item; the hint lives on the shared view-overlay hint layer. Polish, not
+  a contract violation.
+
+- [ ] [chrome] !low Full 8-skin × all-apps tour sweep as a visual-regression baseline.
+  `npm run tour -- --skins all` now spans 8 skins (Daylight/Primary/Mirage added 2026-06-24).
+  The hardening session verified the changed apps in representative skins (dark/daylight/
+  phosphor) but not the full 8×14 matrix. Capture a baseline contact sheet; pairs with the
+  existing "wire the tour into CI" TODO above.
+
+- [ ] [chrome] !low Revisit --font-scale Option B (rem migration) if Phosphor still reads large.
+  2026-06-24 shipped Option A — a scoped `[data-theme="phosphor"] .am-app/.am-gallery-app
+  { zoom: var(--font-scale) }` (=0.9), screenshot-verified gap-free at gallery + app level.
+  Option B (migrate chrome px→rem + a type-root `calc()` multiplier) is the cleaner long-term
+  fix if A proves insufficient; bigger diff, deferred per the design doc.

--- a/docs/sessions/handoff/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/handoff/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -1,0 +1,127 @@
+---
+kind: handoff
+session: 2026-06-24-S01
+date: 2026-06-24
+title: Chrome design cleanup — design-contract hardening (PR #238) + theming-v2 plan
+branch: claude/youthful-cray-7m6z9d
+slug: youthful-cray-7m6z9d
+status: completed
+build: passed
+followup: null
+pr: 238
+app: chrome
+signals: needs-dan, visual-unverified
+next: Merge #238 (chrome contract + foundations, CI green) when ready; then execute the theming-v2 plan (2026-06-24-S02-plan-light-dark-theming.md) next session.
+---
+
+# Chrome design cleanup — design-contract hardening (PR #238) + theming-v2 plan
+
+## Summary
+
+Executed the **Claude Design** "design-system hardening" work order (attached zip),
+then — at Dan's steer — went deeper into the cross-app design contract and scoped the
+next initiative. **PR #238** is open, CI green, **merge-ready**: it delivers semantic/
+data tokens on every skin + 3 new skins, a typed colormap registry, per-app transport/
+compliance fixes, reactive skin-switching, light-skin contrast fixes, and per-skin
+gallery previews. The deeper "every app's *visualization* tracks the skin" work is
+written up as a **proposed plan** ([theming v2](2026-06-24-S02-plan-light-dark-theming.md))
+for next session. Trinary's UI was tokenized this session as the partial reference.
+
+## What changed (all in PR #238)
+
+- **Tokens & skins** (`theme.css`, `skins.tsx`): `--danger/--success(-soft)`,
+  `--shadow-1/2/3`, `--data-1…7`, `--font-scale` on all skins; **3 new skins**
+  (Daylight, Primary, Mirage). A `light` flag + `isLightSkin()`, `useThemeId()`, and a
+  root `data-scheme` attribute.
+- **`useSkin` made reactive** — derives from the live `data-theme` (via `useThemeId`)
+  instead of a private `useState`, so skin changes re-theme **everything live, no
+  refresh**. This was the root-cause fix for the gallery previews lagging until reload
+  (independent `useSkin` instances never synced). Verified with a headless live-switch.
+- **Colormap registry** (`lib/colormapRegistry.ts` + `<ColormapPicker>` + 10 tests):
+  per-theme maps by family (sequential/divergent/discrete/cyclic); discrete = the skin's
+  `--data` tokens. Shader apps stay on GLSL.
+- **Per-app compliance**: Stable Matching (reference — transport→strip, matrix via
+  registry, CSS tokenized, **light-on-light fixed**); Agentic Sorting + Counting the
+  Ways (transport dedup); Trinary (dedup + mode rename **Explore** + Lab transport→strip
+  + **UI/HUD tokenized**); Argand (feed single-homed, fullscreen-safe); Correspondence
+  (transport→strip). Gallery previews theme per-skin.
+- **Review fixes**: Argand fullscreen feed access; light-skin `<select>` rendering
+  (via `data-scheme`).
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`src/chrome/skins.tsx`](https://github.com/piyarsquare/animath/blob/0794709aa93b7362857d424151031f25ab257342/src/chrome/skins.tsx) | reactive `useSkin`/`useThemeId`, `isLightSkin`, `data-scheme`, 8 skins (the live-theming fix) |
+| [`src/chrome/theme.css`](https://github.com/piyarsquare/animath/blob/0794709aa93b7362857d424151031f25ab257342/src/chrome/theme.css) | all token blocks + 3 new skins + Phosphor `--font-scale` zoom |
+| [`src/lib/colormapRegistry.ts`](https://github.com/piyarsquare/animath/blob/0794709aa93b7362857d424151031f25ab257342/src/lib/colormapRegistry.ts) | the per-theme colormap registry (data-voice colors for DOM apps) |
+| [`src/chrome/previews.tsx`](https://github.com/piyarsquare/animath/blob/0794709aa93b7362857d424151031f25ab257342/src/chrome/previews.tsx) | `themeInk()` — gallery previews read live tokens per skin |
+| [`src/animations/StableMatching/StableMatching.tsx`](https://github.com/piyarsquare/animath/blob/0794709aa93b7362857d424151031f25ab257342/src/animations/StableMatching/StableMatching.tsx) | the chrome reference + the light-on-light → per-skin-token fix |
+| [`docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md`](https://github.com/piyarsquare/animath/blob/0794709aa93b7362857d424151031f25ab257342/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md) | **the theming-v2 plan — the next session's spec** |
+
+## Open / not done
+
+- **Merge #238** when Dan's reviewed — it's a clean "chrome contract + foundations"
+  stopping point (build/lint/test green; both light skins contrast-verified).
+- **Theming v2** (the plan): light/dark-*paired* themes so every app's viz tracks the
+  skin. Folds in: Trinary scene/data recolor, the other WebGL apps, Agentic Sorting's
+  deferred discrete-colormap, the Worlds' day/night skies.
+- The transient `trigger-deploy` CI red on `0794709` is a GitHub-API 504 (it dispatches
+  *main's* deploy; harmless to the PR; clears on next push — my integration can't
+  re-run it, 403).
+
+## Context
+
+> [!IMPORTANT]
+> The session's design conclusions (locked with Dan, in the v2 plan): **`--accent` is
+> UI-voice only** (never encodes data); **data voice** = the colormap registry / `--data`
+> / `--success`-`--danger`. **Ordered/polar data** (temperature, good→bad) → *sample a
+> registry colormap*; **identity** (stars) → discrete `--data`; **planet** → a neutral.
+> The linchpin: scenes that must stay dark want **light/dark-paired themes** — force the
+> scene subtree to the theme's dark mode and its objects use the normal tokens at dark
+> values (no bespoke scene palette). The `data-scheme` attribute added this session is
+> that switch.
+
+> [!NOTE]
+> `useSkin()` returns a per-call `useState`; before the fix, a *reader* instance
+> (Gallery) never saw a *writer* instance (TopBar SkinPicker). It now derives from the
+> DOM attribute, so all consumers stay in sync. Any new "read the current skin" code
+> should use `useThemeId()` (reactive), not a fresh `useSkin()[0]`.
+
+## Self-reflection
+
+1. **What would you do with another session?** Execute theming-v2 Phase 0 (the theme
+   engine: `light-dark()` token pairs + the missing light/dark companions + the
+   force-mode primitive + a canvas token hook), then the Trinary scene and Worlds
+   day/night pilots — per the plan.
+2. **What would you change about what you produced?** The Trinary "reference" ships in a
+   half-state (UI tokenized, scene/data hardcoded). It's a real improvement and the
+   deferral is deliberate (v2 makes the rest clean), but a reviewer seeing only the diff
+   might read it as inconsistent — the PR body now flags it.
+3. **What were you not asked that you think is important?** Whether #238 should be split
+   — it grew well past the original 4-phase work order (gallery theming, reactive skins,
+   light-on-light, Trinary UI all came from live feedback). It's coherent as "chrome
+   contract + foundations," but it's large; I kept it as one PR for continuity.
+4. **What did we both overlook?** That tokenizing Stable Matching's panels to follow the
+   skin would expose *light-on-light* — fixed-light semantic text (the lattice `#fff`
+   fallback, the metric green) was invisible once the panel went white. Caught by Dan in
+   Daylight, not by me. Lesson logged: when a background starts following the skin, the
+   text on it must too.
+5. **What did you find difficult?** Drawing the keep-vs-tokenize line on viz colors —
+   much of it is meaningful (rainbow domain, rank ramps, star fields), and the honest
+   answer turned out to need an architecture change (light/dark pairs), not a heuristic.
+6. **What would have made this task easier?** A `light-dark()`-based theme engine from
+   the start — it dissolves the "scene needs its own palette" problem that consumed much
+   of the Trinary discussion.
+7. **How did you verify this, and does each passing check test the user-visible claim?**
+   Mixed, mostly real: build/lint/test by running them (88 tests green); the reactive-
+   skin fix by a **headless live-switch test** (load gallery dark → click picker →
+   Daylight, no reload → re-themed, the exact user claim); the light-on-light fix and
+   every skin by **headless screenshots I actually read** (Daylight/Primary/Phosphor/
+   Mirage/dark across the changed apps). Caveat: headless WebGL is SwiftShader, not a
+   real GPU, so colors aren't pixel-true and touch/real-device behavior is unverified —
+   but the contrast and theming claims are about CSS/token resolution, which the shots
+   show faithfully. No green check here stands in for an unmet claim.
+8. **Follow-up value:** LOW — #238 is complete and verified; the remaining work
+   (theming v2) is a separate, fully-specified initiative, and the one Dan-owned decision
+   (merge timing) is tracked.

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -54,6 +54,61 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 14:05 — Phase 1 done: semantic/data tokens on all skins + 3 new skins, verified
+**Why:** Pure-addition foundation that unblocks every color task; ship and eyeball
+it before building on it (R1 — verify visual changes with my eyes).
+
+Additive edits to `theme.css` + `skins.tsx` (+ a `previews.tsx` source fix):
+- **Semantic/elevation/data/font tokens on all 5 existing skins:** `--danger(-soft)`,
+  `--success(-soft)`, `--shadow-1/2/3`, `--data-1…7`, `--font-scale` — values
+  tuned per skin from the doc. Counts verified: 8× each across skins, `--font-scale`
+  9× (8 skins + `:root` default).
+- **3 new skins** appended: **Daylight** (cool white · blue), **Primary** (Bauhaus
+  primaries), **Mirage** (plum dusk · peach + lavender). Registered in `skins.tsx`
+  (doc comment "five"→"eight").
+- **`--font-scale` consumer = Option A** (doc's recommendation): a scoped
+  `[data-theme="phosphor"] .am-app/.am-gallery-app { zoom: var(--font-scale) }`.
+  **Verified by screenshot** the zoom does NOT create a layout gap at gallery or
+  app level (the worry with `zoom` on a full-bleed root) — Phosphor type now sits
+  right-sized.
+- **New light-skin fix (from the audit):** the *only* hard-coded `skin === 'light'`
+  test lived at `previews.tsx:890` — it rendered Daylight/Primary gallery cards as
+  dark. Fixed at the source: added a `light?` flag to the `Skin` descriptor +
+  `isLightSkin(id)` helper in `skins.tsx`; `previews.tsx` now calls it. Re-shot the
+  Daylight gallery — preview cards now render light. (No app engine has this test;
+  it was isolated to that one chrome file.)
+- Docs: DESIGN-SPEC §5 token list + skin table + the light/dark note updated (additive).
+
+**Checks:** `npm run build` ✓, `npm run lint` ✓ 0 errors (60 baseline warnings),
+`npm test` ✓ 78/78. Visual: gallery in daylight/primary/mirage/phosphor + Stable
+Matching in phosphor & daylight all render cleanly (screenshots in scratch).
+
+### 🟣 decision · 13:50 — Execution plan locked; both flags resolved by Dan
+**Why:** Dan approved both flagged calls and directed: execute the package, fan
+out subagents per app to apply the rules, but have one coherent single pass do
+the compliance checking.
+
+- **Flag 1 (retired):** Stable Marriage stays retired — its `02-COLORMAPS.md` row
+  redirects to **Stable Matching**; the deleted app is not resurrected.
+- **Flag 2 (rename):** Resolve the Trinary "Observatory" skin/mode clash by
+  renaming the **mode** (not the skin). Going with **Sandbox ⇄ Lab** to match
+  Agentic Sorting's existing single-instance⇄batch naming (doc 03 §B suggestion).
+
+Plan:
+1. **Phase 1 (me, serial):** additive tokens on all 5 skins + 3 new skins
+   (Daylight/Primary/Mirage) + `--font-scale` (Option A: Phosphor `zoom`). Shared
+   files `theme.css`/`skins.tsx` — must be exact, not delegated.
+2. **Phase 2 (me, serial):** `colormapRegistry.ts` + `<ColormapPicker>` + vitest;
+   doc notes in DESIGN-SPEC/IN-PROGRESS. Net-new shared infra.
+3. **Compliance audit (single read-only agent, launched now, background):** the
+   "someone goes through singly" pass — confirm doc-03 hypotheses against source
+   for all apps, produce the authoritative per-app task list. Concurrent with
+   Phase 1/2 (read-only → safe).
+4. **Per-app fixes:** Stable Matching first (the reference others copy), then fan
+   out subagents for the remaining offenders, each scoped to its own
+   `src/animations/<App>/` folder (disjoint → conflict-free).
+5. **Final single compliance re-check + skin tour;** build/lint/test; update report.
+
 ### 🟡 milestone · 13:42 — Session oriented; design package reviewed and premises verified
 **Why:** Start-session requires reading the latest handoff, the backlog, and the
 session focus before any work — and the package itself asks that its premises be

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -1,0 +1,95 @@
+---
+kind: progress
+session: 2026-06-24-S01
+date: 2026-06-24
+title: Chrome design cleanup — execute the Claude Design hardening handoff
+branch: claude/youthful-cray-7m6z9d
+slug: youthful-cray-7m6z9d
+status: in-progress
+build: unknown
+followup: null
+pr: null
+app: chrome
+next: With Dan's go-ahead, start Phase 1 (additive tokens + 3 skins in theme.css/skins.tsx) — pure addition, unblocks everything; then the colormap registry.
+---
+
+# Chrome design cleanup — execute the Claude Design hardening handoff
+
+## Session purpose
+
+Reinforce and improve a coherent **design contract across apps**. We have been
+working with **Claude Design** to get a cleaner, more consistent UI; this session
+reviews the attached design-hardening handoff package and (pending Dan's
+direction) executes it. The package is explicitly an **enforcement + four
+genuinely-missing-pieces** effort, *not* a redesign — the chrome is already sound.
+
+## Previous session
+
+**First tracked session on this branch** (`youthful-cray-7m6z9d`). The most recent
+handoff across all branches is
+[`repo-priorities-review-1kse64` S01 (2026-06-23)](../../handoff/repo-priorities-review-1kse64/2026-06-23-S01-repo-priorities-review.md)
+— a docs/process/triage session (shelved the quaternion PR #223, merged Complex
+Particles #230, productionized the signals/to-do system). Build green, no open
+PRs. **Unrelated topic**, but it left the repo clean and flagged the relevant
+`[chrome]` backlog items (theme-driven graphics, App-map richness) and the
+Stable-Marriage→Stable-Matching retirement that this design work builds on.
+
+## The handoff package (attached zip)
+
+A `handoff/` work order authored by Claude Design from the screenshot tour +
+repo docs (`DESIGN-SPEC.md`, `PARAM-MAP.md`, `theme.css`, `skins.tsx`,
+`archetypes.ts`, `colormaps.ts`). Four docs + two reference HTML prototypes:
+
+| Doc | Scope |
+|---|---|
+| `README.md` | Framing: most of a "design contract" is **already built** (ActionBar transport, 11-archetype rail, layouts-not-tabs, skins-by-attribute). Don't rebuild — enforce + add the missing pieces. |
+| `01-TOKENS.md` | **Phase 1.** Additive semantic/elevation/data/font tokens (`--danger`, `--success`, `--shadow-1/2/3`, `--data-1…7`, `--font-scale`) on all 5 skins + **3 new skins** (Daylight, Primary, Mirage). |
+| `02-COLORMAPS.md` | **Phase 2.** New typed, per-theme `src/lib/colormapRegistry.ts` + `<ColormapPicker>` for DOM/2D apps (shader apps stay on `lib/colormaps.ts`). |
+| `03-EXECUTION.md` | **Phases 3–5.** Per-app compliance: dedupe transport into `actions:`, kill hard-coded color, group rails, fix Compact-layout overlaps. Per-app claims are screenshot-derived **hypotheses to confirm against source**. |
+
+The two `reference/*.html` files (Control Contract, Stable Matching reference) are
+**visual prototypes only** — encode intended behavior, do not port literally.
+
+## Working notes
+
+<!-- Newest entry first. -->
+
+### 🟡 milestone · 13:42 — Session oriented; design package reviewed and premises verified
+**Why:** Start-session requires reading the latest handoff, the backlog, and the
+session focus before any work — and the package itself asks that its premises be
+verified against source before trusting them.
+
+Read all four handoff markdown docs + confirmed the reference HTML files are
+prototypes. Ground-checked the package's foundational (non-per-app) premises
+against the live repo — all hold:
+
+- **`src/chrome/workspace/ActionBar.tsx` exists** (+ a vitest) — the always-on
+  transport strip the package treats as the single home for Play/Step/Run is
+  real, so the "dedupe transport into `actions:`" tasks have a real target.
+- **Exactly 5 skins today** in `skins.tsx`: `dark` (Observatory), `light`
+  (Paper), `neon` (Spectrum), `blueprint` (Blueprint), `phosphor` (Phosphor) —
+  matches the package; the 3 new skins are genuinely additive.
+- **The semantic/data tokens are genuinely absent** in `theme.css`: `--danger`,
+  `--success`, `--shadow-1/2/3`, `--data-1…7`, `--font-scale` all return **0
+  occurrences**; only a single `--shadow` exists (5 uses) — exactly the "one
+  shadow, no danger/success, no data ramp" gap the package describes.
+- **`colormapRegistry.ts` and `<ColormapPicker>` do not exist yet** — Phase 2 is
+  net-new, not a rebuild.
+
+Conclusion: the package's scope is accurate and its "additive, enforce-don't-rebuild"
+framing matches reality. Ready to execute on Dan's go-ahead, starting with the
+pure-addition Phase 1.
+
+### 🔵 finding · 13:42 — Package dovetails with three open `[chrome]` backlog items
+**Why:** Worth noting so the work isn't duplicated and the backlog stays the
+source of truth.
+
+- `[chrome] !med Make graphics consistently theme-driven` — the colormap registry
+  (Phase 2) + `--data-*` tokens are the mechanism this item asked for; the
+  `SkellamPreview` getComputedStyle pattern is the model the registry generalizes.
+- `[chrome] Decide Stable Marriage's final fate — DONE (eliminated)` — the package
+  still lists a "Stable Marriage" heatmap app in the 02 colormap table; that app
+  is **retired** (folded into Stable Matching). Note for execution: skip/redirect
+  that row to Stable Matching, don't resurrect the dead app.
+- The Trinary **"Observatory" naming clash** (skin name vs. mode name) the package
+  flags is a real copy collision worth Dan's call (rename the *mode*, not the skin).

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -10,7 +10,8 @@ build: passed
 followup: null
 pr: 238
 app: chrome
-next: PR #238 is open + green; watching it. Remaining optional polish (TODO.md): discrete colormap in Agentic Sorting; in-app-canvas theme sweep (gallery previews now done); Complex Particles hint occlusion; full 8-skin tour.
+signals: needs-dan, visual-unverified
+next: Merge #238 (chrome contract + foundations, CI green) when ready; then execute the theming-v2 plan (docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md) next session — light/dark-paired themes so every app's viz tracks the skin.
 ---
 
 # Chrome design cleanup — execute the Claude Design hardening handoff
@@ -53,6 +54,30 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 ## Working notes
 
 <!-- Newest entry first. -->
+
+### 🟡 milestone · 18:30 — Trinary viz-unification reference + theming-v2 plan; #238 wrapped, merge-ready
+**Why:** Dan steered the session from "fix the chrome" into the deeper cross-app
+question (apps still wear their own color schemes), and we converged on the next
+initiative and closed out this pass.
+
+- **Trinary = the viz-unification reference** (one app first, Dan's "then roll out").
+  Tokenized the bespoke in-viz UI/HUD to skin tokens (the cyan Tour accent → `--accent`,
+  HUD panels/progress → tokens); kept the dark star stage + the semantic temperature/fate
+  colors. Verified across dark/daylight/phosphor/mirage — the UI tracks each skin's accent
+  while the scene stays dark. In #238 as the partial reference.
+- **Design discussion → the real architecture.** Walked the full Trinary color inventory
+  (app-specific vs theme; what each encodes; nearest Observatory analogs). Key outcomes:
+  `--accent` is **UI-voice** (never data); ordered/polar data → **sample a registry
+  colormap**; identity → discrete `--data`; and the linchpin — the scene is *permanently
+  dark*, so the clean answer is **light/dark-paired themes** (force the scene to the
+  theme's dark mode; scene objects then use the normal tokens at dark values). Worlds get
+  day/night skies by mode. Written up as a `kind: plan`:
+  [`2026-06-24-S02-plan-light-dark-theming.md`](2026-06-24-S02-plan-light-dark-theming.md)
+  (status proposed; execute next session).
+- **#238 wrapped.** Refreshed the PR description to the full delivered scope; verified the
+  **Primary** skin (light-on-light clean) and the `Explore` mode label. The transient
+  `trigger-deploy` CI red is a GitHub-API 504 (main-deploy dispatch) — harmless, clears on
+  next push. PR is the "chrome contract + foundations"; **merge-ready**, theming-v2 follows.
 
 ### 🔴 blocker · 16:10 — Skin switch didn't re-theme the gallery live (needed a refresh); fixed `useSkin` at the root
 **Why:** Dan: "the fix requires a page refresh to activate." `useSkin()` returned a

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -6,11 +6,11 @@ title: Chrome design cleanup — execute the Claude Design hardening handoff
 branch: claude/youthful-cray-7m6z9d
 slug: youthful-cray-7m6z9d
 status: in-progress
-build: unknown
+build: passed
 followup: null
 pr: null
 app: chrome
-next: With Dan's go-ahead, start Phase 1 (additive tokens + 3 skins in theme.css/skins.tsx) — pure addition, unblocks everything; then the colormap registry.
+next: Optional Phase-5 polish (all tracked in TODO.md): adopt the discrete colormap in Agentic Sorting; tokenize residual DOM color on the compliant apps; Complex Particles hint occlusion; full 8-skin tour sweep.
 ---
 
 # Chrome design cleanup — execute the Claude Design hardening handoff
@@ -53,6 +53,23 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 ## Working notes
 
 <!-- Newest entry first. -->
+
+### 🔵 finding · 14:55 — Phase 5 spot-check: the "compliant" apps hold on light skins
+**Why:** Before tokenizing the audit's "minor color" notes on the ✓ apps, verify
+whether they actually break on a light skin (R1) — don't fix what isn't broken,
+and don't risk regressions on already-compliant apps for invisible gains.
+
+Screenshot-checked Trees and Nets + Plane Transform in **Daylight**: both render
+cleanly — light panels, light view windows, semantic mark colors legible. Neither
+has Stable Matching's old hard-dark-stage breakage (SM was the outlier — a fully
+hardcoded `#0c0c10` DOM stage). So the residual DOM-color tokenization on the
+compliant apps (Polygon/Solid HUDs, Trinary preset buttons, the SVG mark constants)
+is genuine **low-value polish** — no visible skin breakage — now captured in
+`TODO.md` rather than risked this session.
+
+**Status:** the package's core (the audit's needs-fix apps + the missing tokens,
+skins, and colormap registry) is complete and verified. Remaining items are
+optional polish, all tracked.
 
 ### 🟡 milestone · 14:45 — Phase 4 complete: all 5 fan-out apps fixed, centrally verified
 **Why:** The orchestrator is the single verification pass — agents didn't build/commit,

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -54,6 +54,24 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 
 <!-- Newest entry first. -->
 
+### 🔴 blocker · 16:10 — Skin switch didn't re-theme the gallery live (needed a refresh); fixed `useSkin` at the root
+**Why:** Dan: "the fix requires a page refresh to activate." `useSkin()` returned a
+private `useState`, so each call site is an *independent* instance. The TopBar's
+SkinPicker (the writer) and the Gallery's `const [skin] = useSkin()` (a reader) were
+two different states — clicking a skin updated `data-theme` (CSS re-themes live) but
+NOT the Gallery's `skin`, so `<Preview skin={skin}>` stayed stale until a reload re-read
+localStorage. (That's also why message-1 said the cards themed "on refresh.")
+
+Fix at the root: `useSkin` now derives its value from the live `data-theme` via the
+reactive `useThemeId()` (MutationObserver) instead of a private `useState`; the setter
+applies the attrs + persists. Now **every** useSkin/useThemeId consumer stays in sync the
+instant any of them changes the skin — no stale readers, present or future. **Verified
+with a real live-switch test** (headless: load gallery on dark → click SkinPicker →
+Daylight, *no reload* → screenshot): the gallery + preview cards re-theme live, identical
+to a fresh Daylight load. Lesson: a `useState`-per-call hook is a footgun for shared
+global state — derive readers from the single source (the DOM attribute) so they observe
+writes from anywhere.
+
 ### 🔴 blocker · 15:45 — Light-on-light in Stable Matching on light skins (Dan caught it in Daylight); fixed
 **Why:** Tokenizing SM's stage/cards to follow the skin (Phase 3) was right, but I
 left several **semantic text colors as fixed light hues** — fine on the old hard-dark

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -54,6 +54,25 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 
 <!-- Newest entry first. -->
 
+### 🔴 blocker · 15:45 — Light-on-light in Stable Matching on light skins (Dan caught it in Daylight); fixed
+**Why:** Tokenizing SM's stage/cards to follow the skin (Phase 3) was right, but I
+left several **semantic text colors as fixed light hues** — fine on the old hard-dark
+panels, invisible once the panel is white. A latent regression I introduced.
+
+Found (all light text now on a light panel): the big SOLUTION-SPACE metric (`#7fe3a6`),
+the stability strong text, the narrate jump/resolve strong (`#5eead4`/`#d8b4fe`), the
+Stabilize button text, and — worst — the **lattice node labels** (`#7dd3fc`/`#fca5a5`
+and a `#fff` fallback) as SVG text on the now-white lattice panel. Fix: route them all
+through the **per-skin tokens** that stay legible on every skin — `--success`/`--danger`
+for the good/bad metrics, `--data-1/2/6/7` for the named-solution labels (preserving the
+blue↔pink A/B semantic). SVG labels needed `style={{fill}}` (presentation attributes
+don't resolve `var()`). **Verified by screenshot:** the metric reads clearly in Daylight
+*and* dark (no regression). Lattice labels legible by construction (the `--data` ramp is
+tuned per skin). Swept the other apps in Daylight — text is readable everywhere else
+(some plots still render dark on light skins — the separate "canvas theme sweep" TODO,
+not a contrast bug). Lesson: when a background starts following the skin, the text on it
+must too — fixed light hues that worked on a fixed-dark surface become invisible.
+
 ### 🟢 code · 15:28 — PR #238 opened; review comments addressed; gallery previews themed
 **Why:** Dan asked to open the PR, follow CI, and (then) answer the review comments
 and make every gallery card theme to the skin like Counting the Ways.

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -54,6 +54,29 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 14:10 — Phase 2 done: typed per-theme colormap registry + `<ColormapPicker>` + tests
+**Why:** DOM/2D apps each hard-code their own ramp because `lib/colormaps.ts` is
+GLSL-only (uncallable from JS). This is the shared resource that lets them stop.
+
+- **`src/lib/colormapRegistry.ts`** (new): colormaps typed by *family* — sequential /
+  divergent / discrete / cyclic — where **discrete = the skin's `--data-1…7` tokens**,
+  read live via `discreteStops()`. `THEME_MAPS` gives per-skin recommendations (all 8
+  skins keyed); `themeMapsFor` falls back to the whole family for an unknown skin;
+  `mapStops`/`gradientCss`/`sampleStops` (the last buckets a ramp into N classes —
+  what the DOM adopters need). Shader apps stay on `lib/colormaps.ts`; the shared
+  names (Viridis/Magma/…) match on both sides.
+- **`<ColormapPicker>`** added to `components/ControlPanel.tsx` (the `color`-tier
+  control): family header + recommended-swatch grid + "Other families (advanced)"
+  disclosure (incl. Discrete = theme palette) + optional Reverse; re-curates when
+  `themeId` changes. Styled with new `cp-cmap-*` classes on the `--cp-*` tokens.
+- **Tests:** `src/lib/__tests__/colormapRegistry.test.ts` — 10 cases covering the
+  `themeMapsFor` fallback and `discreteStops` parsing (stubbed `getComputedStyle`),
+  per R4 (test extractable pure logic on write).
+- Recorded the registry decision in `docs/redesign/IN-PROGRESS.md` (additive).
+
+No app consumes it yet (that's Phase 3+). **Checks:** build ✓, `npm test` ✓ 88/88
+(+10), lint ✓ 0 errors.
+
 ### 🟢 code · 14:05 — Phase 1 done: semantic/data tokens on all skins + 3 new skins, verified
 **Why:** Pure-addition foundation that unblocks every color task; ship and eyeball
 it before building on it (R1 — verify visual changes with my eyes).

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -54,6 +54,61 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 
 <!-- Newest entry first. -->
 
+### 🟡 milestone · 14:45 — Phase 4 complete: all 5 fan-out apps fixed, centrally verified
+**Why:** The orchestrator is the single verification pass — agents didn't build/commit,
+so I run one central build/lint/test and screenshot every app (R1) before committing.
+
+Central gate green: **build ✓, lint ✓ 0 errors, test ✓ 88/88**. Screenshot-verified
+each app (default skin):
+- **Agentic Sorting** — Run panel = Step-interval + Wake-rate only; Start/Reset strip-only. ✓
+- **Trinary** — mode pill now **"Explore | Lab"**, transport (Pause/Reset) strip-only. ✓
+- **Counting the Ways** — Build-it panel = Speed only; Play/Next/Reset strip-only. ✓
+- **Argand** — bottom HUD has only the t/j² scrubbers + System pills; feed mode lives
+  solely in the top-bar Point/Shape/Grid pills. ✓
+- **Correspondence** — Draw path / Play / Clear path now on the always-on strip
+  (it previously had none); Seed panel clean. ✓
+
+> [!WARNING]
+> **Caught two bugs by verifying (code + pixels, not just the agent's word).** The
+> Trinary agent renamed the mode to "Sandbox" — which (a) collided with Trinary's
+> *existing layout* named "Sandbox", and (b) it missed `TrinaryLab.tsx`'s mode pill
+> (still "Observatory") and the tour copy, so the two views disagreed. Fixed by
+> renaming the mode to **"Explore"** (clash-free with the skin *and* every layout
+> name) consistently across both views + the tour copy. Lesson: a rename's target
+> must be checked against *all* sibling namespaces (skins · layouts · modes), and
+> a fan-out agent's single-file edit needs a whole-app consistency sweep.
+
+**Deferred (tracked):** Agentic Sorting's Okabe-Ito agent palette → discrete registry
+(feeds 3 surfaces, needs an atomic cross-skin pass; already colorblind-safe).
+
+### 🟢 code · 14:40 — Phase 4: fanned out 5 per-app fixer subagents (4 returned, 1 running)
+**Why:** Dan asked to deploy subagents to apply the rules across apps; the apps are
+self-contained folders (disjoint → conflict-free), so one agent each, scoped to its
+folder, no git/build (I verify centrally), referencing the Stable Matching pattern.
+
+Results so far (each constrained to `src/animations/<App>/`, returns a change summary):
+- **Counting the Ways** ✓ — transport dedup only (Play tutorial/Next/Reset + Run&log/Clear
+  removed from panels; now strip-only). Confirmed zero color changes (already token-clean).
+- **Agentic Sorting** ✓ — transport dedup (sandbox START/PAUSE/Reset + lab Run removed from
+  panels) + dead-CSS-rule cleanup. **Deferred** the discrete-colormap swap with a clear
+  rationale (the Okabe-Ito palette feeds 3 independent surfaces — canvas, DOM swatches,
+  LabResults — that must convert atomically; it's already colorblind-safe; needs a focused
+  pass with cross-skin visual verification). Good conservative call → tracked as follow-up.
+- **Argand** ✓ — removed the duplicate Point/Shape/Grid switcher from the bottom HUD, kept the
+  framework-native top-bar mode pills (verified the immersive layout still shows them). Left
+  the semantic `_COL` mark constants. (Noted a 3rd feed surface — the Input panel Pills —
+  left as a tolerated panel-mirrors-mode pattern.)
+- **Trinary System** ✓ — Observatory transport dedup; **renamed the mode label "Observatory"
+  → "Sandbox"** (kept the persisted id) to clear the skin-name clash; **projected the Lab's
+  transport to a strip via a proper Drive-tier panel** (avoiding the Analyze-tier ActionBar
+  warning — careful, correct); tokenized HUD chrome colors, left scene/outcome semantics.
+- **Correspondence** ⏳ — projecting path transport (Draw/Play/Clear) to an `actions:` strip;
+  running.
+
+Pattern held across all: transport verbs land once (in `actions:`), params stay in panels,
+semantic/scene colors left alone, shared infra (registry/picker/useThemeId) reused. Next:
+central build+lint+test, screenshot-verify each, then commit.
+
 ### 🟢 code · 14:25 — Phase 3 done: Stable Matching, the reference compliance fix (verified)
 **Why:** The doc's worked example the other apps copy — so it must be done by
 hand and screenshot-verified to calibrate the pattern.

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -8,9 +8,9 @@ slug: youthful-cray-7m6z9d
 status: in-progress
 build: passed
 followup: null
-pr: null
+pr: 238
 app: chrome
-next: Optional Phase-5 polish (all tracked in TODO.md): adopt the discrete colormap in Agentic Sorting; tokenize residual DOM color on the compliant apps; Complex Particles hint occlusion; full 8-skin tour sweep.
+next: PR #238 is open + green; watching it. Remaining optional polish (TODO.md): discrete colormap in Agentic Sorting; in-app-canvas theme sweep (gallery previews now done); Complex Particles hint occlusion; full 8-skin tour.
 ---
 
 # Chrome design cleanup — execute the Claude Design hardening handoff
@@ -53,6 +53,31 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 ## Working notes
 
 <!-- Newest entry first. -->
+
+### 🟢 code · 15:28 — PR #238 opened; review comments addressed; gallery previews themed
+**Why:** Dan asked to open the PR, follow CI, and (then) answer the review comments
+and make every gallery card theme to the skin like Counting the Ways.
+
+- **PR [#238](https://github.com/piyarsquare/animath/pull/238) opened.** CI green
+  (lint, smoke, Cloudflare Pages build, trigger-deploy). Cloudflare preview confirmed:
+  branch alias `claude-youthful-cray-7m6z9d.animath.pages.dev`. Subscribed to PR
+  activity + an hourly fallback check-in (session-scoped) for webhook-missed transitions.
+- **Two automated P2 review comments, both from this PR — fixed in `4f23b0a`:**
+  (1) Argand fullscreen — the view can go fullscreen (HUD lives in the view node to
+  survive it; top bar buried), so moving the feed to top-bar pills stranded fullscreen
+  users. Restored the Point/Shape/Grid switcher to the HUD as the single home, dropped
+  the top-bar `modes` props. (2) Native `<select>` on the new light skins kept dark
+  rendering (`ControlPanel.css` only un-forced `color-scheme` for `[data-theme=light]`).
+  Drove it from a new root `data-scheme=light|dark` attribute (from `isLightSkin`) so
+  every light skin works. Replied + resolved both threads.
+- **Gallery previews now theme to the *specific* skin** (was light/dark only; only
+  Skellam did it right). Shared `themeInk(light)` helper in `previews.tsx`; all 12
+  previews read `--viz-bg`/`--accent`/`--accent-2`/`--data-*` live. Rainbow hue art
+  kept on the complex-domain previews (hue = argument). **Verified by screenshot across
+  Phosphor/Neon/Mirage/Daylight** — each card tracks the skin. Caveat: JuliaPreview's
+  cached Mandelbrot inset re-tints only on reload (Julia pane + marker live).
+
+Build/lint/test green throughout (88 tests, 0 lint errors). Watch remains active.
 
 ### 🔵 finding · 14:55 — Phase 5 spot-check: the "compliant" apps hold on light skins
 **Why:** Before tokenizing the audit's "minor color" notes on the ✓ apps, verify

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S01-chrome-design-cleanup.md
@@ -54,6 +54,29 @@ The two `reference/*.html` files (Control Contract, Stable Matching reference) a
 
 <!-- Newest entry first. -->
 
+### 🟢 code · 14:25 — Phase 3 done: Stable Matching, the reference compliance fix (verified)
+**Why:** The doc's worked example the other apps copy — so it must be done by
+hand and screenshot-verified to calibrate the pattern.
+
+Applied all relevant checks end-to-end:
+- **C1 transport dedup:** removed Play/Step/Finish/Reset (and the RVV Back-to-run)
+  from the Playback panel — they now live only in the always-on action strip. The
+  panel keeps the round readout + *params* (Speed, one-shot Stabilize, jump-to).
+- **Colormap adoption:** replaced the hard-coded `BURD` array with the registry
+  (divergent family, default RdBu) via a `<ColormapPicker>` in a new **Color**
+  panel. The legend swatch is driven by the active map (`--sm-scale`) and its text
+  made color-agnostic ("best #1 → worst"), so it stays honest on any divergent map.
+- **CSS tokenized:** stage/card backgrounds, borders, body+dim text, buttons,
+  tooltip/inspect surfaces → theme tokens (the matrix pane was hard-dark `#0c0c10`
+  and broke on light skins). Semantic state markers (gold/purple/green/teal/red)
+  deliberately kept — they're meaningful encodings, like 3D scene color.
+- **Shared infra:** added `useThemeId()` to `skins.tsx` (reactive current-skin via
+  MutationObserver) so the picker re-curates when the skin changes.
+
+**Verified by screenshot** (daylight + dark): matrix pane now follows the skin,
+transport is strip-only, Color panel in the rail, matrix renders, dark unregressed.
+Build/lint/test green (88 tests, 0 lint errors). This is the template the fan-out copies.
+
 ### 🟢 code · 14:10 — Phase 2 done: typed per-theme colormap registry + `<ColormapPicker>` + tests
 **Why:** DOM/2D apps each hard-code their own ramp because `lib/colormaps.ts` is
 GLSL-only (uncallable from JS). This is the shared resource that lets them stop.

--- a/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md
+++ b/docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md
@@ -1,0 +1,149 @@
+---
+kind: plan
+session: 2026-06-24-S02
+date: 2026-06-24
+title: Theming v2 — light/dark-paired themes (decouple identity from mode)
+branch: claude/youthful-cray-7m6z9d
+slug: youthful-cray-7m6z9d
+status: proposed
+build: unknown
+followup: null
+pr: null
+app: chrome
+signals: needs-dan
+next: Execute Phase 0 (theme engine) — convert theme.css tokens to light-dark() pairs + add the missing light/dark companions, then the force-mode primitive + canvas token hook.
+---
+
+# Theming v2 — light/dark-paired themes (decouple identity from mode)
+
+> [!NOTE]
+> A **proposed** plan, scoped this session (`youthful-cray-7m6z9d`) on top of the
+> chrome-hardening PR #238. Execute next session. This is the durable spec.
+
+## Goal
+
+Make each **theme** an *identity* that exists in **both a light and a dark mode**,
+under shared token names, so:
+
+- the user picks an identity + mode (or the identity's default mode);
+- a feature that **requires** a mode (a glowing particle stage, a star field →
+  dark; a printout → light) forces it on its own subtree, and every token there
+  resolves to *that theme's* values for *that mode*;
+- everything else just inherits the user's choice.
+
+This dissolves the "the viz uses its own color scheme" problem the owner raised:
+once a dark-required scene forces dark mode, its objects use the **normal tokens**
+(`--data`, `--fg`, a neutral) resolved at the theme's dark values — no bespoke
+per-app scene palette. The dark variant is **theme-tinted** (Observatory blue-black,
+Blueprint drafting-blue, Mirage plum), so a forced-dark star field still carries the
+theme's character — not generic black.
+
+## Why (the problem this solves)
+
+Today a "skin" conflates a color **identity** (Observatory gold, Phosphor green…)
+with a **mode** (light/dark): 8 skins, 5 dark + 3 light, each fixed. Contexts that
+*need* a surface (the always-dark star stage, additive-glow particles) can't ride
+the normal tokens, because `--data`/`--fg` are tuned to the skin's background and
+flip on light skins (in Daylight they go dark → invisible on a black scene). The
+result is apps hardcoding their own on-dark palettes — "each app its own scheme."
+
+## The architecture
+
+1. **Tokens carry both modes.** Define each token with the native CSS
+   `light-dark(<light>, <dark>)` and drive selection by `color-scheme`. One line
+   carries both values; no doubled blocks. (Conservative fallback if `light-dark()`
+   support is a concern: paired `[data-theme=x][data-scheme=light|dark]` blocks +
+   the scene wrapper carrying `data-theme` + `data-scheme`.)
+2. **Mode axis already exists.** The `data-scheme="light|dark"` attribute added in
+   PR #238 (for native `<select>` rendering) is the switch. The root carries the
+   user's chosen mode; `color-scheme` follows it.
+3. **Force-mode primitive.** A tiny `<Scheme mode="dark">` wrapper (sets
+   `color-scheme: dark` / `data-scheme`) any feature drops around a surface that
+   requires a mode. Under it, `light-dark()` tokens resolve to that mode.
+4. **Identity × mode picker.** The SkinPicker becomes identity list + a mode toggle.
+   `useSkin`/`useThemeId` carry mode (persisted).
+
+## The app contract (every app respects these 4 rules)
+
+1. **No hardcoded color** — every color is a token or a registry colormap, so it
+   resolves to the current theme × mode.
+2. **Declare a mode requirement** — a surface that needs dark (glow, star field) or
+   light wraps itself in `<Scheme mode>`; everything else inherits the user's choice.
+3. **Canvas/WebGL reads tokens reactively** — engines read the *resolved* token
+   values (`getComputedStyle`) and redraw on theme/mode change (`useThemeId` is the
+   trigger; formalize a `useThemeTokens()` hook).
+4. **Data voice ≠ UI voice** — data uses the registry / `--data` / `--success` /
+   `--danger`; `--accent`/`--accent-2` stay UI-only (interaction/identity), never
+   data.
+
+## Per-app blast radius
+
+| App | Surface | Mode need | Work |
+|---|---|---|---|
+| **Stable Matching** | DOM/SVG | agnostic | ✓ none — already tokens + registry |
+| **Counting the Ways** | DOM/SVG | agnostic | ✓ none — already token-clean |
+| **Argand** | SVG | agnostic | small: bg→`--viz-bg`, marks→`--data` identity |
+| **Trees & Nets** | SVG + 3D | agnostic | small: tokenize SVG colors |
+| **Agentic Sorting** | DOM + canvas | agnostic | medium: agents→discrete `--data` (registry), canvas reads tokens + redraws |
+| **Fractals GPU** | shader | agnostic | small: viewport bg→`--viz-bg`; keep palette |
+| **Correspondence** | shader | agnostic | small: same as Fractals |
+| **Plane Transform** | shader panes | agnostic | small: pane bg→`--viz-bg`, draw accents→tokens; keep rainbow |
+| **Complex Particles** | WebGL glow | **needs dark** | medium: force-dark; clear-color→dark `--viz-bg`; read tokens + redraw; keep GLSL domain palette |
+| **Trinary** | WebGL scene + DOM | scene **needs dark** | medium: force-dark scene (stars/planet/ghost from dark tokens); HUD/Lab done (#238); outcomes→registry divergent; mini-canvases read tokens |
+| **Topology Walk** | WebGL immersive | **needs dark** | low (retiring): force-dark + look |
+| **Polygon / Solid Worlds** | WebGL sky walkers | **day/night by mode** | medium: sky + lighting follow the theme's light/dark (day=light, night=dark); HUD→tokens |
+
+**Pattern:** DOM/SVG apps mostly *just work* once tokenized (two already do); the
+real plumbing is the WebGL/canvas apps (force-mode wrapper + token-reading + redraw).
+
+## Decisions locked this session
+
+- **Worlds skies = day/night by mode**, using theme colors (light mode = day sky,
+  dark mode = night sky). The mode *is* the time of day.
+- **Outcomes** (Trinary climate, sim outcomes, census bins) → **sample a divergent
+  colormap** by goodness/polarity (happy at the good end, failures clustered toward
+  bad). Chaos ramp + stat magma → registry sequential maps. The colormap carries the
+  ordering, so "cold = blue" stops being an arbitrary `--data` pick.
+- **Stars** = three *distinct identities* (colored by index, no temperature meaning)
+  → discrete `--data` slots of the **forced-dark** variant (read bright-on-dark, and
+  theme-tinted automatically). Not a colormap, not `--accent`.
+- **Planet** = distinct identity, **neutral** ("the calm subject" vs the vivid
+  stars) → the dark variant's neutral (`--fg`/a neutral token under forced-dark).
+- **`--accent` is UI-only** — interaction/identity, never data.
+- **Phosphor gets a light analog** — the beige 1980s computer *case* (not the CRT
+  glass). Every identity gets both modes; where an identity is mode-intrinsic, the
+  companion variant primarily serves forced-mode subtrees.
+
+## Phasing
+
+- **Phase 0 — Theme engine (prerequisite, the bulk).** `theme.css` → `light-dark()`
+  token pairs; author the missing companions (light Phosphor/Neon/Mirage, dark
+  Primary, theme-tinted darks). `skins.tsx`/picker → identity + mode model + toggle;
+  `useSkin`/`useThemeId` carry mode. The `<Scheme mode>` primitive + `useThemeTokens()`
+  canvas hook. Verify all identities × both modes across the chrome.
+- **Phase 1 — Pilots.** Trinary star scene (force-dark, stars/planet/ghost from dark
+  tokens, outcomes via divergent registry) and the Worlds (day/night sky). These two
+  prove the force-mode + canvas-token path end-to-end.
+- **Phase 2 — Roll out** the contract to the remaining WebGL/canvas apps (Complex
+  Particles, Plane Transform, Fractals, Correspondence, Trees) + finish the
+  DOM tokenization (Agentic discrete-registry, Argand marks).
+- **Phase 3 — Sweep & verify** every app × every identity × both modes (tour across
+  skins+modes); update DESIGN-SPEC + PARAM-MAP.
+
+## Open questions (small)
+
+- `light-dark()` vs paired `[data-scheme]` blocks — pick in Phase 0 after a quick
+  browser-support check against the project's targets.
+- Whether the mode toggle is global-only or also per-identity-default (some
+  identities prefer one mode by default).
+- Exact divergent map for outcomes (`--success`→`--danger` custom, or a registry
+  entry like RdYlGn) — decide when wiring Phase 1.
+
+## Relationship to PR #238
+
+#238 delivers the chrome contract + foundations this builds on: the token set, the
+3 new skins, the **colormap registry**, per-app transport/compliance, the **reactive
+`useSkin`/`useThemeId`**, the `data-scheme` attribute, and the **Trinary UI/HUD
+tokenization** (the partial reference — scene/data deferred here, intentionally, so
+v2's force-dark mechanism makes it nearly free). #238 is a clean merge point; this is
+the next initiative.

--- a/src/animations/AgenticSorting/AgenticSorting.tsx
+++ b/src/animations/AgenticSorting/AgenticSorting.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef, useCallback } from 'react';
-import { Play, Pause, RotateCcw, Snowflake } from 'lucide-react';
+import { Snowflake } from 'lucide-react';
 import './agenticSorting.css';
 import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef } from '../../chrome/workspace/types';
@@ -532,24 +532,10 @@ export default function AgenticSorting() {
     </div>
   );
 
+  // START/PAUSE + Reset are the always-on action strip (see `actions` below);
+  // this panel keeps only the pacing controls so the verbs aren't duplicated.
   const runNode = (
     <div className="as-panel">
-      <div className="as-controls-row">
-        <button
-          className={`as-button as-button-primary ${isRunning ? 'as-button-pause' : ''}`}
-          onClick={() => setIsRunning(r => !r)}
-        >
-          {isRunning ? <Pause size={18} /> : <Play size={18} />}
-          {isRunning ? 'PAUSE' : 'START'}
-        </button>
-        <button
-          className="as-button as-button-reset"
-          onClick={regenerate}
-          title="Regenerate the population with the current settings"
-        >
-          <RotateCcw size={18} />
-        </button>
-      </div>
       <Slider
         label="Step interval" value={stepInterval}
         min={1} max={200} step={1} onChange={setStepInterval} format={(v) => `${v} ms`}
@@ -725,13 +711,20 @@ export default function AgenticSorting() {
     </div>
   );
 
+  // "Run experiment" is the always-on action strip (see `actions` below); this
+  // panel keeps the live progress bar and the not-ready hint.
   const labRunNode = (
     <div className="as-panel">
-      <button className="as-button as-button-primary" disabled={labRunning || !labReady} onClick={runLab}>
-        {labRunning ? `Running… ${Math.round(labProgress * 100)}%` : 'Run experiment'}
-      </button>
-      {labRunning && <div className="as-progress"><div className="as-progress-fill" style={{ width: `${labProgress * 100}%` }} /></div>}
-      {!labReady && !labRunning && <p className="as-hint">Add at least two mixes to compare.</p>}
+      {labRunning
+        ? (
+          <>
+            <p className="as-hint">Running… {Math.round(labProgress * 100)}%</p>
+            <div className="as-progress"><div className="as-progress-fill" style={{ width: `${labProgress * 100}%` }} /></div>
+          </>
+        )
+        : !labReady
+          ? <p className="as-hint">Add at least two mixes to compare.</p>
+          : <p className="as-hint">Press <strong>Run experiment</strong> in the action bar to run this experiment.</p>}
     </div>
   );
 

--- a/src/animations/AgenticSorting/agenticSorting.css
+++ b/src/animations/AgenticSorting/agenticSorting.css
@@ -57,12 +57,8 @@
   color: var(--dim);
 }
 
-/* ── Run buttons ── */
-.as-controls-row {
-  display: flex;
-  gap: 8px;
-}
-
+/* ── Buttons ── (transport verbs moved to the action strip; the only button
+   left in a panel is the Lab's "+ Add current mix") */
 .as-button {
   display: inline-flex;
   align-items: center;
@@ -78,20 +74,6 @@
 }
 
 .as-button:active { transform: scale(0.97); }
-
-.as-button-primary {
-  flex: 1;
-  padding: 12px;
-  background: var(--accent);
-  color: var(--accent-fg, #fff);
-}
-
-.as-button-primary:hover { filter: brightness(1.08); }
-
-.as-button-primary.as-button-pause {
-  background: var(--warn, #f59e0b);
-  color: #1a1205;
-}
 
 .as-button-reset {
   padding: 12px 16px;

--- a/src/animations/Argand/Argand.tsx
+++ b/src/animations/Argand/Argand.tsx
@@ -399,8 +399,17 @@ export default function Argand() {
         fontFamily: 'var(--font-mono, monospace)',
       }}
     >
-      {/* shape preset switcher — only in Shape feed (feed itself lives in the
-          top-bar mode pills) */}
+      {/* feed switcher — the single home for Point/Shape/Grid. It lives in the
+          HUD (inside the view node) so it stays reachable in fullscreen, where
+          the top bar and its mode pills are buried. */}
+      <div style={hudRow}>
+        {(['point', 'shape', 'grid'] as Feed[]).map(fd => (
+          <button key={fd} style={pill(feed === fd)} onClick={() => setFeed(fd)}>
+            {fd === 'point' ? 'Point' : fd === 'shape' ? 'Shape' : 'Grid'}
+          </button>
+        ))}
+      </div>
+      {/* shape preset switcher — only in Shape feed */}
       {isShape && (
         <div style={hudRow}>
           {CURVES.map(c => (
@@ -489,9 +498,6 @@ export default function Argand() {
       sections={sections}
       views={views}
       immersive
-      modes={[{ id: 'point', label: 'Point' }, { id: 'shape', label: 'Shape' }, { id: 'grid', label: 'Grid' }]}
-      activeMode={feed}
-      onModeChange={id => setFeed(id as Feed)}
       layouts={layouts}
       defaultLayoutId="essentials"
       explainer={explainerText || null}

--- a/src/animations/Argand/Argand.tsx
+++ b/src/animations/Argand/Argand.tsx
@@ -399,18 +399,15 @@ export default function Argand() {
         fontFamily: 'var(--font-mono, monospace)',
       }}
     >
-      {/* feed switcher — pressing Shape reveals its presets */}
-      <div style={hudRow}>
-        {(['point', 'shape', 'grid'] as Feed[]).map(fd => (
-          <button key={fd} style={pill(feed === fd)} onClick={() => setFeed(fd)}>
-            {fd[0].toUpperCase() + fd.slice(1)}
-          </button>
-        ))}
-        {isShape && <div style={{ width: 1, height: 18, background: 'var(--border, #3a3a44)', margin: '0 2px' }} />}
-        {isShape && CURVES.map(c => (
-          <button key={c.id} style={pill(curveName === c.id)} onClick={() => setCurveName(c.id)}>{c.label}</button>
-        ))}
-      </div>
+      {/* shape preset switcher — only in Shape feed (feed itself lives in the
+          top-bar mode pills) */}
+      {isShape && (
+        <div style={hudRow}>
+          {CURVES.map(c => (
+            <button key={c.id} style={pill(curveName === c.id)} onClick={() => setCurveName(c.id)}>{c.label}</button>
+          ))}
+        </div>
+      )}
       {/* path parameter t */}
       <div style={hudRow}>
         <span style={hudLabel}>t</span>

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -1,7 +1,7 @@
-import React, { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
 import Workspace from '../../chrome/workspace/Workspace';
-import type { LayoutDef, SectionDef, ViewDef } from '../../chrome/workspace/types';
+import type { ActionDef, LayoutDef, SectionDef, ViewDef } from '../../chrome/workspace/types';
 import { Slider, Select, NumberInput } from '../../components/ControlPanel';
 import { Kicker } from '../../chrome/readouts';
 import readmeText from './README.md?raw';
@@ -148,35 +148,16 @@ export default function Correspondence() {
     </div>
   );
 
+  // Transport (Draw c-path · Play/Pause · Clear path) lives once, in the
+  // always-on action strip (`actions` below) — never duplicated here. This
+  // panel keeps only the *parameters*: the playback Speed and the Progress
+  // scrubber (which pauses a running playback via seek() so the user stays in
+  // control).
   const pathNode = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-      <ActionButton
-        label={drawingPath ? 'Finish drawing path' : 'Draw c-path'}
-        active={drawingPath}
-        onClick={() => setDrawingPath(p => !p)}
-      />
-      <ActionButton
-        label="Clear path"
-        disabled={path.length === 0}
-        onClick={() => { stopPath(); setPath([]); progressRef.current = 0; setProgress(0); }}
-      />
-      <ActionButton
-        label={playing ? 'Stop playback' : 'Play path'}
-        primary
-        disabled={path.length < 2}
-        onClick={playing ? stopPath : playPath}
-      />
-      {playing && (
-        <ActionButton
-          label={paused ? 'Resume' : 'Pause'}
-          onClick={() => setPaused(p => !p)}
-        />
-      )}
       <Slider label="Speed" value={speed}
         min={0.005} max={0.5} step={0.005}
         onChange={setSpeed} format={v => v.toFixed(3)} />
-      {/* The old floater's vertical scrubber, rebuilt as a horizontal row.
-          seek() pauses a running playback so the user stays in control. */}
       <div style={path.length < 2 ? { opacity: 0.45, pointerEvents: 'none' } : undefined}>
         <Slider label="Progress" value={progress}
           min={0} max={1} step={0.001}
@@ -259,6 +240,40 @@ export default function Correspondence() {
   // so nothing from the old drawer's About section is lost.
   const help = [explainerText, readmeText].filter(Boolean).join('\n\n---\n\n');
 
+  /* Always-on action strip — the primary path transport, projected from the
+     Path (playback) panel. Play/Pause is one toggle that also serves as Resume
+     when a scrubbed playback is paused; Clear fully resets the path. The rich
+     params (Speed, Progress) stay in the panel. */
+  const advancing = playing && !paused;          // the orbit is actively stepping
+  const actions: ActionDef[] = [
+    {
+      id: 'draw',
+      icon: 'pin',
+      label: 'Draw path',
+      active: drawingPath,
+      sectionId: 'path',
+      onClick: () => setDrawingPath(p => !p),
+    },
+    {
+      id: 'play',
+      icon: advancing ? 'pause' : 'play',
+      label: advancing ? 'Pause' : 'Play',
+      primary: true,
+      active: advancing,
+      sectionId: 'path',
+      disabled: path.length < 2,
+      onClick: () => { if (!playingRef.current) playPath(); else setPaused(p => !p); },
+    },
+    {
+      id: 'clear',
+      icon: 'reset',
+      label: 'Clear path',
+      sectionId: 'path',
+      disabled: path.length === 0,
+      onClick: () => { stopPath(); setPath([]); progressRef.current = 0; setProgress(0); },
+    },
+  ];
+
   return (
     <Workspace
       appId="correspondence"
@@ -269,24 +284,7 @@ export default function Correspondence() {
       layouts={layouts}
       defaultLayoutId="explore"
       explainer={help || null}
+      actions={actions}
     />
   );
-}
-
-function ActionButton({ label, onClick, active, primary, disabled }: {
-  label: string; onClick: () => void;
-  active?: boolean; primary?: boolean; disabled?: boolean;
-}) {
-  const style: React.CSSProperties = {
-    padding: '12px 16px', borderRadius: 6,
-    border: active ? '1px solid var(--cp-accent)' : '1px solid var(--cp-border)',
-    background: primary && !disabled ? '#10b981'
-      : active ? 'rgba(255, 212, 0, 0.18)'
-      : 'rgba(255,255,255,0.06)',
-    color: primary && !disabled ? '#fff' : 'var(--cp-fg)',
-    cursor: disabled ? 'not-allowed' : 'pointer',
-    fontSize: 14, opacity: disabled ? 0.5 : 1, fontWeight: primary ? 700 : 500,
-    textAlign: 'left',
-  };
-  return <button style={style} onClick={onClick} disabled={disabled}>{label}</button>;
 }

--- a/src/animations/CountingTheWays/CountingTheWays.tsx
+++ b/src/animations/CountingTheWays/CountingTheWays.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { Play, Pause, SkipForward, RotateCcw, FlaskConical, Trash2 } from 'lucide-react';
+import { FlaskConical } from 'lucide-react';
 import './countingTheWays.css';
 import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../chrome/workspace/types';
@@ -500,12 +500,10 @@ export default function CountingTheWays() {
     </>
   );
 
+  // transport (Play / Next step / Reset) lives in the action strip; this panel keeps the readout + Speed
   const tutorNode = (
     <div className="ctw-actions">
       <div className="ctw-progress">{tut.stage === 'static' ? 'Full picture' : `Step ${tut.step} / 3 · ${tut.stage}`}</div>
-      <button className="ctw-btn primary" onClick={playPause}>{playing ? <Pause size={16} /> : <Play size={16} />}{playing ? 'Pause' : frame > 0 && frame < total ? 'Resume' : 'Play tutorial'}</button>
-      <button className="ctw-btn" onClick={stepStage} disabled={playing}><SkipForward size={16} />Next step</button>
-      <button className="ctw-btn" onClick={resetTut} disabled={frame === 0 && !playing}><RotateCcw size={16} />Reset</button>
       <Slider label="Speed" value={speed} min={0} max={100} step={1} onChange={setSpeed} />
     </div>
   );
@@ -515,12 +513,11 @@ export default function CountingTheWays() {
     <FormulaBand mu1={mu1} mu2={mu2} k={activeK} partialBessel={partialBessel} partialSum={partialSum} notes={showNotes} />
   );
 
+  // transport (Run & log / Clear catalog) lives in the action strip; this panel keeps the readouts + sample size
   const labNode = (
     <div className="ctw-actions">
       <div className="ctw-progress">{runs.length} run{runs.length === 1 ? '' : 's'} logged · next seed {labSeed}</div>
       <NumberInput label="Sample size" value={labN} onChange={v => setLabN(clamp(Math.round(v), 20, 20000))} min={20} max={20000} integer />
-      <button className="ctw-btn primary" onClick={runLab}><FlaskConical size={16} />Run &amp; log</button>
-      <button className="ctw-btn" onClick={clearRuns} disabled={runs.length === 0}><Trash2 size={16} />Clear catalog</button>
       <p className="ctw-hint">Each run draws a fresh sample from the current rates, fits μ̂ from its mean &amp; variance, and adds a row. Run repeatedly to see the recovery wobble; change the rates to compare.</p>
     </div>
   );

--- a/src/animations/StableMatching/StableMatching.tsx
+++ b/src/animations/StableMatching/StableMatching.tsx
@@ -238,10 +238,13 @@ function LatticeView({ inst, set, capped, named, picked, onPick }: {
   const W = 760, H = 480, padX = 40, padY = 36;
   const X = (x: number) => padX + x * (W - 2 * padX);
   const Y = (y: number) => padY + y * (H - 2 * padY);
-  const NAMED_RING: Partial<Record<NamedKey, string>> = { egalitarian: '#5eead4', median: '#a78bfa', minRegret: '#fbbf24', sexEqual: '#f472b6', balanced: '#60a5fa' };
+  // Legible per-skin label colors: the --data ramp stays readable on every skin's
+  // lattice panel — fixed light hues (the old #7dd3fc/#fca5a5/#fff) vanished on the
+  // light skins. Applied via `style` since SVG fill/stroke attributes don't resolve var().
+  const NAMED_RING: Partial<Record<NamedKey, string>> = { egalitarian: 'var(--data-2)', median: 'var(--data-7)', minRegret: 'var(--data-4)', sexEqual: 'var(--data-5)', balanced: 'var(--data-3)' };
   const labelFor = (i: number): { text: string; color: string } | null => {
     for (const k of ['aOptimal', 'bOptimal', 'egalitarian', 'median', 'minRegret', 'sexEqual', 'balanced'] as NamedKey[])
-      if (namedAt[k] === i) return { text: NAMED_LABELS[k], color: k === 'aOptimal' ? '#7dd3fc' : k === 'bOptimal' ? '#fca5a5' : (NAMED_RING[k] ?? '#fff') };
+      if (namedAt[k] === i) return { text: NAMED_LABELS[k], color: k === 'aOptimal' ? 'var(--data-1)' : k === 'bOptimal' ? 'var(--data-6)' : (NAMED_RING[k] ?? 'var(--fg)') };
     return null;
   };
 
@@ -257,14 +260,14 @@ function LatticeView({ inst, set, capped, named, picked, onPick }: {
           const sel = picked === i;
           return (
             <g key={i} className="sm2-lnode" onClick={() => onPick(i)} style={{ cursor: 'pointer' }}>
-              <circle cx={X(p.x)} cy={Y(p.y)} r={sel ? 9 : 6} fill={fill} stroke={sel ? '#fff' : lab ? lab.color : '#14141b'} strokeWidth={sel ? 2.5 : lab ? 2 : 1} />
-              {lab && <text x={X(p.x)} y={Y(p.y) - 11} textAnchor="middle" fontSize={11} fill={lab.color}>{lab.text}</text>}
+              <circle cx={X(p.x)} cy={Y(p.y)} r={sel ? 9 : 6} fill={fill} style={{ stroke: sel ? 'var(--fg)' : lab ? lab.color : 'var(--border-strong)' }} strokeWidth={sel ? 2.5 : lab ? 2 : 1} />
+              {lab && <text x={X(p.x)} y={Y(p.y) - 11} textAnchor="middle" fontSize={11} style={{ fill: lab.color }}>{lab.text}</text>}
               <title>{`${lab ? lab.text + ' · ' : ''}Σrank ${s.total} (A ${s.aTot} + B ${s.bTot})`}</title>
             </g>
           );
         })}
       </svg>
-      <p className="sm2-lattice-cap">{capped ? '≥' : ''}{N} stable matchings · <span style={{ color: '#7dd3fc' }}>A-optimal</span> top → <span style={{ color: '#fca5a5' }}>B-optimal</span> bottom · each edge is one rotation · click a node to view it. Node color = how good for A (blue) → for B (red).</p>
+      <p className="sm2-lattice-cap">{capped ? '≥' : ''}{N} stable matchings · <span style={{ color: 'var(--data-1)' }}>A-optimal</span> top → <span style={{ color: 'var(--data-6)' }}>B-optimal</span> bottom · each edge is one rotation · click a node to view it. Node color = how good for A (blue) → for B (red).</p>
     </div>
   );
 }

--- a/src/animations/StableMatching/StableMatching.tsx
+++ b/src/animations/StableMatching/StableMatching.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import {
-  Activity, AlertTriangle, Check, Copy, Download, FastForward, FlaskConical, Layers, Pause, Play,
-  RotateCcw, Shuffle, SkipForward, ShieldCheck,
+  Activity, AlertTriangle, Check, Copy, Download, FlaskConical, Layers, Pause,
+  Shuffle, ShieldCheck,
 } from 'lucide-react';
 import './stableMatching.css';
 import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef } from '../../chrome/workspace/types';
-import { Slider, Pills, Select, NumberInput, Checkbox } from '../../components/ControlPanel';
+import { Slider, Pills, Select, NumberInput, Checkbox, ColormapPicker } from '../../components/ControlPanel';
 import { usePersistentState } from '../../lib/usePersistentState';
 import explainerText from './EXPLAINER.md?raw';
 import readmeText from './README.md?raw';
@@ -17,6 +17,8 @@ import {
 } from './galeShapley';
 import { allStableMatchings, stablePairs, namedSolutions, score, layoutLattice, NAMED_LABELS, type NamedKey } from './rotations';
 import { rothVandeVate, replaySteps, type ResolveResult } from './resolver';
+import { mapStops, gradientCss } from '../../lib/colormapRegistry';
+import { useThemeId } from '../../chrome/skins';
 
 const FOOT_CAP = 1000; // cap the (worst-case exponential) stable-matching enumeration
 type Jump = 'live' | NamedKey;
@@ -45,12 +47,26 @@ const ENUM_CAP = 300;    // stable-matching enumeration cap for the "# stable" s
 const EMPTY_MARKERS = new Map<string, 'active' | 'reject' | 'stolen'>();
 const EMPTY_TRAIL = new Map<string, number>();
 
-// shared BuRd diverging scale (blue = best rank → white → red = worst)
-const BURD = [[33, 102, 172], [103, 169, 207], [247, 247, 247], [239, 138, 98], [178, 24, 43]];
+// The rank color scale comes from the shared colormap registry (a divergent-family
+// map) instead of a hard-coded array. RANK_RAMP holds the active map's anchors as
+// rgb triples, low→high; setRankRamp() refreshes it from the Color panel's choice
+// (called once per render, before the cell renderers below read burd()/rankBurd()).
+// Default = RdBu reversed, so rank #1 reads cool/blue and the worst reads warm/red.
+function hexToRgb(h: string): [number, number, number] {
+  const s = h.replace('#', '');
+  const n = s.length === 3 ? s.split('').map(c => c + c).join('') : s;
+  return [parseInt(n.slice(0, 2), 16), parseInt(n.slice(2, 4), 16), parseInt(n.slice(4, 6), 16)];
+}
+let RANK_RAMP: number[][] = mapStops('rdbu').slice().reverse().map(hexToRgb);
+function setRankRamp(id: string, reverse: boolean): void {
+  const hex = mapStops(id);
+  RANK_RAMP = (reverse ? hex.slice().reverse() : hex.slice()).map(hexToRgb);
+}
 function burd(u: number): string {
+  const R = RANK_RAMP;
   const x = Math.max(0, Math.min(1, u));
-  const seg = x * (BURD.length - 1), i = Math.min(BURD.length - 2, Math.floor(seg)), f = seg - i;
-  const c = BURD[i].map((v, k) => Math.round(v + (BURD[i + 1][k] - v) * f));
+  const seg = x * (R.length - 1), i = Math.min(R.length - 2, Math.floor(seg)), f = seg - i;
+  const c = R[i].map((v, k) => Math.round(v + (R[i + 1][k] - v) * f));
   return `rgb(${c[0]},${c[1]},${c[2]})`;
 }
 const rankBurd = (r: number, maxRank: number) => burd(maxRank > 1 ? (r - 1) / (maxRank - 1) : 0);
@@ -269,6 +285,14 @@ export default function StableMatching() {
   const [tight, setTight] = usePersistentState(`${NS}:tight`, true);
   const [liveSort, setLiveSort] = usePersistentState(`${NS}:liveSort`, false);
   const [showFootprint, setShowFootprint] = usePersistentState(`${NS}:footprint`, true);
+  // Matrix/heatmap rank coloring — a divergent-family colormap from the shared
+  // registry (replaces the old hard-coded BuRd). Default RdBu reversed = blue #1.
+  const [matrixMap, setMatrixMap] = usePersistentState(`${NS}:matrixMap`, 'rdbu');
+  const [matrixReverse, setMatrixReverse] = usePersistentState(`${NS}:matrixRev`, true);
+  const themeId = useThemeId();
+  // Refresh the module-level rank ramp before the Matrix/Heatmap renderers (which
+  // call burd()/rankBurd()) run this render. Cheap + deterministic; single-instance.
+  setRankRamp(matrixMap, matrixReverse);
 
   const [step, setStep] = useState(0);
   const [playing, setPlaying] = useState(false);
@@ -682,25 +706,17 @@ export default function StableMatching() {
     </>
   );
 
+  // Transport (Play/Step/Finish/Reset · the RVV Back-to-run) lives once, in the
+  // always-on action strip (`actions` below) — never duplicated here. This panel
+  // keeps only the round readout and the *parameters*: speed, the one-shot
+  // Stabilize repair, and the jump-to-solution navigator.
   const playbackNode = (
     <div className="sm2-actions">
       <div className="sm2-progress">Round {safeStep} / {total}{done ? ' · complete' : ''}</div>
-      {resolve ? (
+      <Slider label="Speed" value={speed} min={0} max={100} step={1} onChange={setSpeed} />
+      {!resolve && (
         <>
-          <button className="sm2-btn primary" onClick={() => setRPlaying(p => !p)} disabled={rStep >= resolve.steps.length && !rPlaying}>{rPlaying ? <Pause size={16} /> : <Play size={16} />}{rPlaying ? 'Pause' : 'Play'}</button>
-          <button className="sm2-btn" onClick={() => setRStep(s => Math.min(resolve.steps.length, s + 1))} disabled={rPlaying || rStep >= resolve.steps.length}><SkipForward size={16} />Step</button>
-          <button className="sm2-btn" onClick={() => setRStep(resolve.steps.length)} disabled={rStep >= resolve.steps.length}><FastForward size={16} />Finish</button>
-          <button className="sm2-btn" onClick={endResolve}><RotateCcw size={16} />Back to run</button>
-          <Slider label="Speed" value={speed} min={0} max={100} step={1} onChange={setSpeed} />
-        </>
-      ) : (
-        <>
-          <button className="sm2-btn primary" onClick={() => { goLive(); setPlaying(p => !p); }} disabled={jump === 'live' && !pickedMatching && done && !playing}>{playing ? <Pause size={16} /> : <Play size={16} />}{playing ? 'Pause' : 'Play'}</button>
-          <button className="sm2-btn" onClick={() => { goLive(); setStep(s => Math.min(total, s + 1)); }} disabled={playing || (jump === 'live' && !pickedMatching && done)}><SkipForward size={16} />Step</button>
-          <button className="sm2-btn" onClick={() => { goLive(); setStep(total); }} disabled={jump === 'live' && !pickedMatching && done}><FastForward size={16} />Finish</button>
-          <button className="sm2-btn" onClick={reset}><RotateCcw size={16} />Reset</button>
           <button className="sm2-btn stabilize" onClick={stabilize} disabled={!finalUnstable} title={finalUnstable ? 'Repair the unstable result to a stable matching' : 'Already stable — nothing to repair'}><ShieldCheck size={16} />Stabilize</button>
-          <Slider label="Speed" value={speed} min={0} max={100} step={1} onChange={setSpeed} />
           <Select label="Jump to a stable solution" value={pickedMatching ? 'live' : jump} onChange={(v) => { setPickedNode(null); setJump(v); }}
             options={(['live', 'aOptimal', 'bOptimal', 'egalitarian', 'median', 'minRegret', 'sexEqual', 'balanced'] as Jump[])
               .map(k => ({ value: k, label: JUMP_LABELS[k] }))} />
@@ -738,14 +754,17 @@ export default function StableMatching() {
     return `${n} A's and ${n} B's; ${cons}. Each round the whole proposing side asks at once and every receiver keeps its single best offer (bumping if better), rejecting the rest; ${sched}. ${tail}`;
   })();
 
+  // The rank-scale legend swatch is driven by the active colormap (--sm-scale), so
+  // it always matches the matrix; the text stays color-agnostic (direction, not
+  // hue) so it reads correctly whatever divergent map is chosen.
   const legend = (
-    <p className="sm2-legend">
+    <p className="sm2-legend" style={{ '--sm-scale': gradientCss(matrixMap, matrixReverse) } as React.CSSProperties}>
       {cellView === 'both' && <><span className="k sq">square = A→B rank</span><span className="k disc">circle = B→A rank</span></>}
       {cellView === 'a' && <span className="k sq">color = A's rank of B</span>}
       {cellView === 'b' && <span className="k sq">color = B's rank of A</span>}
       {cellView === 'diff'
-        ? <span className="k scale diverge">blue = A keener · red = B keener</span>
-        : <span className="k scale">blue #1 → red last</span>}
+        ? <span className="k scale diverge">A keener ←→ B keener</span>
+        : <span className="k scale">best #1 → worst</span>}
       <span className="k matched">held / matched</span><span className="k active">proposing</span><span className="k blocking">blocking</span>
       {showFootprint && <span className="k footprint">stable elsewhere</span>}
     </p>
@@ -835,9 +854,21 @@ export default function StableMatching() {
 
   /* ── workspace assembly: panels, view windows, built-in layouts ── */
 
+  const colorNode = (
+    <ColormapPicker
+      family="divergent"
+      value={matrixMap}
+      onChange={setMatrixMap}
+      themeId={themeId}
+      reverse={matrixReverse}
+      onReverse={setMatrixReverse}
+    />
+  );
+
   const sections: SectionDef[] = [
     { id: 'algorithm', title: 'Algorithm', arch: 'subject', node: algorithmNode, estHeight: 170 },
     { id: 'instance', title: 'Instance', arch: 'domain', node: instanceNode, estHeight: 300 },
+    { id: 'color', title: 'Color', arch: 'color', node: colorNode, estHeight: 300 },
     { id: 'display', title: 'Display', arch: 'marks', node: displayNode, estHeight: 360 },
     { id: 'playback', title: 'Playback', arch: 'playback', node: playbackNode, estHeight: 470 },
     { id: 'lab', title: 'Lab', arch: 'lab', node: labNode, estHeight: 540 },

--- a/src/animations/StableMatching/stableMatching.css
+++ b/src/animations/StableMatching/stableMatching.css
@@ -15,20 +15,20 @@
 
 /* narration */
 .sm2-narrate { font-size: 13.5px; color: var(--fg); background: var(--panel-solid); border: 1px solid var(--border); border-left: 3px solid #2563eb; border-radius: 8px; padding: 9px 13px; margin-bottom: 14px; line-height: 1.45; }
-.sm2-narrate.jump { border-left-color: #2dd4bf; }   /* teal: showing a named stable solution */
-.sm2-narrate.jump strong { color: #5eead4; }
-.sm2-narrate.resolve { border-left-color: #c084fc; }  /* purple: stabilizing (RVV) */
-.sm2-narrate.resolve strong { color: #d8b4fe; }
+.sm2-narrate.jump { border-left-color: var(--data-2); }   /* teal-ish: showing a named stable solution */
+.sm2-narrate.jump strong { color: var(--data-2); }
+.sm2-narrate.resolve { border-left-color: var(--data-7); }  /* purple-ish: stabilizing (RVV) */
+.sm2-narrate.resolve strong { color: var(--data-7); }
 
 /* metrics */
 .sm2-metrics { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 12px; margin-bottom: 18px; }
 .sm2-metric { background: var(--panel-solid); border: 1px solid var(--border); border-radius: 12px; padding: 12px 14px; display: flex; flex-direction: column; gap: 5px; }
 .sm2-metric-label { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--dim); text-transform: uppercase; letter-spacing: .04em; }
 .sm2-metric strong { font-size: 24px; font-variant-numeric: tabular-nums; }
-.sm2-metric.big strong { color: #7fe3a6; }
+.sm2-metric.big strong { color: var(--success); }
 .sm2-metric-sub { font-size: 12px; color: var(--dim-2); line-height: 1.4; }
-.sm2-metric.stability.ok { border-color: #1f7a44; } .sm2-metric.stability.ok strong { color: #4ade80; }
-.sm2-metric.stability.bad { border-color: #8a2b2b; } .sm2-metric.stability.bad strong { color: #f87171; }
+.sm2-metric.stability.ok { border-color: var(--success); } .sm2-metric.stability.ok strong { color: var(--success); }
+.sm2-metric.stability.bad { border-color: var(--danger); } .sm2-metric.stability.bad strong { color: var(--danger); }
 .sm2-dist { display: flex; gap: 2px; align-items: flex-end; height: 40px; }
 .sm2-dist .b { flex: 1; min-height: 2px; background: linear-gradient(#8b8bd6, #3f3f5a); border-radius: 2px 2px 0 0; }
 
@@ -108,7 +108,7 @@
 .sm2-actions { display: flex; flex-direction: column; gap: 8px; }
 .sm2-btn { display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border); background: var(--panel-2); color: var(--fg); font: inherit; font-size: 14px; cursor: pointer; }
 .sm2-btn:hover { background: var(--hover); } .sm2-btn.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-fg); } .sm2-btn:disabled { opacity: .4; cursor: default; }
-.sm2-btn.stabilize:not(:disabled) { border-color: #7c3aed; color: #d8b4fe; }
+.sm2-btn.stabilize:not(:disabled) { border-color: var(--data-7); color: var(--data-7); }
 
 /* lab */
 .sm2-lab { max-width: 680px; }

--- a/src/animations/StableMatching/stableMatching.css
+++ b/src/animations/StableMatching/stableMatching.css
@@ -2,7 +2,7 @@
  * absolute inset 0) and scrolls its own content — never the page */
 .sm2-stage {
   position: absolute; inset: 0; overflow: auto;
-  background: #0c0c10; color: #e7e7ea;
+  background: var(--viz-bg); color: var(--fg);
   font-family: system-ui, -apple-system, sans-serif;
   padding: 12px 14px 18px;
 }
@@ -11,10 +11,10 @@
 .sm2-stage-matrix { display: flex; flex-direction: column; padding-bottom: 0; }
 
 /* round-progress readout (Playback panel) */
-.sm2-progress { font-size: 13px; color: #8b8b99; font-variant-numeric: tabular-nums; }
+.sm2-progress { font-size: 13px; color: var(--dim); font-variant-numeric: tabular-nums; }
 
 /* narration */
-.sm2-narrate { font-size: 13.5px; color: #d6d6e2; background: #14141b; border: 1px solid #26262f; border-left: 3px solid #2563eb; border-radius: 8px; padding: 9px 13px; margin-bottom: 14px; line-height: 1.45; }
+.sm2-narrate { font-size: 13.5px; color: var(--fg); background: var(--panel-solid); border: 1px solid var(--border); border-left: 3px solid #2563eb; border-radius: 8px; padding: 9px 13px; margin-bottom: 14px; line-height: 1.45; }
 .sm2-narrate.jump { border-left-color: #2dd4bf; }   /* teal: showing a named stable solution */
 .sm2-narrate.jump strong { color: #5eead4; }
 .sm2-narrate.resolve { border-left-color: #c084fc; }  /* purple: stabilizing (RVV) */
@@ -22,11 +22,11 @@
 
 /* metrics */
 .sm2-metrics { display: grid; grid-template-columns: 2fr 1fr 1fr; gap: 12px; margin-bottom: 18px; }
-.sm2-metric { background: #14141b; border: 1px solid #26262f; border-radius: 12px; padding: 12px 14px; display: flex; flex-direction: column; gap: 5px; }
-.sm2-metric-label { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: #8b8b99; text-transform: uppercase; letter-spacing: .04em; }
+.sm2-metric { background: var(--panel-solid); border: 1px solid var(--border); border-radius: 12px; padding: 12px 14px; display: flex; flex-direction: column; gap: 5px; }
+.sm2-metric-label { display: inline-flex; align-items: center; gap: 6px; font-size: 12px; color: var(--dim); text-transform: uppercase; letter-spacing: .04em; }
 .sm2-metric strong { font-size: 24px; font-variant-numeric: tabular-nums; }
 .sm2-metric.big strong { color: #7fe3a6; }
-.sm2-metric-sub { font-size: 12px; color: #777; line-height: 1.4; }
+.sm2-metric-sub { font-size: 12px; color: var(--dim-2); line-height: 1.4; }
 .sm2-metric.stability.ok { border-color: #1f7a44; } .sm2-metric.stability.ok strong { color: #4ade80; }
 .sm2-metric.stability.bad { border-color: #8a2b2b; } .sm2-metric.stability.bad strong { color: #f87171; }
 .sm2-dist { display: flex; gap: 2px; align-items: flex-end; height: 40px; }
@@ -34,7 +34,7 @@
 
 /* side identity is SHAPE (square = A, circle = B, like the matrix); color is the
  * shared BuRd rank scale everywhere, so blue always means "good rank". */
-.sw { display: inline-block; width: 10px; height: 10px; vertical-align: -1px; margin-right: 4px; border-radius: 3px; background: #9a9aa8; }
+.sw { display: inline-block; width: 10px; height: 10px; vertical-align: -1px; margin-right: 4px; border-radius: 3px; background: var(--dim); }
 .sw.disc { border-radius: 50%; }
 
 /* one panel per side: marker + average + the sorted outcome colorbar on a row.
@@ -42,8 +42,8 @@
  * best→worst on the BuRd scale (an ECDF read as color). */
 .sm2-rows { display: flex; flex-direction: column; gap: 9px; margin: 6px 0 4px; }
 .sm2-row { display: flex; align-items: center; gap: 10px; }
-.sm2-bar-label { display: inline-flex; align-items: center; width: 1.9em; font-size: 13px; color: #aab; }
-.sm2-outcome .sm2-row strong { width: 3.1em; font-size: 19px; font-variant-numeric: tabular-nums; color: #e7e7ea; }
+.sm2-bar-label { display: inline-flex; align-items: center; width: 1.9em; font-size: 13px; color: var(--dim); }
+.sm2-outcome .sm2-row strong { width: 3.1em; font-size: 19px; font-variant-numeric: tabular-nums; color: var(--fg); }
 /* ticks fill the strip's width when there's room, but never shrink below a
  * visible minimum — so the same panel scales from a few people to hundreds
  * (overflowing into a horizontal scroll only when even 3px/tick won't fit). */
@@ -54,13 +54,13 @@
 .sm2-matrix-wrap { overflow-x: auto; flex: 1 1 auto; min-height: 140px; }
 .sm2-matrix { display: grid; gap: 3px; align-items: stretch; width: max-content; }
 .sm2-corner { }
-.sm2-chead, .sm2-rhead { display: flex; align-items: center; justify-content: center; font-size: 12px; color: #9a9aa8; font-variant-numeric: tabular-nums; }
+.sm2-chead, .sm2-rhead { display: flex; align-items: center; justify-content: center; font-size: 12px; color: var(--dim); font-variant-numeric: tabular-nums; }
 .sm2-chead { padding-bottom: 2px; }
 .sm2-rhead { justify-content: flex-end; padding-right: 7px; }
 /* each cell: a SQUARE heat (A's rank of B) with a CIRCLE heat inside (B's rank of A) */
 .sm2-mcell { position: relative; border-radius: 4px; transition: box-shadow .15s; }
 .sm2-matrix.tight .sm2-mcell { border-radius: 0; }
-.sm2-story { font-size: 13px; color: #b9b9c8; line-height: 1.5; margin: 0 0 10px; max-width: 82ch; }
+.sm2-story { font-size: 13px; color: var(--dim); line-height: 1.5; margin: 0 0 10px; max-width: 82ch; }
 .sm2-disc { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -50%); width: 58%; height: 58%; border-radius: 50%; }
 /* white + difference blend → auto-contrasts on the light midtones and dark ends of BuRd */
 .sm2-mcell .ar { position: absolute; top: 1px; left: 3px; font-size: 9px; color: #fff; mix-blend-mode: difference; font-variant-numeric: tabular-nums; }
@@ -76,29 +76,29 @@
 @keyframes sm2-flash { 0% { box-shadow: 0 0 0 3px #c084fc; } 100% { box-shadow: 0 0 0 0 transparent; } }   /* purple: rejected/stolen */
 
 /* inspect preferences: hover/click highlights a row+column; the panel reads the lists */
-.sm2-chead.hi, .sm2-rhead.hi { color: #fff; font-weight: 600; }
+.sm2-chead.hi, .sm2-rhead.hi { color: var(--fg); font-weight: 600; }
 .sm2-mcell.hi { filter: brightness(1.18) saturate(1.1); }
 .sm2-mcell.sel { outline: 2px solid #fff; outline-offset: -2px; z-index: 4; }
 
 /* sticks to the bottom of the matrix WINDOW (not the viewport) so it never
  * pushes the grid out of view; full-bleed via negative margins into the
  * stage padding */
-.sm2-inspect { position: sticky; bottom: 0; z-index: 20; margin: 10px -14px 0; display: flex; flex-direction: column; gap: 6px; background: rgba(20, 20, 27, 0.96); border-top: 1px solid #2a2a36; padding: 10px 14px; box-shadow: 0 -6px 22px rgba(0, 0, 0, 0.45); backdrop-filter: blur(4px); }
+.sm2-inspect { position: sticky; bottom: 0; z-index: 20; margin: 10px -14px 0; display: flex; flex-direction: column; gap: 6px; background: var(--panel); border-top: 1px solid var(--border); padding: 10px 14px; box-shadow: 0 -6px 22px rgba(0, 0, 0, 0.45); backdrop-filter: blur(4px); }
 .sm2-inspect.pinned { border-top-color: #3a6ea5; }
 .sm2-pref { display: flex; align-items: baseline; gap: 10px; flex-wrap: wrap; }
-.sm2-pref-who { font-size: 12.5px; color: #aab; white-space: nowrap; min-width: 7.5em; }
+.sm2-pref-who { font-size: 12.5px; color: var(--dim); white-space: nowrap; min-width: 7.5em; }
 .sm2-pref-chips { display: flex; flex-wrap: wrap; gap: 3px; }
 .sm2-chip { display: inline-flex; align-items: center; justify-content: center; min-width: 18px; height: 18px; padding: 0 3px; border-radius: 4px; font-size: 11px; color: #fff; mix-blend-mode: difference; font-variant-numeric: tabular-nums; }
 .sm2-chip.partner { outline: 2px solid #4ade80; outline-offset: 1px; mix-blend-mode: normal; }
 .sm2-chip.mark { box-shadow: 0 0 0 2px #fff; }
-.sm2-inspect-hint { font-size: 11.5px; color: #777; }
+.sm2-inspect-hint { font-size: 11.5px; color: var(--dim-2); }
 
-.sm2-legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 12px; font-size: 12px; color: #8b8b99; }
+.sm2-legend { display: flex; flex-wrap: wrap; gap: 14px; margin-top: 12px; font-size: 12px; color: var(--dim); }
 .sm2-legend .k { display: inline-flex; align-items: center; gap: 6px; }
 .sm2-legend .k::before { content: ''; width: 13px; height: 13px; border-radius: 3px; border: 0; }
 .sm2-legend .k.sq::before { background: rgb(103,169,207); }
 .sm2-legend .k.disc::before { background: rgb(103,169,207); border-radius: 50%; }
-.sm2-legend .k.scale::before { width: 46px; background: linear-gradient(90deg, rgb(33,102,172), rgb(247,247,247), rgb(178,24,43)); }
+.sm2-legend .k.scale::before { width: 46px; background: var(--sm-scale, linear-gradient(90deg, rgb(33,102,172), rgb(247,247,247), rgb(178,24,43))); }
 .sm2-legend .k.matched::before { background: transparent; outline: 2px solid #4ade80; outline-offset: -2px; }
 .sm2-legend .k.active::before { background: transparent; box-shadow: 0 0 0 2px #f0c040; }
 .sm2-legend .k.blocking::before { background: transparent; outline: 2px solid #c084fc; outline-offset: -2px; }
@@ -106,45 +106,45 @@
 
 /* action stacks (Playback / Lab workspace panels) */
 .sm2-actions { display: flex; flex-direction: column; gap: 8px; }
-.sm2-btn { display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px; border-radius: 8px; border: 1px solid #2e2e38; background: #1b1b22; color: #ddd; font: inherit; font-size: 14px; cursor: pointer; }
-.sm2-btn:hover { background: #24242d; } .sm2-btn.primary { background: #2563eb; border-color: #2563eb; color: #fff; } .sm2-btn:disabled { opacity: .4; cursor: default; }
+.sm2-btn { display: inline-flex; align-items: center; gap: 7px; padding: 8px 12px; border-radius: 8px; border: 1px solid var(--border); background: var(--panel-2); color: var(--fg); font: inherit; font-size: 14px; cursor: pointer; }
+.sm2-btn:hover { background: var(--hover); } .sm2-btn.primary { background: var(--accent); border-color: var(--accent); color: var(--accent-fg); } .sm2-btn:disabled { opacity: .4; cursor: default; }
 .sm2-btn.stabilize:not(:disabled) { border-color: #7c3aed; color: #d8b4fe; }
 
 /* lab */
 .sm2-lab { max-width: 680px; }
-.sm2-heatmap h4 { margin: 0 0 10px; font-size: 14px; color: #cfcfe0; }
-.sm2-heatmap-grid { position: relative; width: 100%; padding-bottom: 100%; background: #14141b; border: 1px solid #26262f; border-radius: 10px; overflow: hidden; }
+.sm2-heatmap h4 { margin: 0 0 10px; font-size: 14px; color: var(--fg); }
+.sm2-heatmap-grid { position: relative; width: 100%; padding-bottom: 100%; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
 .sm2-cell { position: absolute; }
-.sm2-tip { position: absolute; top: 8px; left: 8px; right: 8px; background: rgba(10,10,14,.9); border: 1px solid #33333f; border-radius: 7px; padding: 6px 9px; font-size: 12px; pointer-events: none; line-height: 1.5; }
-.sm2-heatmap-x { text-align: center; font-size: 12px; color: #8b8b99; margin-top: 6px; }
-.sm2-heatmap-legend { display: flex; align-items: center; gap: 8px; font-size: 12px; color: #8b8b99; margin-top: 6px; }
+.sm2-tip { position: absolute; top: 8px; left: 8px; right: 8px; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 7px; padding: 6px 9px; font-size: 12px; pointer-events: none; line-height: 1.5; }
+.sm2-heatmap-x { text-align: center; font-size: 12px; color: var(--dim); margin-top: 6px; }
+.sm2-heatmap-legend { display: flex; align-items: center; gap: 8px; font-size: 12px; color: var(--dim); margin-top: 6px; }
 .sm2-heatmap-legend .bar { flex: 1; height: 9px; border-radius: 4px; }
-.sm2-heatmap-legend .cap { color: #6a6a78; }
-.sm2-tip .dim { color: #9a9aa8; }
-.sm2-heatmap-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; aspect-ratio: 1; max-width: 480px; color: #6a6a78; background: #14141b; border: 1px dashed #2c2c38; border-radius: 10px; }
-.sm2-lab-note { font-size: 13px; color: #9a9aa8; line-height: 1.6; margin-top: 14px; max-width: 60ch; }
+.sm2-heatmap-legend .cap { color: var(--dim-2); }
+.sm2-tip .dim { color: var(--dim); }
+.sm2-heatmap-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; aspect-ratio: 1; max-width: 480px; color: var(--dim-2); background: var(--panel-solid); border: 1px dashed var(--border); border-radius: 10px; }
+.sm2-lab-note { font-size: 13px; color: var(--dim); line-height: 1.6; margin-top: 14px; max-width: 60ch; }
 
 /* lab controls + summary */
 .sm2-seedrow { display: flex; align-items: flex-end; gap: 8px; }
 .sm2-seedrow > :first-child { flex: 1; }
-.sm2-lab-stats { margin-top: 14px; background: #14141b; border: 1px solid #26262f; border-radius: 10px; padding: 12px 14px; }
+.sm2-lab-stats { margin-top: 14px; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 10px; padding: 12px 14px; }
 .sm2-stat-head { display: flex; align-items: center; justify-content: space-between; gap: 10px; margin-bottom: 6px; }
-.sm2-stat-head h4 { margin: 0; font-size: 13px; color: #cfcfe0; text-transform: uppercase; letter-spacing: .04em; }
+.sm2-stat-head h4 { margin: 0; font-size: 13px; color: var(--fg); text-transform: uppercase; letter-spacing: .04em; }
 .sm2-stat-export { display: flex; gap: 6px; }
 .sm2-btn.sm { padding: 5px 9px; font-size: 12.5px; }
-.sm2-stat-meta { font-size: 12.5px; color: #9a9aa8; margin: 0 0 8px; line-height: 1.5; }
-.sm2-stat-meta strong { color: #cfcfe0; }
+.sm2-stat-meta { font-size: 12.5px; color: var(--dim); margin: 0 0 8px; line-height: 1.5; }
+.sm2-stat-meta strong { color: var(--fg); }
 .sm2-stat-table { width: 100%; border-collapse: collapse; font-size: 12.5px; }
-.sm2-stat-table th { text-align: left; color: #8b8b99; font-weight: 500; padding: 3px 12px 3px 0; white-space: nowrap; vertical-align: top; }
-.sm2-stat-table td { color: #c8c8d4; padding: 3px 14px 3px 0; font-variant-numeric: tabular-nums; }
-.sm2-stat-table strong { color: #e7e7ea; }
+.sm2-stat-table th { text-align: left; color: var(--dim); font-weight: 500; padding: 3px 12px 3px 0; white-space: nowrap; vertical-align: top; }
+.sm2-stat-table td { color: var(--fg); padding: 3px 14px 3px 0; font-variant-numeric: tabular-nums; }
+.sm2-stat-table strong { color: var(--fg); }
 
 /* lattice of stable matchings */
 .sm2-lattice-view { max-width: 820px; }
-.sm2-lattice-svg { width: 100%; height: auto; background: #14141b; border: 1px solid #26262f; border-radius: 12px; }
+.sm2-lattice-svg { width: 100%; height: auto; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 12px; }
 .sm2-lnode:hover circle { filter: brightness(1.25); }
 .sm2-lnode text { pointer-events: none; font-family: system-ui, sans-serif; }
-.sm2-lattice-cap { font-size: 12.5px; color: #9a9aa8; line-height: 1.6; margin-top: 10px; max-width: 64ch; }
-.sm2-lattice-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; aspect-ratio: 16/10; max-width: 560px; color: #6a6a78; background: #14141b; border: 1px dashed #2c2c38; border-radius: 12px; text-align: center; padding: 0 30px; }
+.sm2-lattice-cap { font-size: 12.5px; color: var(--dim); line-height: 1.6; margin-top: 10px; max-width: 64ch; }
+.sm2-lattice-empty { display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 10px; aspect-ratio: 16/10; max-width: 560px; color: var(--dim-2); background: var(--panel-solid); border: 1px dashed var(--border); border-radius: 12px; text-align: center; padding: 0 30px; }
 
 @media (max-width: 760px) { .sm2-metrics { grid-template-columns: 1fr; } }

--- a/src/animations/TrinaryStars/Observatory.tsx
+++ b/src/animations/TrinaryStars/Observatory.tsx
@@ -16,7 +16,7 @@ function statusText(s: Snapshot): { text: string; color: string } {
   if (s.planetFate === 'destroyed') return { text: '☄ Planet destroyed', color: '#ff7043' };
   if (s.planetFate === 'ejected') return { text: '❄ Planet ejected — frozen wanderer', color: '#5a9be8' };
   if (s.ejectedStar >= 0) return { text: `⊘ Star ${s.ejectedStar + 1} ejected → binary`, color: '#46d98a' };
-  return { text: s.bound ? '☉☉☉ three stars · planet bound' : '⚠ planet unbound', color: '#cfe0f5' };
+  return { text: s.bound ? '☉☉☉ three stars · planet bound' : '⚠ planet unbound', color: 'var(--fg)' };
 }
 
 /** Maps insolation to a 0..1 position on a log scale spanning the habitable band. */
@@ -69,9 +69,9 @@ export default function Observatory({ snapshot }: { snapshot: Snapshot | null })
   return (
     <div style={{
       position: 'absolute', left: 0, right: 0, bottom: 0,
-      padding: '8px 12px 10px', background: 'rgba(6,9,14,0.78)',
-      borderTop: '1px solid rgba(120,150,200,0.25)', backdropFilter: 'blur(5px)',
-      color: '#cfe0f5', font: '12px/1.4 ui-monospace, monospace', pointerEvents: 'none',
+      padding: '8px 12px 10px', background: 'var(--panel)',
+      borderTop: '1px solid var(--border)', backdropFilter: 'blur(5px)',
+      color: 'var(--fg)', font: '12px/1.4 ui-monospace, monospace', pointerEvents: 'none',
     }}>
       {/* Stats row */}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: '4px 18px', marginBottom: 6 }}>
@@ -80,17 +80,17 @@ export default function Observatory({ snapshot }: { snapshot: Snapshot | null })
           <span style={{ width: 9, height: 9, borderRadius: 9, background: CLIMATE_COLOR[snapshot.climate] }} />
           {snapshot.climate.toUpperCase()}
         </span>
-        <span style={chip}>habitable&nbsp;<b style={{ color: '#46d98a' }}>{pct(snapshot.habitableFraction)}</b></span>
-        <span style={chip}>paradise&nbsp;<b style={{ color: '#46d98a' }}>{pct(snapshot.bothFraction)}</b></span>
-        <span style={chip}>longest stable&nbsp;<b style={{ color: '#9ec7ff' }}>{snapshot.longestHabitable.toFixed(1)}</b></span>
+        <span style={chip}>habitable&nbsp;<b style={{ color: 'var(--success)' }}>{pct(snapshot.habitableFraction)}</b></span>
+        <span style={chip}>paradise&nbsp;<b style={{ color: 'var(--success)' }}>{pct(snapshot.bothFraction)}</b></span>
+        <span style={chip}>longest stable&nbsp;<b style={{ color: 'var(--accent)' }}>{snapshot.longestHabitable.toFixed(1)}</b></span>
       </div>
 
       {/* Insolation bar with habitable band highlighted */}
-      <div style={{ position: 'relative', height: 8, borderRadius: 4, background: 'rgba(255,255,255,0.08)', marginBottom: 6 }}>
+      <div style={{ position: 'relative', height: 8, borderRadius: 4, background: 'var(--track)', marginBottom: 6 }}>
         <div style={{
           position: 'absolute', top: 0, bottom: 0, borderRadius: 4,
           left: `${bar.loPos * 100}%`, width: `${(bar.hiPos - bar.loPos) * 100}%`,
-          background: 'rgba(70,217,138,0.35)',
+          background: 'var(--success-soft)',
         }} />
         <div style={{
           position: 'absolute', top: -2, width: 3, height: 12, borderRadius: 2,

--- a/src/animations/TrinaryStars/Tour.tsx
+++ b/src/animations/TrinaryStars/Tour.tsx
@@ -51,24 +51,24 @@ const scrim: React.CSSProperties = {
 };
 const card: React.CSSProperties = {
   width: 'min(440px, 100%)',
-  background: 'rgba(14,18,28,0.97)', border: '1px solid rgba(120,150,200,0.3)',
-  borderRadius: 14, padding: '20px 22px', color: '#cfe0f5',
+  background: 'var(--panel-solid)', border: '1px solid var(--border)',
+  borderRadius: 14, padding: '20px 22px', color: 'var(--fg)',
   boxShadow: '0 18px 50px rgba(0,0,0,0.55)',
 };
 const kicker: React.CSSProperties = {
   font: '600 11px/1 ui-monospace, monospace', letterSpacing: 0.6,
-  textTransform: 'uppercase', color: '#66f0ff', marginBottom: 8,
+  textTransform: 'uppercase', color: 'var(--accent)', marginBottom: 8,
 };
-const titleStyle: React.CSSProperties = { margin: '0 0 8px', font: '700 19px/1.25 system-ui, sans-serif', color: '#fff' };
-const bodyStyle: React.CSSProperties = { margin: 0, font: '14px/1.6 system-ui, sans-serif', color: '#b6c6e0' };
+const titleStyle: React.CSSProperties = { margin: '0 0 8px', font: '700 19px/1.25 system-ui, sans-serif', color: 'var(--fg)' };
+const bodyStyle: React.CSSProperties = { margin: 0, font: '14px/1.6 system-ui, sans-serif', color: 'var(--dim)' };
 const dotsRow: React.CSSProperties = { display: 'flex', gap: 6, margin: '18px 0 14px' };
 function dot(active: boolean): React.CSSProperties {
-  return { width: active ? 20 : 7, height: 7, borderRadius: 999, background: active ? '#66f0ff' : 'rgba(150,170,200,0.3)', transition: 'width 0.2s, background 0.2s' };
+  return { width: active ? 20 : 7, height: 7, borderRadius: 999, background: active ? 'var(--accent)' : 'var(--dim-2)', transition: 'width 0.2s, background 0.2s' };
 }
 const btnRow: React.CSSProperties = { display: 'flex', alignItems: 'center', gap: 8 };
 const baseBtn: React.CSSProperties = {
   appearance: 'none', cursor: 'pointer', borderRadius: 8,
   padding: '8px 16px', font: '600 13px/1 system-ui, sans-serif',
 };
-const ghostBtn: React.CSSProperties = { ...baseBtn, border: '1px solid rgba(120,150,200,0.28)', background: 'transparent', color: '#9aa7bd' };
-const primaryBtn: React.CSSProperties = { ...baseBtn, border: 'none', background: '#66f0ff', color: '#06121f' };
+const ghostBtn: React.CSSProperties = { ...baseBtn, border: '1px solid var(--border)', background: 'transparent', color: 'var(--dim)' };
+const primaryBtn: React.CSSProperties = { ...baseBtn, border: 'none', background: 'var(--accent)', color: 'var(--accent-fg)' };

--- a/src/animations/TrinaryStars/Trinary.tsx
+++ b/src/animations/TrinaryStars/Trinary.tsx
@@ -12,7 +12,7 @@ import Tour, { type TourStep } from './Tour';
  * This wrapper hosts both behind one entry, swapping the active view while
  * preserving the existing hash routes so old deep-links keep working:
  * `#/trinary` → Observatory, `#/trinary-lab` → Lab. Each view renders its own
- * Workspace chrome with Observatory | Lab mode pills in the top bar (the old
+ * Workspace chrome with Explore | Lab mode pills in the top bar (the old
  * bottom tab bar's replacement); the pills switch views by setting the hash,
  * which this wrapper observes. Each view still manages its own URL query
  * (shareable configs).
@@ -74,6 +74,6 @@ const TOUR_STEPS: TourStep[] = [
   },
   {
     title: 'Open the Lab',
-    body: 'Use the Observatory | Lab pills in the top bar to switch to the Lab — it runs thousands of these worlds headless and maps their fates into fractal “destiny” portraits and statistics. Enjoy exploring!',
+    body: 'Use the Explore | Lab pills in the top bar to switch to the Lab — it runs thousands of these worlds headless and maps their fates into fractal “destiny” portraits and statistics. Enjoy exploring!',
   },
 ];

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -138,10 +138,15 @@ const FRAME_PRESETS: { label: string; c: string; a: string }[] = [
   { label: '⟨2,3⟩ on x', c: 'bary', a: 'c12' },
 ];
 
-/** Top-bar mode pills: the Observatory ↔ Lab switch (replaces the old tab bar).
- *  Switching sets the hash, which Trinary.tsx observes. */
+/** Top-bar mode pills: the Explore ↔ Lab switch (replaces the old tab bar).
+ *  The id stays 'observatory' (persisted + read by Trinary.tsx); only the
+ *  user-facing label changed to "Explore" — the old "Observatory" collided with
+ *  the dark skin's display name, and "Sandbox" would collide with this view's
+ *  "Sandbox" layout, so "Explore" is the clash-free choice. Keep it in sync with
+ *  the Lab's copy (lab/TrinaryLab.tsx). Switching sets the hash, which Trinary.tsx
+ *  observes. */
 const MODES: WorkspaceMode[] = [
-  { id: 'observatory', label: 'Observatory' },
+  { id: 'observatory', label: 'Explore' },
   { id: 'lab', label: 'Lab' },
 ];
 
@@ -657,7 +662,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
           lyapElRef.current.textContent = sim.t > 2
             ? `${lyap.toFixed(3)}  (τ≈${(1 / Math.max(lyap, 1e-6)).toFixed(1)})  ${chaotic ? 'chaotic' : 'regular'}`
             : '…';
-          lyapElRef.current.style.color = sim.t > 2 ? (chaotic ? '#ff7043' : '#46d98a') : '#9ec7ff';
+          lyapElRef.current.style.color = sim.t > 2 ? (chaotic ? 'var(--danger)' : 'var(--success)') : 'var(--dim)';
         }
         if (analyzer) setLabSnap(analyzer.snapshot());
       }
@@ -922,12 +927,11 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
     </>
   );
 
+  // Play/Pause + Reset live once, in the always-on action strip (`actions`
+  // below) — never duplicated here. This panel keeps the Speed knob and the
+  // one-shot tour launch.
   const simNode = (
     <>
-      <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
-        <button style={btnStyle} onClick={() => setPaused(p => !p)}>{paused ? '▶ Play' : '❚❚ Pause'}</button>
-        <button style={btnStyle} onClick={() => api.current?.reset()}>↺ Reset</button>
-      </div>
       <Slider label="Speed" value={speed} min={0.1} max={4} step={0.1}
         onChange={setSpeed} format={v => `${v.toFixed(1)}×`} />
       {onTour && (
@@ -969,20 +973,20 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
       title: 'Orbit',
       defaultRect: { x: 372, y: 16, w: 712, h: 600 },
       node: (
-        <div style={{ position: 'absolute', inset: 0, background: '#05060a' }}>
+        <div style={{ position: 'absolute', inset: 0, background: 'var(--viz-bg)' }}>
           <Canvas3D onMount={onMount} />
 
           {/* Live divergence readout. */}
           <div style={{
             position: 'absolute', top: 10, left: 10, padding: '8px 12px',
-            background: 'rgba(8,12,20,0.62)', border: '1px solid rgba(120,150,200,0.25)',
-            borderRadius: 8, color: '#cfe0f5', font: '12px/1.5 ui-monospace, monospace',
+            background: 'var(--panel)', border: '1px solid var(--border)',
+            borderRadius: 8, color: 'var(--fg)', font: '12px/1.5 ui-monospace, monospace',
             pointerEvents: 'none', backdropFilter: 'blur(4px)',
           }}>
             <div>cloud spread&nbsp; <span ref={spreadElRef} style={{ color: GHOST_COLOR_HEX }}>0.00e+0</span></div>
-            <div>Lyapunov λ&nbsp;&nbsp; <span ref={lyapElRef} style={{ color: '#9ec7ff' }}>…</span></div>
-            <div>sim time&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span ref={timeElRef} style={{ color: '#9ec7ff' }}>0.0</span></div>
-            {placeMode && <div style={{ color: '#ffd27f' }}>click + drag to launch</div>}
+            <div>Lyapunov λ&nbsp;&nbsp; <span ref={lyapElRef} style={{ color: 'var(--dim)' }}>…</span></div>
+            <div>sim time&nbsp;&nbsp;&nbsp;&nbsp;&nbsp; <span ref={timeElRef} style={{ color: 'var(--dim)' }}>0.0</span></div>
+            {placeMode && <div style={{ color: 'var(--accent)' }}>click + drag to launch</div>}
           </div>
 
           {skyOn && <SkyView dataRef={skyRef} dayLen={dayLen} tilt={tilt} />}

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -752,12 +752,12 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
 
   const btnStyle: React.CSSProperties = {
     padding: '10px 14px', borderRadius: 6, border: '1px solid var(--cp-border, #2a3550)',
-    background: 'rgba(255,255,255,0.06)', color: 'var(--cp-fg, #e8edf6)', cursor: 'pointer', fontSize: 14, flex: 1,
+    background: 'var(--panel-2)', color: 'var(--cp-fg, #e8edf6)', cursor: 'pointer', fontSize: 14, flex: 1,
   };
   const placeBtnStyle: React.CSSProperties = {
     ...btnStyle,
-    background: placeMode ? 'rgba(255, 212, 0, 0.18)' : 'rgba(255,255,255,0.06)',
-    borderColor: placeMode ? 'rgba(255,212,0,0.5)' : 'var(--cp-border, #2a3550)',
+    background: placeMode ? 'var(--accent-soft)' : 'var(--panel-2)',
+    borderColor: placeMode ? 'var(--accent)' : 'var(--cp-border, #2a3550)',
   };
 
   const note: React.CSSProperties = {

--- a/src/animations/TrinaryStars/lab/BasinMap.tsx
+++ b/src/animations/TrinaryStars/lab/BasinMap.tsx
@@ -549,9 +549,9 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
     setTimeout(render, mode === 'radspeed' ? 40 : 0);
   };
 
-  const panel: React.CSSProperties = { background: 'rgba(12,16,24,0.6)', border: '1px solid rgba(120,150,200,0.18)', borderRadius: 10, padding: 12 };
-  const h3: React.CSSProperties = { margin: '0 0 8px', font: '600 12px/1.2 ui-monospace, monospace', color: '#9ec7ff', letterSpacing: 0.4 };
-  const btn: React.CSSProperties = { padding: '6px 14px', borderRadius: 6, border: '1px solid var(--cp-border, #2a3550)', background: 'rgba(255,255,255,0.06)', color: '#e8edf6', cursor: 'pointer', fontSize: 13 };
+  const panel: React.CSSProperties = { background: 'var(--panel)', border: '1px solid var(--border)', borderRadius: 10, padding: 12 };
+  const h3: React.CSSProperties = { margin: '0 0 8px', font: '600 12px/1.2 ui-monospace, monospace', color: 'var(--dim)', letterSpacing: 0.4 };
+  const btn: React.CSSProperties = { padding: '6px 14px', borderRadius: 6, border: '1px solid var(--cp-border, #2a3550)', background: 'var(--panel-2)', color: 'var(--fg)', cursor: 'pointer', fontSize: 13 };
 
   return (
     <div style={{ ...panel, marginBottom: 12 }}>
@@ -620,12 +620,12 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
             </div>
           )}
           {engine === 'gpu' && gpuSupportsMap(metric, lens) && (
-            <div style={{ font: '11px/1.5 system-ui', color: '#6f7f99', marginTop: 4 }}>
+            <div style={{ font: '11px/1.5 system-ui', color: 'var(--dim)', marginTop: 4 }}>
               ⚡ Experimental WebGPU: 32-bit precision, so fine fractal detail can differ slightly from Workers/CPU. Falls back automatically on error.
             </div>
           )}
           <div style={{ display: 'flex', gap: 8, marginTop: 8 }}>
-            <button style={{ ...btn, background: busy ? 'rgba(255,212,0,0.18)' : 'rgba(70,217,138,0.18)' }} onClick={busy ? stop : render}>{busy ? '❚❚ Stop' : '▦ Render map'}</button>
+            <button style={{ ...btn, background: busy ? 'var(--accent-soft)' : 'var(--success-soft)' }} onClick={busy ? stop : render}>{busy ? '❚❚ Stop' : '▦ Render map'}</button>
             <button style={btn} onClick={() => {
               if (mode === 'radspeed' && system?.onBox) {
                 const d = DEFAULT_DOMAIN.radspeed;
@@ -646,18 +646,18 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
                   <DimPlot dim={dim} />
                   <div style={{ font: '11px/1.45 ui-monospace, monospace', whiteSpace: 'nowrap' }}>
                     <div>boundary&nbsp;<b style={{ color: '#ffd27f' }}>D ≈ {dim.D.toFixed(3)}</b></div>
-                    <div>uncertainty&nbsp;<b style={{ color: '#66f0ff' }}>α ≈ {dim.alpha.toFixed(3)}</b></div>
-                    <div style={{ color: '#9aa7bd' }}>boundary {(dim.boundary * 100).toFixed(0)}%</div>
+                    <div>uncertainty&nbsp;<b style={{ color: 'var(--accent-2)' }}>α ≈ {dim.alpha.toFixed(3)}</b></div>
+                    <div style={{ color: 'var(--dim)' }}>boundary {(dim.boundary * 100).toFixed(0)}%</div>
                   </div>
                 </div>
               ) : (
-                <div style={{ font: '11px/1.5 system-ui', color: '#4a566b' }}>The boundary’s box-counting dimension appears here after a render.</div>
+                <div style={{ font: '11px/1.5 system-ui', color: 'var(--dim-2)' }}>The boundary’s box-counting dimension appears here after a render.</div>
               )}
             </div>
           )}
 
           {lens === 'stat' ? (
-            <div style={{ marginTop: 10, font: '11px ui-monospace, monospace', color: '#9aa7bd' }}>
+            <div style={{ marginTop: 10, font: '11px ui-monospace, monospace', color: 'var(--dim)' }}>
               <div style={{
                 height: 10, borderRadius: 3, marginBottom: 2,
                 background: `linear-gradient(90deg, rgb(${statRamp(0).join(',')}), rgb(${statRamp(0.5).join(',')}), rgb(${statRamp(1).join(',')}))`,
@@ -676,7 +676,7 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
               ))}
             </div>
           ) : (
-            <div style={{ marginTop: 10, font: '11px ui-monospace, monospace', color: '#9aa7bd' }}>
+            <div style={{ marginTop: 10, font: '11px ui-monospace, monospace', color: 'var(--dim)' }}>
               <div style={{
                 height: 10, borderRadius: 3, marginBottom: 2,
                 background: `linear-gradient(90deg, rgb(${chaosRamp(0).join(',')}), rgb(${chaosRamp(0.33).join(',')}), rgb(${chaosRamp(0.66).join(',')}), rgb(${chaosRamp(1).join(',')}))`,
@@ -687,7 +687,7 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
               </div>
             </div>
           )}
-          <div style={{ font: '11px/1.5 system-ui', color: '#6f7f99', marginTop: 8 }}>
+          <div style={{ font: '11px/1.5 system-ui', color: 'var(--dim)', marginTop: 8 }}>
             {lens === 'stat'
               ? `Each pixel is a mini-census: ${statRuns} worlds that share these axes but randomise the other launch dimensions, colored by ${STAT_LABEL[statMetric]}. The Exact lens shows one world per pixel — switch to it to see the fractal final-state boundaries underneath these smooth statistics.`
               : metric === 'fate'
@@ -695,7 +695,7 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
                 : 'One pixel = one exact starting condition. Color = the planet’s Lyapunov exponent λ — how fast its future becomes unpredictable (blue = regular orbits, red = strongly chaotic). Drag a box to zoom. D is the box-counting dimension of the regular/chaotic frontier.'}
           </div>
           {mode === 'pos' && frame !== 'bary' && (
-            <div style={{ font: '11px/1.5 system-ui', color: '#8aa0c8', marginTop: 6 }}>
+            <div style={{ font: '11px/1.5 system-ui', color: 'var(--dim)', marginTop: 6 }}>
               Frame co-moving with <b>{frame === 's0' ? 'Star A' : frame === 's1' ? 'Star B' : 'Star C'}</b>: each pixel is a start offset from that star, launched with the star’s own velocity, so destinies are read relative to a moving star (⌖ marks it, pinned at the origin while the others orbit).
             </div>
           )}
@@ -709,23 +709,23 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
               onPointerDown={onDown} onPointerMove={onMove} onPointerUp={onUp} onPointerLeave={() => setHover('')} />
             <canvas ref={starCanvasRef} width={600} height={600}
               style={{ position: 'absolute', inset: 0, width: '100%', height: '100%', borderRadius: 6, pointerEvents: 'none' }} />
-            <div ref={overlayRef} style={{ position: 'absolute', display: 'none', border: '1px solid #66f0ff', background: 'rgba(102,240,255,0.12)', pointerEvents: 'none' }} />
+            <div ref={overlayRef} style={{ position: 'absolute', display: 'none', border: '1px solid var(--accent-2)', background: 'var(--accent-soft)', pointerEvents: 'none' }} />
             {busy && (
               <div style={{ position: 'absolute', left: 8, right: 8, bottom: 8, pointerEvents: 'none' }}>
-                <div style={{ font: '10px ui-monospace, monospace', color: '#dfeaff', textShadow: '0 1px 3px #000', marginBottom: 3 }}>
+                <div style={{ font: '10px ui-monospace, monospace', color: 'var(--fg)', textShadow: '0 1px 3px #000', marginBottom: 3 }}>
                   rendering… {Math.round(progress * 100)}%
                 </div>
                 <div style={{ height: 5, borderRadius: 3, background: 'rgba(0,0,0,0.55)', overflow: 'hidden' }}>
-                  <div style={{ height: '100%', width: `${progress * 100}%`, background: '#46d98a', borderRadius: 3 }} />
+                  <div style={{ height: '100%', width: `${progress * 100}%`, background: 'var(--success)', borderRadius: 3 }} />
                 </div>
               </div>
             )}
           </div>
-          <div style={{ display: 'flex', justifyContent: 'space-between', font: '10px ui-monospace, monospace', color: '#6f7f99', marginTop: 3 }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', font: '10px ui-monospace, monospace', color: 'var(--dim)', marginTop: 3 }}>
             <span>{AXIS_LABELS[mode][0]} {effDomain.a0.toFixed(2)}…{effDomain.a1.toFixed(2)}</span>
             <span>{AXIS_LABELS[mode][1]} {effDomain.b0.toFixed(2)}…{effDomain.b1.toFixed(2)}</span>
           </div>
-          <div style={{ font: '11px ui-monospace, monospace', color: '#9aa7bd', marginTop: 4, minHeight: 16 }}>{hover || 'Hover the map to inspect a starting condition.'}</div>
+          <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', marginTop: 4, minHeight: 16 }}>{hover || 'Hover the map to inspect a starting condition.'}</div>
         </div>
       </div>
     </div>

--- a/src/animations/TrinaryStars/lab/TrinaryLab.tsx
+++ b/src/animations/TrinaryStars/lab/TrinaryLab.tsx
@@ -381,9 +381,9 @@ export default function TrinaryLab() {
   const happyPct = n ? (agg!.counts.happy / n) : 0;
   const btn: React.CSSProperties = {
     padding: '8px 16px', borderRadius: 6, border: '1px solid var(--cp-border, #2a3550)',
-    background: 'rgba(255,255,255,0.06)', color: '#e8edf6', cursor: 'pointer', fontSize: 14,
+    background: 'var(--panel-2)', color: 'var(--fg)', cursor: 'pointer', fontSize: 14,
   };
-  const note: React.CSSProperties = { font: '11px/1.5 system-ui', color: '#6f7f99', marginTop: 4 };
+  const note: React.CSSProperties = { font: '11px/1.5 system-ui', color: 'var(--dim)', marginTop: 4 };
 
   const targetOptions: { value: TargetId; label: string }[] = [
     { value: 'bary', label: 'Barycenter' }, { value: 's0', label: 'Star 1' },
@@ -425,7 +425,7 @@ export default function TrinaryLab() {
         </div>
       )}
       <div style={note}>
-        How long each world is integrated, and the insolation band counted as habitable — used by <b style={{ color: '#9aa7bd' }}>both</b> the Destiny Map and the Census. Changing any setting clears the tally.
+        How long each world is integrated, and the insolation band counted as habitable — used by <b style={{ color: 'var(--fg)' }}>both</b> the Destiny Map and the Census. Changing any setting clears the tally.
       </div>
     </>
   );
@@ -444,7 +444,7 @@ export default function TrinaryLab() {
       </div>
       <div style={note}>
         Each dot is a candidate world: a launch radius and a speed (as a multiple of the local circular speed). The cyan box is what you’re sampling now — move the sliders to reshape it, or drag a box on the Destiny Map’s radius×speed plane. Below the amber line orbits tend to be bound; above the red √2 line they tend to escape.
-        <span style={{ color: '#9aa7bd' }}> Changing any setting clears the tally.</span>
+        <span style={{ color: 'var(--dim)' }}> Changing any setting clears the tally.</span>
       </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 10 }}>
         <button style={btn} title="New random ensemble seed" onClick={() => setBaseSeed((Math.random() * 4294967296) >>> 0)}>🎲 Reseed</button>
@@ -461,12 +461,12 @@ export default function TrinaryLab() {
   const transportNode = (
     <>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-        <button style={{ ...btn, background: running ? 'rgba(255,212,0,0.18)' : 'rgba(70,217,138,0.18)' }}
+        <button style={{ ...btn, background: running ? 'var(--accent-soft)' : 'var(--success-soft)' }}
           onClick={running ? pause : start}>{running ? '❚❚ Pause' : (n > 0 && n < targetN ? '▶ Resume' : '▶ Run census')}</button>
         <button style={btn} onClick={reset}>↺ Reset</button>
       </div>
       <div style={{ height: 8, borderRadius: 4, background: 'var(--track)', marginTop: 10, overflow: 'hidden' }}>
-        <div style={{ height: '100%', width: `${Math.min(100, n / Math.max(1, targetN) * 100)}%`, background: '#46d98a', transition: 'width 0.1s' }} />
+        <div style={{ height: '100%', width: `${Math.min(100, n / Math.max(1, targetN) * 100)}%`, background: 'var(--success)', transition: 'width 0.1s' }} />
       </div>
       <div style={{ font: '12px ui-monospace, monospace', color: 'var(--dim-2)', marginTop: 6 }}>
         {n.toLocaleString()} / {targetN.toLocaleString()} worlds{rate > 0 ? ` · ${rate.toFixed(0)} worlds/s` : ''}
@@ -476,8 +476,8 @@ export default function TrinaryLab() {
 
   const outcomesNode = (
     <>
-      <div style={{ font: '12px ui-monospace, monospace', color: '#9aa7bd', margin: '4px 0 8px' }}>
-        <b style={{ color: '#fff' }}>{n.toLocaleString()}</b> / {targetN.toLocaleString()} worlds ·{' '}
+      <div style={{ font: '12px ui-monospace, monospace', color: 'var(--dim)', margin: '4px 0 8px' }}>
+        <b style={{ color: 'var(--fg)' }}>{n.toLocaleString()}</b> / {targetN.toLocaleString()} worlds ·{' '}
         <b style={{ color: '#46d98a' }}>{pct(happyPct)}</b> happy endings
       </div>
       {OUTCOMES.map(o => {
@@ -487,9 +487,9 @@ export default function TrinaryLab() {
           <div key={o} style={{ marginBottom: 7 }}>
             <div style={{ display: 'flex', justifyContent: 'space-between', font: '11px ui-monospace, monospace' }}>
               <span style={{ color: OUTCOME_META[o].color }}>{OUTCOME_META[o].label}</span>
-              <span style={{ color: '#9aa7bd' }}>{pct(frac)}</span>
+              <span style={{ color: 'var(--dim)' }}>{pct(frac)}</span>
             </div>
-            <div style={{ height: 6, borderRadius: 3, background: 'rgba(255,255,255,0.06)', marginTop: 2 }}>
+            <div style={{ height: 6, borderRadius: 3, background: 'var(--track)', marginTop: 2 }}>
               <div style={{ height: '100%', width: `${frac * 100}%`, background: OUTCOME_META[o].color, borderRadius: 3 }} />
             </div>
           </div>
@@ -497,7 +497,7 @@ export default function TrinaryLab() {
       })}
       <div style={{ display: 'flex', flexDirection: 'column', gap: 3, marginTop: 10, font: '12px ui-monospace, monospace' }}>
         <span>mean habitable&nbsp;<b style={{ color: '#46d98a' }}>{agg ? pct(agg.habMean) : '—'}</b>
-          {agg && agg.n > 1 ? <span style={{ color: '#6f7f99' }}> ±{(agg.habStderr * 100).toFixed(2)}</span> : null}</span>
+          {agg && agg.n > 1 ? <span style={{ color: 'var(--dim-2)' }}> ±{(agg.habStderr * 100).toFixed(2)}</span> : null}</span>
         <span>mean stable era&nbsp;<b style={{ color: '#9ec7ff' }}>{agg ? agg.longMean.toFixed(1) : '—'}</b></span>
         <span>longest ever&nbsp;<b style={{ color: '#ffd27f' }}>{agg ? agg.longMax.toFixed(1) : '—'}</b></span>
       </div>
@@ -506,11 +506,11 @@ export default function TrinaryLab() {
 
   const distNode = (
     <>
-      <div style={{ font: '11px ui-monospace, monospace', color: '#9aa7bd', margin: '2px 0' }}>habitable fraction of lifetime</div>
+      <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '2px 0' }}>habitable fraction of lifetime</div>
       <Histogram data={agg?.histHab ?? []} max={agg?.histMax.hab ?? 1} color="#46d98a" domain={['0%', '100%']} />
-      <div style={{ font: '11px ui-monospace, monospace', color: '#9aa7bd', margin: '8px 0 2px' }}>longest stable era</div>
+      <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '8px 0 2px' }}>longest stable era</div>
       <Histogram data={agg?.histLong ?? []} max={agg?.histMax.long ?? 1} color="#9ec7ff" domain={['0', tMax.toFixed(0)]} />
-      <div style={{ font: '11px ui-monospace, monospace', color: '#9aa7bd', margin: '8px 0 2px' }}>time to star ejection (happy runs)</div>
+      <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '8px 0 2px' }}>time to star ejection (happy runs)</div>
       <Histogram data={agg?.histEject ?? []} max={agg?.histMax.eject ?? 1} color="#ffd27f" domain={['0', tMax.toFixed(0)]} />
       <div style={note}>Distributions sharpen as N grows.</div>
     </>
@@ -518,17 +518,17 @@ export default function TrinaryLab() {
 
   const recordsNode = (
     <>
-      <div style={{ font: '11px ui-monospace, monospace', color: '#9aa7bd', margin: '2px 0 6px' }}>longest stable eras</div>
+      <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '2px 0 6px' }}>longest stable eras</div>
       <table style={{ width: '100%', borderCollapse: 'collapse', font: '11px ui-monospace, monospace' }}>
         <thead>
-          <tr style={{ color: '#6f7f99', textAlign: 'right' }}>
+          <tr style={{ color: 'var(--dim-2)', textAlign: 'right' }}>
             <th style={{ textAlign: 'left' }}>#</th><th>stable</th><th>hab%</th><th>r</th><th>v</th><th>dir</th><th>outcome</th>
           </tr>
         </thead>
         <tbody>
           {(agg?.records ?? []).map((r, i) => (
-            <tr key={i} style={{ textAlign: 'right', borderTop: '1px solid rgba(255,255,255,0.05)' }}>
-              <td style={{ textAlign: 'left', color: '#6f7f99' }}>{i + 1}</td>
+            <tr key={i} style={{ textAlign: 'right', borderTop: '1px solid var(--border)' }}>
+              <td style={{ textAlign: 'left', color: 'var(--dim-2)' }}>{i + 1}</td>
               <td style={{ color: '#ffd27f' }}>{r.longestHabitable.toFixed(1)}</td>
               <td>{(r.habitableFraction * 100).toFixed(0)}</td>
               <td>{r.radius.toFixed(2)}</td>
@@ -537,7 +537,7 @@ export default function TrinaryLab() {
               <td style={{ color: OUTCOME_META[r.outcome].color }}>{r.outcome}</td>
             </tr>
           ))}
-          {!agg?.records.length && <tr><td colSpan={7} style={{ color: '#6f7f99', padding: '8px 0' }}>Run the census to populate…</td></tr>}
+          {!agg?.records.length && <tr><td colSpan={7} style={{ color: 'var(--dim-2)', padding: '8px 0' }}>Run the census to populate…</td></tr>}
         </tbody>
       </table>
     </>
@@ -598,7 +598,7 @@ export default function TrinaryLab() {
               <span style={{ color: 'var(--dim-2)' }}>happy endings</span>
             </div>
             <div style={{ height: 8, borderRadius: 4, background: 'var(--track)', marginTop: 8, overflow: 'hidden' }}>
-              <div style={{ height: '100%', width: `${Math.min(100, (n / targetN) * 100)}%`, background: '#46d98a', transition: 'width 0.1s' }} />
+              <div style={{ height: '100%', width: `${Math.min(100, (n / targetN) * 100)}%`, background: 'var(--success)', transition: 'width 0.1s' }} />
             </div>
           </div>
           <div style={panel}>

--- a/src/animations/TrinaryStars/lab/TrinaryLab.tsx
+++ b/src/animations/TrinaryStars/lab/TrinaryLab.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Workspace from '../../../chrome/workspace/Workspace';
-import type { LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../../chrome/workspace/types';
+import type { ActionDef, LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../../chrome/workspace/types';
 import { Slider, Pills } from '../../../components/ControlPanel';
 import { SCENARIOS, getScenario, DEFAULT_CLASSIFY, type TargetId, type Outcome, type RunResult } from '@/lib/nbody';
 import { Aggregator, OUTCOMES, type AggSnapshot } from './ensemble';
@@ -16,10 +16,12 @@ const HAS_WORKERS = typeof Worker !== 'undefined';
 const HAS_GPU = gpuAvailable();
 type Engine = 'cpu' | 'workers' | 'gpu';
 
-/** Top-bar mode pills: the Observatory ↔ Lab switch (replaces the old tab bar).
- *  Switching sets the hash, which Trinary.tsx observes. */
+/** Top-bar mode pills: the Explore ↔ Lab switch (replaces the old tab bar).
+ *  Label "Explore" (not "Observatory", which collides with the dark skin name);
+ *  must match TrinaryStars.tsx's MODES. Switching sets the hash, which
+ *  Trinary.tsx observes. */
 const MODES: WorkspaceMode[] = [
-  { id: 'observatory', label: 'Observatory' },
+  { id: 'observatory', label: 'Explore' },
   { id: 'lab', label: 'Lab' },
 ];
 
@@ -57,10 +59,10 @@ const OUTCOME_META: Record<Outcome, { label: string; color: string }> = {
 };
 
 const panel: React.CSSProperties = {
-  background: 'rgba(12,16,24,0.6)', border: '1px solid rgba(120,150,200,0.18)',
+  background: 'var(--panel)', border: '1px solid var(--border)',
   borderRadius: 10, padding: 12,
 };
-const h3: React.CSSProperties = { margin: '0 0 8px', font: '600 12px/1.2 ui-monospace, monospace', color: '#9ec7ff', letterSpacing: 0.4 };
+const h3: React.CSSProperties = { margin: '0 0 8px', font: '600 12px/1.2 ui-monospace, monospace', color: 'var(--dim)', letterSpacing: 0.4 };
 
 function Histogram({ data, max, color, domain }: { data: number[]; max: number; color: string; domain: [string, string] }) {
   const ref = useRef<HTMLCanvasElement>(null);
@@ -445,19 +447,30 @@ export default function TrinaryLab() {
         <span style={{ color: '#9aa7bd' }}> Changing any setting clears the tally.</span>
       </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 10 }}>
-        <button style={{ ...btn, background: running ? 'rgba(255,212,0,0.18)' : 'rgba(70,217,138,0.18)' }}
-          onClick={running ? pause : start}>{running ? '❚❚ Pause' : (n > 0 && n < targetN ? '▶ Resume' : '▶ Run census')}</button>
-        <button style={btn} onClick={reset}>↺ Reset</button>
         <button style={btn} title="New random ensemble seed" onClick={() => setBaseSeed((Math.random() * 4294967296) >>> 0)}>🎲 Reseed</button>
         <button style={btn} onClick={copyLink}>{copied ? '✓ Copied' : '🔗 Copy link'}</button>
         <button style={btn} onClick={exportJSON} disabled={!agg}>⬇ JSON</button>
         <button style={btn} onClick={exportCSV} disabled={!agg}>⬇ CSV</button>
       </div>
-      {rate > 0 && (
-        <div style={{ font: '12px ui-monospace, monospace', color: '#6f7f99', marginTop: 6 }}>
-          {rate.toFixed(0)} worlds/s
-        </div>
-      )}
+    </>
+  );
+
+  // Transport for the census run. The same verbs (Run / Pause / Resume / Reset)
+  // project to the always-on action strip (`actions` below); reseed, exports and
+  // the sampling box stay in the Sampling panel.
+  const transportNode = (
+    <>
+      <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
+        <button style={{ ...btn, background: running ? 'rgba(255,212,0,0.18)' : 'rgba(70,217,138,0.18)' }}
+          onClick={running ? pause : start}>{running ? '❚❚ Pause' : (n > 0 && n < targetN ? '▶ Resume' : '▶ Run census')}</button>
+        <button style={btn} onClick={reset}>↺ Reset</button>
+      </div>
+      <div style={{ height: 8, borderRadius: 4, background: 'var(--track)', marginTop: 10, overflow: 'hidden' }}>
+        <div style={{ height: '100%', width: `${Math.min(100, n / Math.max(1, targetN) * 100)}%`, background: '#46d98a', transition: 'width 0.1s' }} />
+      </div>
+      <div style={{ font: '12px ui-monospace, monospace', color: 'var(--dim-2)', marginTop: 6 }}>
+        {n.toLocaleString()} / {targetN.toLocaleString()} worlds{rate > 0 ? ` · ${rate.toFixed(0)} worlds/s` : ''}
+      </div>
     </>
   );
 
@@ -533,7 +546,8 @@ export default function TrinaryLab() {
   const sections: SectionDef[] = [
     { id: 'system', title: 'System', arch: 'subject', node: systemNode, estHeight: 540 },
     { id: 'sim', title: 'Simulation', arch: 'lab', node: simNode, estHeight: 380 },
-    { id: 'sampling', title: 'Sampling', arch: 'lab', node: samplingNode, estHeight: 620 },
+    { id: 'sampling', title: 'Sampling', arch: 'lab', node: samplingNode, estHeight: 520 },
+    { id: 'transport', title: 'Census run', arch: 'playback', node: transportNode, estHeight: 150 },
     { id: 'outcomes', title: 'Outcomes', arch: 'readout', node: outcomesNode, estHeight: 380 },
     { id: 'dist', title: 'Distributions', arch: 'readout', node: distNode, estHeight: 420 },
     { id: 'records', title: 'Records', arch: 'readout', node: recordsNode, estHeight: 340 },
@@ -542,8 +556,8 @@ export default function TrinaryLab() {
   /* ---- view windows: the two instruments ---- */
 
   const viewWrap: React.CSSProperties = {
-    position: 'absolute', inset: 0, overflow: 'auto', background: '#05060a',
-    color: '#cfe0f5', font: '13px/1.5 system-ui, sans-serif', padding: 12,
+    position: 'absolute', inset: 0, overflow: 'auto', background: 'var(--viz-bg)',
+    color: 'var(--fg)', font: '13px/1.5 system-ui, sans-serif', padding: 12,
   };
 
   const views: ViewDef[] = [
@@ -553,12 +567,12 @@ export default function TrinaryLab() {
       defaultRect: { x: 372, y: 16, w: 712, h: 640 },
       node: (
         <div style={viewWrap}>
-          <div style={{ ...panel, marginBottom: 12, font: '12px/1.6 system-ui', color: '#9aa7bd' }}>
-            Pick a slice of launch space (<b style={{ color: '#cfe8ff' }}>Plane</b>) and a way to color it. With the
-            <b style={{ color: '#cfe8ff' }}> Exact</b> lens each pixel is one precise world — its boundaries stay fractal at
-            every zoom. With the <b style={{ color: '#cfe8ff' }}>Statistical</b> lens each pixel is a mini-census of many
-            worlds, painting the odds of a happy ending. <b style={{ color: '#cfe8ff' }}>Drag a box</b> to zoom; <b style={{ color: '#cfe8ff' }}>click</b> a
-            point to open that world in the single-run Observatory (in a new tab, so your map stays put).
+          <div style={{ ...panel, marginBottom: 12, font: '12px/1.6 system-ui', color: 'var(--dim)' }}>
+            Pick a slice of launch space (<b style={{ color: 'var(--accent)' }}>Plane</b>) and a way to color it. With the
+            <b style={{ color: 'var(--accent)' }}> Exact</b> lens each pixel is one precise world — its boundaries stay fractal at
+            every zoom. With the <b style={{ color: 'var(--accent)' }}>Statistical</b> lens each pixel is a mini-census of many
+            worlds, painting the odds of a happy ending. <b style={{ color: 'var(--accent)' }}>Drag a box</b> to zoom; <b style={{ color: 'var(--accent)' }}>click</b> a
+            point to open that world in the single-run Explore view (in a new tab, so your map stays put).
           </div>
           <BasinMap ref={basinRef} cfg={cfg} system={{
             box: { rMin, rMax, fMin, fMax },
@@ -576,14 +590,14 @@ export default function TrinaryLab() {
         <div style={viewWrap}>
           <div style={{ ...panel, marginBottom: 12 }}>
             <div style={{ display: 'flex', alignItems: 'baseline', gap: 12, flexWrap: 'wrap' }}>
-              <span style={{ font: '700 26px/1 ui-monospace, monospace', color: '#fff' }}>{n.toLocaleString()}</span>
-              <span style={{ color: '#6f7f99' }}>/ {targetN.toLocaleString()} worlds explored</span>
+              <span style={{ font: '700 26px/1 ui-monospace, monospace', color: 'var(--fg)' }}>{n.toLocaleString()}</span>
+              <span style={{ color: 'var(--dim-2)' }}>/ {targetN.toLocaleString()} worlds explored</span>
               <span style={{ flex: 1 }} />
-              {rate > 0 && <span style={{ font: '12px ui-monospace, monospace', color: '#6f7f99' }}>{rate.toFixed(0)} worlds/s</span>}
+              {rate > 0 && <span style={{ font: '12px ui-monospace, monospace', color: 'var(--dim-2)' }}>{rate.toFixed(0)} worlds/s</span>}
               <span style={{ font: '700 20px ui-monospace, monospace', color: '#46d98a' }}>{pct(happyPct)}</span>
-              <span style={{ color: '#6f7f99' }}>happy endings</span>
+              <span style={{ color: 'var(--dim-2)' }}>happy endings</span>
             </div>
-            <div style={{ height: 8, borderRadius: 4, background: 'rgba(255,255,255,0.08)', marginTop: 8, overflow: 'hidden' }}>
+            <div style={{ height: 8, borderRadius: 4, background: 'var(--track)', marginTop: 8, overflow: 'hidden' }}>
               <div style={{ height: '100%', width: `${Math.min(100, (n / targetN) * 100)}%`, background: '#46d98a', transition: 'width 0.1s' }} />
             </div>
           </div>
@@ -610,13 +624,28 @@ export default function TrinaryLab() {
     },
     {
       id: 'census', name: 'Census', sub: 'Thousands of worlds, tallied', icon: 'flask',
-      open: { sampling: { x: 84, y: 18 }, outcomes: { x: 366, y: 18 }, dist: { x: 366, y: 440 } },
+      open: { sampling: { x: 84, y: 18 }, transport: { x: 84, y: 548 }, outcomes: { x: 366, y: 18 }, dist: { x: 366, y: 440 } },
       views: { map: { open: false }, census: { x: 648, y: 16, w: 470, h: 470, open: true } },
     },
   ];
 
+  /* Always-on action strip — projection of the Drive-tier Census-run panel's
+     transport verbs (the sampling box, exports and reseed stay in the Sampling
+     panel). The primary button mirrors the panel's Run / Pause / Resume logic. */
+  const actions: ActionDef[] = [
+    {
+      id: 'run',
+      icon: running ? 'pause' : 'flask',
+      label: running ? 'Pause' : (n > 0 && n < targetN ? 'Resume' : 'Run census'),
+      primary: true, active: running, sectionId: 'transport',
+      onClick: running ? pause : start,
+    },
+    { id: 'reset', icon: 'reset', label: 'Reset', sectionId: 'transport', onClick: reset },
+  ];
+
   return (
     <Workspace
+      actions={actions}
       appId="trinary-lab"
       title="Trinary System · Lab"
       subtitle={preset.name}

--- a/src/chrome/previews.tsx
+++ b/src/chrome/previews.tsx
@@ -65,6 +65,41 @@ function useCanvas(draw: DrawFn, deps: React.DependencyList) {
 
 const canvasStyle: React.CSSProperties = { display: 'block', width: '100%', height: '100%' };
 
+/** Live theme tokens for a preview, read fresh each draw so the card tracks the
+ *  active skin (not just light/dark). `light` supplies the fallback. */
+function themeInk(light: boolean) {
+  const cs = typeof document !== 'undefined' ? getComputedStyle(document.documentElement) : null;
+  const pick = (n: string, fb: string) => (cs?.getPropertyValue(n).trim() || fb);
+  return {
+    bg:      pick('--viz-bg', light ? '#f4f3ef' : '#04060c'),
+    fg:      pick('--fg',     light ? '#1d1c18' : '#eef1f7'),
+    dim:     pick('--dim',    light ? '#6a6354' : '#8d96ab'),
+    accent:  pick('--accent', light ? '#b67d10' : '#ffce47'),
+    accent2: pick('--accent-2', light ? '#1d8a78' : '#5fe3cd'),
+    data6:   pick('--data-6', light ? '#c23f6c' : '#ff6f9c'), // a distinct 3rd (pink/magenta)
+  };
+}
+
+/** Parse a token color to [r,g,b] bytes for the pixel-buffer previews (fractal/
+ *  Julia write into ImageData). Handles #rgb / #rrggbb / rgb(); falls back to fb. */
+function rgbBytes(col: string, fb: [number, number, number]): [number, number, number] {
+  const s = col.trim();
+  let m = /^#([0-9a-f]{3})$/i.exec(s);
+  if (m) { const h = m[1]; return [parseInt(h[0] + h[0], 16), parseInt(h[1] + h[1], 16), parseInt(h[2] + h[2], 16)]; }
+  m = /^#([0-9a-f]{6})$/i.exec(s);
+  if (m) { const h = m[1]; return [parseInt(h.slice(0, 2), 16), parseInt(h.slice(2, 4), 16), parseInt(h.slice(4, 6), 16)]; }
+  m = /^rgba?\(([^)]+)\)$/i.exec(s);
+  if (m) { const p = m[1].split(',').map(v => parseFloat(v)); if (p.length >= 3) return [p[0], p[1], p[2]]; }
+  return fb;
+}
+
+/** A token color rendered as rgba() at the given alpha, so faint/fading strokes
+ *  can keep their intent while following the skin (theme tokens are opaque). */
+function withAlpha(col: string, a: number): string {
+  const [r, g, b] = rgbBytes(col, [128, 128, 128]);
+  return `rgba(${Math.round(r)},${Math.round(g)},${Math.round(b)},${a})`;
+}
+
 /** Deterministic PRNG so module-scope "simulations" are stable across loads. */
 function mulberry32(seed: number) {
   let a = seed >>> 0;
@@ -93,14 +128,14 @@ function ParticlePreview({ light }: { light: boolean }) {
     }
     pts.current = arr;
   }
-  const bg = light ? '#f4f3ef' : '#000';
   // axis hues match lib/particles AXIS_COLORS (x 0 · y .25 · u .5 · v .75)
   const AXES: Array<[number, number, number, number, number]> = [
     [1.5, 0, 0, 0, 0], [0, 1.5, 0, 0, 0.25], [0, 0, 1.5, 0, 0.5], [0, 0, 0, 1.5, 0.75],
   ];
   const ref = useCanvas((ctx, W, H, t) => {
+    const ink = themeInk(light); // hue-based preview: only the bg follows the skin
     ctx.globalCompositeOperation = 'source-over';
-    ctx.fillStyle = bg;
+    ctx.fillStyle = ink.bg;
     ctx.fillRect(0, 0, W, H);
     const cx = W / 2, cy = H / 2;
     const scale = Math.min(W, H) * 0.30;
@@ -145,10 +180,10 @@ function ParticlePreview({ light }: { light: boolean }) {
 /* Mirrors the app's two view windows: the z-plane grid on the left sheet, its
    image under f on the right, with a probe line and its image linking them. */
 function PlanePreview({ light }: { light: boolean }) {
-  const bg = light ? '#f4f3ef' : '#000';
   const ref = useCanvas((ctx, W, H, t) => {
+    const ink = themeInk(light); // hue-based preview: only bg + labels follow the skin
     ctx.globalCompositeOperation = 'source-over';
-    ctx.fillStyle = bg;
+    ctx.fillStyle = ink.bg;
     ctx.fillRect(0, 0, W, H);
     const LINES = 9, SAMPLES = 28, R = 1.15;
     // a sheet = a gently tilted card; (u, v) in math coords → screen
@@ -201,7 +236,7 @@ function PlanePreview({ light }: { light: boolean }) {
     drawLine(range, k => [c, k * 2 * R - R], true, light ? 0.07 : 0.13, 0.95, probeW);
     // sheet labels
     ctx.globalCompositeOperation = 'source-over';
-    ctx.fillStyle = light ? 'rgba(40,40,50,0.75)' : 'rgba(255,255,255,0.65)';
+    ctx.fillStyle = ink.dim;
     ctx.font = `${Math.max(9, W * 0.032)}px ui-monospace, monospace`;
     const [zx, zy] = domain(-R, -R);
     const [fx, fy] = range(-R, -R);
@@ -216,6 +251,7 @@ function FractalPreview({ light }: { light: boolean }) {
   const field = useRef<{ its: Int16Array; rw: number; rh: number } | null>(null);
   const off = useRef<HTMLCanvasElement | null>(null);
   const ref = useCanvas((ctx, W, H, t) => {
+    const ink = themeInk(light); // hue-based preview: escape palette stays rainbow; only the set interior (the flat "background") follows the skin
     const rw = 260, rh = Math.max(1, Math.round(260 * H / Math.max(1, W)));
     const maxIt = 90;
     if (!field.current || field.current.rw !== rw || field.current.rh !== rh) {
@@ -254,11 +290,11 @@ function FractalPreview({ light }: { light: boolean }) {
       lut[i * 3] = r; lut[i * 3 + 1] = g; lut[i * 3 + 2] = b;
     }
     const { its } = field.current;
-    const inside = light ? 245 : 8;
+    const [ir, ig, ib] = rgbBytes(ink.bg, light ? [245, 245, 245] : [8, 8, 8]);
     for (let i = 0; i < its.length; i++) {
       const k = i * 4, it = its[i];
       if (it >= maxIt) {
-        img.data[k] = img.data[k + 1] = img.data[k + 2] = inside;
+        img.data[k] = ir; img.data[k + 1] = ig; img.data[k + 2] = ib;
       } else {
         const j = Math.min(255, Math.round((it / maxIt) * 255)) * 3;
         img.data[k] = lut[j]; img.data[k + 1] = lut[j + 1]; img.data[k + 2] = lut[j + 2];
@@ -278,6 +314,9 @@ function JuliaPreview({ light }: { light: boolean }) {
   const jul = useRef<HTMLCanvasElement | null>(null);
   const MX = -0.6, MSPAN = 3.0; // mandel pane: re ∈ [-2.1, 0.9]
   const ref = useCanvas((ctx, W, H, t) => {
+    const ink = themeInk(light); // hue-based preview: escape coloring stays; set interiors + marker follow the skin
+    const [bgR, bgG, bgB] = rgbBytes(ink.bg, light ? [230, 230, 230] : [14, 14, 14]);
+    const [accR, accG, accB] = rgbBytes(ink.accent, light ? [180, 120, 30] : [255, 200, 80]);
     const split = Math.round(W * 0.42);
     const maxIt = 60;
     if (!mandel.current) {
@@ -297,7 +336,7 @@ function JuliaPreview({ light }: { light: boolean }) {
           }
           const k = (px + py * rw) * 4;
           if (it >= maxIt) {
-            img.data[k] = img.data[k + 1] = img.data[k + 2] = light ? 230 : 14;
+            img.data[k] = bgR; img.data[k + 1] = bgG; img.data[k + 2] = bgB;
           } else {
             const m = it / maxIt;
             const v = light ? 235 - m * 160 : 25 + m * 120;
@@ -333,7 +372,8 @@ function JuliaPreview({ light }: { light: boolean }) {
           }
           const k = (px + py * rw) * 4;
           if (it >= jIt) {
-            img.data[k] = light ? 180 : 255; img.data[k + 1] = light ? 120 : 200; img.data[k + 2] = light ? 30 : 80;
+            // filled Julia set tinted by the skin accent (the gradient below stays intrinsic escape coloring)
+            img.data[k] = accR; img.data[k + 1] = accG; img.data[k + 2] = accB;
           } else {
             const m = it / jIt;
             const v = light ? 244 - m * 130 : m * 110;
@@ -352,10 +392,10 @@ function JuliaPreview({ light }: { light: boolean }) {
     ctx.fillRect(split - 1, 0, 2, H);
     const mpx = ((cr - MX) / MSPAN + 0.5) * split;
     const mpy = ((ci / (MSPAN * (H / Math.max(1, split)))) + 0.5) * H;
-    ctx.strokeStyle = light ? '#b67d10' : '#ffd400';
+    ctx.strokeStyle = ink.accent;
     ctx.lineWidth = Math.max(1, W * 0.004);
     ctx.beginPath(); ctx.arc(mpx, mpy, Math.max(3, W * 0.012), 0, 7); ctx.stroke();
-    ctx.fillStyle = light ? '#b67d10' : '#ffd400';
+    ctx.fillStyle = ink.accent;
     ctx.beginPath(); ctx.arc(mpx, mpy, Math.max(1.5, W * 0.004), 0, 7); ctx.fill();
   }, [light]);
   return <canvas ref={ref} style={canvasStyle} />;
@@ -363,9 +403,9 @@ function JuliaPreview({ light }: { light: boolean }) {
 
 /* ---- Topology walk: first-person flight down a twisting corridor ---------- */
 function CorridorPreview({ light }: { light: boolean }) {
-  const bg = light ? '#f4f3ef' : '#04060c';
   const ref = useCanvas((ctx, W, H, t) => {
-    ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
+    const ink = themeInk(light);
+    ctx.fillStyle = ink.bg; ctx.fillRect(0, 0, W, H);
     const s = t * 1.3;
     const f = s - Math.floor(s);
     const cx = W / 2 + Math.sin(s * 0.45) * W * 0.02;
@@ -386,9 +426,7 @@ function CorridorPreview({ light }: { light: boolean }) {
       }
       const fade = Math.min(1, 1.8 / Z);
       ctx.lineWidth = Math.max(1, (W * 0.0035) * fade);
-      ctx.strokeStyle = light
-        ? `rgba(40,44,66,${0.65 * fade})`
-        : `rgba(120,225,255,${0.75 * fade})`;
+      ctx.strokeStyle = withAlpha(ink.accent2, (light ? 0.65 : 0.75) * fade);
       ctx.beginPath();
       for (let j = 0; j <= 4; j++) {
         const [x, y] = corners[j % 4];
@@ -396,9 +434,7 @@ function CorridorPreview({ light }: { light: boolean }) {
       }
       ctx.stroke();
       if (prev) {
-        ctx.strokeStyle = light
-          ? `rgba(40,44,66,${0.3 * fade})`
-          : `rgba(120,225,255,${0.35 * fade})`;
+        ctx.strokeStyle = withAlpha(ink.accent2, (light ? 0.3 : 0.35) * fade);
         ctx.beginPath();
         for (let j = 0; j < 4; j++) {
           ctx.moveTo(corners[j][0], corners[j][1]);
@@ -415,13 +451,15 @@ function CorridorPreview({ light }: { light: boolean }) {
 /* ---- Trinary: three stars + a doomed orbiting world ----------------------- */
 function TrinaryPreview({ light }: { light: boolean }) {
   const trail = useRef<[number, number][]>([]);
-  const bg = light ? '#f4f3ef' : '#04040a';
   const ref = useCanvas((ctx, W, H, t) => {
-    ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
+    const ink = themeInk(light);
+    ctx.fillStyle = ink.bg; ctx.fillRect(0, 0, W, H);
     const cx = W / 2, cy = H / 2, R = Math.min(W, H) * 0.22;
+    // three stars in three distinct skin colors (was fixed gold/orange/cyan)
+    const starCols = [ink.accent, ink.data6, ink.accent2];
     const stars = [0, 1, 2].map(i => {
       const a = t * 0.25 + i * (Math.PI * 2 / 3);
-      return { x: cx + Math.cos(a) * R, y: cy + Math.sin(a) * R, c: ['#ffd400', '#ff7a59', '#5ad1ff'][i] };
+      return { x: cx + Math.cos(a) * R, y: cy + Math.sin(a) * R, c: starCols[i] };
     });
     // planet position: chaotic-ish lissajous influenced by time
     const pa = t * 0.9, pr = R * (1.5 + 0.5 * Math.sin(t * 0.5));
@@ -440,7 +478,7 @@ function TrinaryPreview({ light }: { light: boolean }) {
       ctx.fillStyle = g; ctx.beginPath(); ctx.arc(s.x, s.y, R * 0.5, 0, 7); ctx.fill();
       ctx.fillStyle = s.c; ctx.beginPath(); ctx.arc(s.x, s.y, Math.max(2, W * 0.006), 0, 7); ctx.fill();
     });
-    ctx.fillStyle = light ? '#222' : '#fff';
+    ctx.fillStyle = ink.fg;
     ctx.beginPath(); ctx.arc(px, py, Math.max(1.5, W * 0.004), 0, 7); ctx.fill();
   }, [light]);
   return <canvas ref={ref} style={canvasStyle} />;
@@ -459,11 +497,14 @@ function SortingPreview({ light }: { light: boolean }) {
     return a;
   };
   if (!sim.current) sim.current = { arr: shuffled(), agents: [2, 11, 20, 29], last: 0, doneAt: -1 };
-  const bg = light ? '#f4f3ef' : '#05060d';
-  const pal = light
+  const palFallback = light
     ? ['#b3457a', '#7a4fbf', '#1d7a9e', '#b06a10', '#1d8a5e']
     : ['#ff5aa6', '#b78cff', '#5ad1ff', '#ffb04d', '#3de8b0'];
   const ref = useCanvas((ctx, W, H, t) => {
+    const ink = themeInk(light);
+    // value-band palette from the skin's categorical data tokens (data-2..6)
+    const cs = typeof document !== 'undefined' ? getComputedStyle(document.documentElement) : null;
+    const pal = palFallback.map((fb, i) => (cs?.getPropertyValue(`--data-${i + 2}`).trim() || fb));
     const s = sim.current!;
     const sorted = s.arr.every((v, i) => i === 0 || s.arr[i - 1] <= v);
     if (sorted && s.doneAt < 0) s.doneAt = t;
@@ -479,7 +520,7 @@ function SortingPreview({ light }: { light: boolean }) {
         return ni >= N - 1 ? 0 : ni;
       });
     }
-    ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = ink.bg; ctx.fillRect(0, 0, W, H);
     const mid = H * 0.5, m = W * 0.05, bw = (W - 2 * m) / N, amp = H * 0.38;
     for (let i = 0; i < N; i++) {
       const v = s.arr[i];
@@ -494,9 +535,9 @@ function SortingPreview({ light }: { light: boolean }) {
     s.agents.forEach(i => {
       const x = m + i * bw + bw * 0.5;
       const r = Math.max(2.4, W * 0.0085);
-      ctx.fillStyle = light ? '#222' : '#fff';
+      ctx.fillStyle = ink.fg;
       ctx.beginPath(); ctx.arc(x, mid, r, 0, 7); ctx.fill();
-      ctx.strokeStyle = light ? 'rgba(34,34,34,0.35)' : 'rgba(255,255,255,0.35)';
+      ctx.strokeStyle = withAlpha(ink.fg, 0.35);
       ctx.lineWidth = Math.max(1, W * 0.003);
       ctx.beginPath(); ctx.arc(x, mid, r * 2, 0, 7); ctx.stroke();
     });
@@ -521,9 +562,9 @@ const LATTICE = (() => {
 })();
 
 function MatrixPreview({ light }: { light: boolean }) {
-  const bg = light ? '#f4f3ef' : '#05060d';
   const ref = useCanvas((ctx, W, H, t) => {
-    ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
+    const ink = themeInk(light);
+    ctx.fillStyle = ink.bg; ctx.fillRect(0, 0, W, H);
     const { n, heat, perms } = LATTICE;
     const cell = Math.min(W * 0.8 / n, H * 0.8 / n);
     const ox = (W - cell * n) / 2, oy = (H - cell * n) / 2;
@@ -532,9 +573,10 @@ function MatrixPreview({ light }: { light: boolean }) {
         const v = heat[i][j];
         const shimmer = 0.06 * Math.sin(t * 1.2 + i * 0.9 + j * 1.3);
         const a = Math.max(0, Math.min(1, v + shimmer));
-        ctx.fillStyle = light
-          ? `hsla(${35 + a * 10},${50 + a * 30}%,${88 - a * 45}%,1)`
-          : `hsla(${230 - a * 200},75%,${14 + a * 42}%,1)`;
+        // preference-intensity heatmap as an alpha ramp of the skin's secondary accent
+        ctx.fillStyle = ink.bg;
+        ctx.fillRect(ox + j * cell + 1, oy + i * cell + 1, cell - 2, cell - 2);
+        ctx.fillStyle = withAlpha(ink.accent2, 0.12 + a * 0.8);
         ctx.fillRect(ox + j * cell + 1, oy + i * cell + 1, cell - 2, cell - 2);
       }
     }
@@ -544,7 +586,7 @@ function MatrixPreview({ light }: { light: boolean }) {
     const k2 = (k + 1) % perms.length;
     const f = (t % PERIOD) / PERIOD;
     const ease = f < 0.3 ? f / 0.3 : 1; // slide early, rest late
-    ctx.strokeStyle = light ? '#b67d10' : '#ffd400';
+    ctx.strokeStyle = ink.accent;
     ctx.lineWidth = Math.max(1.4, W * 0.005);
     for (let i = 0; i < n; i++) {
       const j = perms[k][i] + (perms[k2][i] - perms[k][i]) * ease;
@@ -566,14 +608,15 @@ function PolygonPreview({ light }: { light: boolean }) {
     const dt = Math.min(0.05, Math.max(0, t - c.pt));
     c.pt = t;
     c.x += 0.1 * dt; c.z += 0.5 * dt;   // stroll forward with a slow drift
-    const gold = light ? '#b67d10' : '#ffd400';
-    const cyan = light ? '#1d8a78' : '#5ad1ff';
-    const pink = light ? '#b3457a' : '#ff5aa6';
+    const ink = themeInk(light);
+    const gold = ink.accent;
+    const cyan = ink.accent2;
+    const pink = ink.data6;
     const horizon = H * 0.4, f = W * 0.42, camH = 0.34;
-    // sky + ground
-    ctx.fillStyle = light ? '#eef0f2' : '#04060c';
-    ctx.fillRect(0, 0, W, horizon);
-    ctx.fillStyle = light ? '#e4dfd2' : '#0a0e1c';
+    // sky + ground: sky is the skin bg, the ground a faint dimmed wash over it
+    ctx.fillStyle = ink.bg;
+    ctx.fillRect(0, 0, W, H);
+    ctx.fillStyle = withAlpha(ink.dim, light ? 0.18 : 0.22);
     ctx.fillRect(0, horizon, W, H - horizon);
     const frac = (v: number) => ((v % 1) + 1) % 1;
     // tile grid on the ground: cross lines recede, long lines converge
@@ -634,7 +677,7 @@ function PolygonPreview({ light }: { light: boolean }) {
     ctx.beginPath(); ctx.arc(ax, ay - ar * 1.9, ar * 0.55, 0, 7); ctx.fill();
     // minimap inset: the fundamental square with glued-edge arrows
     const ms = Math.min(W, H) * 0.32, mx = W - ms - W * 0.03, my = H * 0.06;
-    ctx.fillStyle = light ? 'rgba(244,243,239,0.85)' : 'rgba(5,6,13,0.78)';
+    ctx.fillStyle = withAlpha(ink.bg, light ? 0.85 : 0.78);
     ctx.fillRect(mx, my, ms, ms);
     ctx.lineWidth = Math.max(1.4, W * 0.0045);
     ctx.strokeStyle = gold;
@@ -656,7 +699,7 @@ function PolygonPreview({ light }: { light: boolean }) {
     arrow(mx + ms, my + ms / 2, -Math.PI / 2, gold);  // right edge ↑ (same way = torus)
     arrow(mx + ms / 2, my, 0, cyan);                  // top edge →
     arrow(mx + ms / 2, my + ms, 0, cyan);             // bottom edge →
-    ctx.fillStyle = light ? '#222' : '#fff';
+    ctx.fillStyle = ink.fg;
     ctx.beginPath();
     ctx.arc(mx + frac(c.x) * ms, my + (1 - frac(c.z)) * ms, Math.max(2, W * 0.006), 0, 7);
     ctx.fill();
@@ -709,11 +752,12 @@ function TreeNetPreview({ light }: { light: boolean }) {
   }, []);
 
   const ref = useCanvas((ctx, W, H, t) => {
+    const ink = themeInk(light);
     const { n, tris } = cyc;
-    const gold = light ? '#b67d10' : '#ffd400';
-    const teal = light ? '#1d8a78' : '#5ad1ff';
-    const fg = light ? 'rgba(60,65,80,' : 'rgba(200,210,230,';
-    ctx.fillStyle = light ? '#eef0f2' : '#0a0e1c';
+    const gold = ink.accent;
+    const teal = ink.accent2;
+    const fg = (a: number) => withAlpha(ink.fg, a);
+    ctx.fillStyle = ink.bg;
     ctx.fillRect(0, 0, W, H);
     const cx = W / 2, cy = H * 0.52, R = Math.min(W, H) * 0.34;
     const vA = (k: number) => -Math.PI / 2 + (2 * Math.PI * k) / n;
@@ -739,10 +783,10 @@ function TreeNetPreview({ light }: { light: boolean }) {
       return [from[0] + (to[0] - from[0]) * lt, from[1] + (to[1] - from[1]) * lt] as [number, number];
     });
 
-    ctx.strokeStyle = `${fg}0.18)`; ctx.lineWidth = Math.max(1, W * 0.004);
+    ctx.strokeStyle = fg(0.18); ctx.lineWidth = Math.max(1, W * 0.004);
     ctx.beginPath(); for (let k = 0; k < n; k++) { if (k === 0) ctx.moveTo(PX(k), PY(k)); else ctx.lineTo(PX(k), PY(k)); } ctx.closePath(); ctx.stroke();
 
-    ctx.lineWidth = Math.max(1.5, W * 0.006); ctx.strokeStyle = `${fg}0.6)`;
+    ctx.lineWidth = Math.max(1.5, W * 0.006); ctx.strokeStyle = fg(0.6);
     for (let k = 0; k < n; k++) {
       const ti = B.findIndex((bt) => has(bt, k) && has(bt, (k + 1) % n)); if (ti < 0) continue;
       ctx.beginPath(); ctx.moveTo(nodeB[ti][0], nodeB[ti][1]); ctx.lineTo(cx + R * 0.96 * Math.cos(eA(k)), cy + R * 0.96 * Math.sin(eA(k))); ctx.stroke();
@@ -753,7 +797,7 @@ function TreeNetPreview({ light }: { light: boolean }) {
       B.forEach((bt, i) => { if (has(bt, a) && has(bt, b)) ts.push(i); });
       if (ts.length === 2) { ctx.beginPath(); ctx.moveTo(nodeB[ts[0]][0], nodeB[ts[0]][1]); ctx.lineTo(nodeB[ts[1]][0], nodeB[ts[1]][1]); ctx.stroke(); }
     }
-    ctx.fillStyle = light ? '#eef0f2' : '#0a0e1c'; ctx.strokeStyle = `${fg}0.9)`; ctx.lineWidth = Math.max(1, W * 0.004);
+    ctx.fillStyle = ink.bg; ctx.strokeStyle = fg(0.9); ctx.lineWidth = Math.max(1, W * 0.004);
     for (const p of nodeB) { ctx.beginPath(); ctx.arc(p[0], p[1], Math.max(2.5, W * 0.012), 0, 7); ctx.fill(); ctx.stroke(); }
     ctx.fillStyle = gold;
     for (let k = 0; k < n; k++) { ctx.beginPath(); ctx.arc(cx + R * 0.96 * Math.cos(eA(k)), cy + R * 0.96 * Math.sin(eA(k)), Math.max(2.5, W * 0.013), 0, 7); ctx.fill(); }
@@ -763,7 +807,8 @@ function TreeNetPreview({ light }: { light: boolean }) {
 
 function SolidPreview({ light }: { light: boolean }) {
   const ref = useCanvas((ctx, W, H, t) => {
-    ctx.fillStyle = light ? '#eef0f2' : '#070a14';
+    const ink = themeInk(light);
+    ctx.fillStyle = ink.bg;
     ctx.fillRect(0, 0, W, H);
     const cx = W / 2, cy = H / 2, s = Math.min(W, H) * 0.2;
     const ay = t * 0.5, ax = 0.5;
@@ -781,7 +826,7 @@ function SolidPreview({ light }: { light: boolean }) {
       [-1, -1, 1], [1, -1, 1], [1, 1, 1], [-1, 1, 1],
     ];
     const edges = [[0, 1], [1, 2], [2, 3], [3, 0], [4, 5], [5, 6], [6, 7], [7, 4], [0, 4], [1, 5], [2, 6], [3, 7]];
-    const accent = light ? '#1d6fb8' : '#5ad1ff';
+    const accent = ink.accent2;
     // a 3×1×1 strip of cubes — one room repeating along x
     for (let c = -1; c <= 1; c++) {
       const fade = c === 0 ? 1 : 0.4;
@@ -805,7 +850,7 @@ function SolidPreview({ light }: { light: boolean }) {
       ctx.stroke();
     };
     const c0 = proj(0, 0, 0); drawF(c0[0], c0[1], 1, accent);
-    const c1 = proj(2.05, 0, 0); drawF(c1[0], c1[1], -1, light ? '#b3457a' : '#ff5aa6');
+    const c1 = proj(2.05, 0, 0); drawF(c1[0], c1[1], -1, ink.data6);
   }, [light]);
   return <canvas ref={ref} style={canvasStyle} />;
 }
@@ -836,11 +881,8 @@ const SKELLAM = (() => {
 function SkellamPreview({ light }: { light: boolean }) {
   const ref = useCanvas((ctx, W, H, t) => {
     // pull the live theme tokens so the card matches the active skin, not just light/dark
-    const cs = getComputedStyle(document.documentElement);
-    const pick = (name: string, fb: string) => cs.getPropertyValue(name).trim() || fb;
-    const bg = pick('--bg', light ? '#f4f3ef' : '#05060d');
-    const gold = pick('--accent', light ? '#b67d10' : '#ffce47');
-    const teal = pick('--accent-2', light ? '#1d8a78' : '#5fe3cd');
+    const ink = themeInk(light);
+    const bg = ink.bg, gold = ink.accent, teal = ink.accent2;
     ctx.fillStyle = bg; ctx.fillRect(0, 0, W, H);
     const { G, K, pX, pY, jmax, sk, skmax } = SKELLAM;
     const gs = Math.min(W * 0.72, H * 0.6);

--- a/src/chrome/previews.tsx
+++ b/src/chrome/previews.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useRef } from 'react';
+import { isLightSkin } from './skins';
 
 /**
  * Lightweight, authentic preview animations for the gallery cards. One flavor
@@ -887,7 +888,7 @@ function SkellamPreview({ light }: { light: boolean }) {
 }
 
 export function Preview({ kind, skin }: { kind: PreviewKind; skin: string; hue?: number }) {
-  const light = skin === 'light';
+  const light = isLightSkin(skin);
   switch (kind) {
     case 'plane': return <PlanePreview light={light} />;
     case 'fractal': return <FractalPreview light={light} />;

--- a/src/chrome/skins.tsx
+++ b/src/chrome/skins.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { Icon } from './icons';
 import { useEscLayer } from './useEscLayer';
 
@@ -64,16 +64,21 @@ export function applyPersistedSkin(): void {
 }
 
 /**
- * The current skin id + setter. Setting a skin updates `data-theme` on the
- * root element (restyling all chrome) and persists the choice.
+ * The current skin id + setter. The value is derived from the live `data-theme`
+ * attribute (via {@link useThemeId}), NOT a private `useState` — so every
+ * useSkin/useThemeId consumer (gallery, top bar, in-app controls) stays in sync
+ * the instant ANY of them, or boot, changes the skin. Without this, a second
+ * useSkin instance reading the skin would go stale until a page reload, because
+ * independent useState copies don't observe each other. Setting a skin applies
+ * the attrs immediately (restyling all chrome) and persists the choice.
  */
 export function useSkin(): [string, (id: string) => void] {
-  const [skin, setSkinState] = useState(loadSkin);
-  useEffect(() => {
-    applySkinAttrs(skin);
-    try { window.localStorage.setItem(SKIN_KEY, skin); } catch { /* ignore */ }
-  }, [skin]);
-  return [skin, setSkinState];
+  const skin = useThemeId();
+  const setSkin = useCallback((id: string) => {
+    applySkinAttrs(id);
+    try { window.localStorage.setItem(SKIN_KEY, id); } catch { /* ignore */ }
+  }, []);
+  return [skin, setSkin];
 }
 
 /**

--- a/src/chrome/skins.tsx
+++ b/src/chrome/skins.tsx
@@ -3,7 +3,7 @@ import { Icon } from './icons';
 import { useEscLayer } from './useEscLayer';
 
 /**
- * Skins — the five switchable styling systems on `data-theme` (see
+ * Skins — the eight switchable styling systems on `data-theme` (see
  * docs/redesign/DESIGN-SPEC.md §5). Adding a skin = one token block in
  * src/chrome/theme.css + one entry here.
  */
@@ -13,15 +13,29 @@ export interface Skin {
   blurb: string;
   /** Three swatch colors shown in the picker. */
   dots: [string, string, string];
+  /** True when this skin renders on a light viz background (`color-scheme:
+   *  light` in theme.css). Drives gallery-preview light/dark rendering — never
+   *  test `id === 'light'`, which misses the other light skins. */
+  light?: boolean;
 }
 
 export const SKINS: Skin[] = [
   { id: 'dark', name: 'Observatory', blurb: 'Ink blue · refined gold', dots: ['#0a0c12', '#ffce47', '#5fe3cd'] },
-  { id: 'light', name: 'Paper', blurb: 'Warm paper · deep amber', dots: ['#f0ede4', '#b67d10', '#1d8a78'] },
+  { id: 'light', name: 'Paper', blurb: 'Warm paper · deep amber', dots: ['#f0ede4', '#b67d10', '#1d8a78'], light: true },
   { id: 'neon', name: 'Spectrum', blurb: 'Space black · cyan + magenta', dots: ['#05060f', '#34e6cf', '#ff5aa6'] },
   { id: 'blueprint', name: 'Blueprint', blurb: 'Drafting blue · chalk lines', dots: ['#102650', '#f2f6ff', '#69a8ff'] },
   { id: 'phosphor', name: 'Phosphor', blurb: 'CRT green · all mono', dots: ['#04130a', '#3dff7a', '#b5ffce'] },
+  { id: 'daylight', name: 'Daylight', blurb: 'Cool white · clear blue', dots: ['#eef2f8', '#2f6fe0', '#e0683a'], light: true },
+  { id: 'primary', name: 'Primary', blurb: 'Bauhaus · bold primaries', dots: ['#f0eee8', '#f5c518', '#1f4fd6'], light: true },
+  { id: 'mirage', name: 'Mirage', blurb: 'Surreal dusk · peach + lavender', dots: ['#1a1230', '#ffb37a', '#b08cff'] },
 ];
+
+/** Whether a skin id renders on a light viz background — the single source of
+ *  truth for light/dark branching (e.g. gallery previews). Defaults to false
+ *  for unknown ids. */
+export function isLightSkin(id: string): boolean {
+  return SKINS.find(s => s.id === id)?.light ?? false;
+}
 
 const SKIN_KEY = 'animath:v1:chrome:skin';
 const DEFAULT_SKIN = 'dark';

--- a/src/chrome/skins.tsx
+++ b/src/chrome/skins.tsx
@@ -66,6 +66,27 @@ export function useSkin(): [string, (id: string) => void] {
   return [skin, setSkinState];
 }
 
+/**
+ * Read-only, reactive current skin id — tracks `data-theme` on the root element,
+ * so it updates when the skin changes anywhere (e.g. the top-bar SkinPicker),
+ * without the caller threading skin state. Use this to feed theme-aware controls
+ * like `<ColormapPicker themeId={…}>`.
+ */
+export function useThemeId(): string {
+  const read = () => (typeof document !== 'undefined'
+    ? document.documentElement.getAttribute('data-theme') ?? DEFAULT_SKIN
+    : DEFAULT_SKIN);
+  const [id, setId] = useState(read);
+  useEffect(() => {
+    const el = document.documentElement;
+    const obs = new MutationObserver(() => setId(el.getAttribute('data-theme') ?? DEFAULT_SKIN));
+    obs.observe(el, { attributes: true, attributeFilter: ['data-theme'] });
+    setId(read()); // sync in case it changed between first render and effect
+    return () => obs.disconnect();
+  }, []);
+  return id;
+}
+
 /** Pill button (swatch dots + name) opening the skins dropdown. */
 export function SkinPicker({ skin, onSetSkin, compact }: {
   skin: string;

--- a/src/chrome/skins.tsx
+++ b/src/chrome/skins.tsx
@@ -48,9 +48,19 @@ function loadSkin(): string {
   return DEFAULT_SKIN;
 }
 
+/** Reflect a skin on the root element: `data-theme` drives the token blocks, and
+ *  `data-scheme` (light/dark, derived from isLightSkin) lets CSS pick light/dark
+ *  UA rendering — e.g. native `<select>` popups — for *every* light skin without
+ *  hardcoding which ids are light. */
+function applySkinAttrs(id: string): void {
+  const el = document.documentElement;
+  el.setAttribute('data-theme', id);
+  el.setAttribute('data-scheme', isLightSkin(id) ? 'light' : 'dark');
+}
+
 /** Apply the persisted skin to <html data-theme>. Call once at boot, before render. */
 export function applyPersistedSkin(): void {
-  document.documentElement.setAttribute('data-theme', loadSkin());
+  applySkinAttrs(loadSkin());
 }
 
 /**
@@ -60,7 +70,7 @@ export function applyPersistedSkin(): void {
 export function useSkin(): [string, (id: string) => void] {
   const [skin, setSkinState] = useState(loadSkin);
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', skin);
+    applySkinAttrs(skin);
     try { window.localStorage.setItem(SKIN_KEY, skin); } catch { /* ignore */ }
   }, [skin]);
   return [skin, setSkinState];

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -40,6 +40,10 @@
   --z-sheet: 136;
   --z-modal: 150;
   --z-rail: 200;
+
+  /* type-size multiplier (default 1); consumed by the Phosphor zoom rule
+     below so a wider face can be scaled to match — see DESIGN-SPEC §5 */
+  --font-scale: 1;
 }
 
 /* ---------------- Observatory · dark (default) ----------------
@@ -64,6 +68,14 @@
   --active: rgba(150,175,220,0.12);
   --shadow: 0 14px 44px rgba(0,0,0,0.55);
   --track: rgba(150,175,220,0.16);
+  --danger: #f0746a;  --danger-soft: rgba(240,116,106,0.14);
+  --success: #4cc878; --success-soft: rgba(76,200,120,0.14);
+  --shadow-1: 0 2px 8px rgba(0,0,0,0.35);
+  --shadow-2: 0 8px 24px rgba(0,0,0,0.45);
+  --shadow-3: 0 18px 52px rgba(0,0,0,0.6);
+  --data-1: #5fa8ff; --data-2: #5fe3cd; --data-3: #9ee85f; --data-4: #ffce47;
+  --data-5: #ff9a5f; --data-6: #ff6f9c; --data-7: #c08bff;
+  --font-scale: 1;
 }
 
 /* ---------------- Paper · light ----------------
@@ -88,6 +100,14 @@
   --active: rgba(40,34,20,0.09);
   --shadow: 0 12px 34px rgba(60,50,30,0.16);
   --track: rgba(40,34,20,0.15);
+  --danger: #c0492f;  --danger-soft: rgba(192,73,47,0.12);
+  --success: #2e8d56; --success-soft: rgba(46,141,86,0.12);
+  --shadow-1: 0 1px 4px rgba(60,50,30,0.1);
+  --shadow-2: 0 6px 18px rgba(60,50,30,0.14);
+  --shadow-3: 0 16px 40px rgba(60,50,30,0.2);
+  --data-1: #2f6fd0; --data-2: #1d8a78; --data-3: #5a9e2e; --data-4: #b67d10;
+  --data-5: #c4682a; --data-6: #c23f6c; --data-7: #7a52c0;
+  --font-scale: 1;
 }
 
 /* ---------------- Blueprint · drafting board ----------------
@@ -113,6 +133,14 @@
   --shadow: 0 14px 40px rgba(2,10,30,0.55);
   --track: rgba(170,200,255,0.24);
   --dot-color: rgba(170,200,255,0.28);
+  --danger: #ff9d8f;  --danger-soft: rgba(255,157,143,0.16);
+  --success: #7fe0a8; --success-soft: rgba(127,224,168,0.16);
+  --shadow-1: 0 2px 8px rgba(2,10,30,0.4);
+  --shadow-2: 0 8px 22px rgba(2,10,30,0.5);
+  --shadow-3: 0 18px 48px rgba(2,10,30,0.6);
+  --data-1: #69a8ff; --data-2: #7fe0a8; --data-3: #cfe06a; --data-4: #ffd98a;
+  --data-5: #ffab7a; --data-6: #ff8fb0; --data-7: #c0a8ff;
+  --font-scale: 1;
 }
 
 /* ---------------- Phosphor · CRT terminal ----------------
@@ -140,6 +168,14 @@
   --dot-color: rgba(80,255,140,0.14);
   --font-display: "Space Mono", ui-monospace, monospace;
   --font-ui: "Space Mono", ui-monospace, monospace;
+  --danger: #ff8a6f;  --danger-soft: rgba(255,138,111,0.14);
+  --success: #3dff7a; --success-soft: rgba(61,255,122,0.14);
+  --shadow-1: 0 2px 8px rgba(0,0,0,0.4);
+  --shadow-2: 0 8px 22px rgba(0,0,0,0.5);
+  --shadow-3: 0 18px 48px rgba(0,0,0,0.65);
+  --data-1: #5affc8; --data-2: #3dff7a; --data-3: #b5ff5a; --data-4: #ffd24d;
+  --data-5: #ffa05a; --data-6: #ff6f9c; --data-7: #9affd2;
+  --font-scale: 0.9;   /* mono display+UI runs wider — scale type down to match */
 }
 
 /* ---------------- Spectrum · neon ----------------
@@ -164,12 +200,78 @@
   --active: rgba(130,170,255,0.15);
   --shadow: 0 16px 46px rgba(0,0,0,0.62), 0 0 0 1px rgba(52,230,207,0.06);
   --track: rgba(130,170,255,0.2);
+  --danger: #ff6f9c;  --danger-soft: rgba(255,111,156,0.15);
+  --success: #5fe3a0; --success-soft: rgba(95,227,160,0.15);
+  --shadow-1: 0 2px 10px rgba(0,0,0,0.45);
+  --shadow-2: 0 8px 26px rgba(0,0,0,0.55);
+  --shadow-3: 0 18px 52px rgba(0,0,0,0.66);
+  --data-1: #5fa8ff; --data-2: #34e6cf; --data-3: #9ee85f; --data-4: #ffce47;
+  --data-5: #ff9a5f; --data-6: #ff5aa6; --data-7: #c08bff;
+  --font-scale: 1;
+}
+
+/* ---------------- Daylight · light (cool) ----------------
+   Clean cool white, clear editorial blue, warm orange counter. */
+[data-theme="daylight"] {
+  color-scheme: light;
+  --bg: #eef2f8; --viz-bg: #f7f9fc; --panel: rgba(255,255,255,0.9); --panel-solid: #ffffff;
+  --panel-2: rgba(30,50,90,0.04); --fg: #16202e; --dim: #5b6678; --dim-2: #93a0b4;
+  --accent: #2f6fe0; --accent-fg: #ffffff; --accent-soft: rgba(47,111,224,0.12); --accent-2: #e0683a;
+  --border: rgba(20,40,80,0.12); --border-strong: rgba(20,40,80,0.22);
+  --hover: rgba(20,40,80,0.05); --active: rgba(20,40,80,0.09);
+  --shadow: 0 12px 32px rgba(20,40,80,0.14); --track: rgba(20,40,80,0.15);
+  --danger: #cf3b3b; --danger-soft: rgba(207,59,59,0.1);
+  --success: #2e8d56; --success-soft: rgba(46,141,86,0.1);
+  --shadow-1: 0 1px 4px rgba(20,40,80,0.1); --shadow-2: 0 6px 18px rgba(20,40,80,0.13); --shadow-3: 0 16px 40px rgba(20,40,80,0.18);
+  --data-1: #2f6fe0; --data-2: #1d8a8a; --data-3: #5a9e2e; --data-4: #e0a82e; --data-5: #e0683a; --data-6: #cf3b6e; --data-7: #7a52c0;
+  --font-scale: 1;
+}
+
+/* ---------------- Primary · basic colors (Bauhaus / De Stijl) ----------------
+   Bone white, true-black ink, bold primaries. Flat, confident, geometric. */
+[data-theme="primary"] {
+  color-scheme: light;
+  --bg: #f0eee8; --viz-bg: #faf9f5; --panel: rgba(255,255,255,0.94); --panel-solid: #ffffff;
+  --panel-2: rgba(0,0,0,0.04); --fg: #14130f; --dim: #5a584f; --dim-2: #908d82;
+  --accent: #f5c518; --accent-fg: #14130f; --accent-soft: rgba(245,197,24,0.18); --accent-2: #1f4fd6;
+  --border: rgba(0,0,0,0.14); --border-strong: rgba(0,0,0,0.28);
+  --hover: rgba(0,0,0,0.05); --active: rgba(0,0,0,0.1);
+  --shadow: 0 10px 28px rgba(0,0,0,0.16); --track: rgba(0,0,0,0.16);
+  --danger: #e63327; --danger-soft: rgba(230,51,39,0.12);
+  --success: #149e57; --success-soft: rgba(20,158,87,0.12);
+  --shadow-1: 0 1px 4px rgba(0,0,0,0.14); --shadow-2: 0 6px 18px rgba(0,0,0,0.18); --shadow-3: 0 16px 40px rgba(0,0,0,0.24);
+  --data-1: #e63327; --data-2: #1f4fd6; --data-3: #f5c518; --data-4: #149e57; --data-5: #e6731f; --data-6: #7a2fd6; --data-7: #14130f;
+  --font-scale: 1;
+}
+
+/* ---------------- Mirage · surreal ----------------
+   Deep plum dusk, peach light, lavender structure. Dreamlike and soft. */
+[data-theme="mirage"] {
+  color-scheme: dark;
+  --bg: #1a1230; --viz-bg: #120c24; --panel: rgba(40,28,68,0.72); --panel-solid: #241638;
+  --panel-2: rgba(255,200,235,0.06); --fg: #fbeef6; --dim: #b59ec9; --dim-2: #7d6699;
+  --accent: #ffb37a; --accent-fg: #2a1640; --accent-soft: rgba(255,179,122,0.16); --accent-2: #b08cff;
+  --border: rgba(200,170,255,0.18); --border-strong: rgba(200,170,255,0.34);
+  --hover: rgba(200,170,255,0.09); --active: rgba(200,170,255,0.15);
+  --shadow: 0 18px 50px rgba(10,4,30,0.6); --track: rgba(200,170,255,0.22);
+  --dot-color: rgba(200,170,255,0.18);
+  --danger: #ff7a9c; --danger-soft: rgba(255,122,156,0.16);
+  --success: #7fe0c0; --success-soft: rgba(127,224,192,0.16);
+  --shadow-1: 0 2px 10px rgba(10,4,30,0.45); --shadow-2: 0 8px 26px rgba(10,4,30,0.55); --shadow-3: 0 18px 52px rgba(10,4,30,0.66);
+  --data-1: #b08cff; --data-2: #ffb37a; --data-3: #7fe0c0; --data-4: #ff9ed6; --data-5: #8cc0ff; --data-6: #ffd98a; --data-7: #d68cff;
+  --font-scale: 1;
 }
 
 body {
   background: var(--bg);
   color: var(--fg);
 }
+
+/* Phosphor's mono UI face renders wider than the sans skins; scale the whole app
+   root down by --font-scale so its type matches the others (Option A, DESIGN-SPEC
+   §5 — zoom scales layout+type together; revisit with a rem migration if needed). */
+[data-theme="phosphor"] .am-app,
+[data-theme="phosphor"] .am-gallery-app { zoom: var(--font-scale, 1); }
 
 /* ============ Display type — Space Grotesk on wordmarks, titles, headers ============ */
 .am-brand, .am-title, .am-gal-title, .am-gal-kicker, .am-modal h2,

--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -284,6 +284,95 @@
 }
 .cp-quarter button:hover { background: var(--cp-hover); }
 
+/* ---------- ColormapPicker (color-tier control for DOM/2D apps) ---------- */
+.cp-cmap { gap: 7px; }
+.cp-cmap-note {
+  font-size: 11px;
+  color: var(--cp-fg-dim);
+  line-height: 1.35;
+}
+.cp-cmap-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 5px;
+}
+.cp-cmap-sw {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  background: var(--panel-2, rgba(255, 255, 255, 0.04));
+  border: 1px solid var(--cp-border);
+  border-radius: 7px;
+  padding: 5px 5px 6px;
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+.cp-cmap-sw:hover { background: var(--cp-hover); }
+.cp-cmap-sw.cp-active {
+  border-color: var(--cp-accent);
+  background: var(--accent-soft, var(--cp-hover));
+}
+.cp-cmap-bar {
+  display: block;
+  height: 16px;
+  border-radius: 4px;
+  border: 1px solid var(--cp-border);
+}
+.cp-cmap-name {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--cp-fg);
+}
+.cp-cmap-cb {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  /* a green dot = colorblind-safe; uses the success token */
+  background: var(--success, #4cc878);
+  flex-shrink: 0;
+}
+.cp-cmap-rev {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--cp-fg-dim);
+}
+.cp-cmap-more {
+  background: transparent;
+  border: none;
+  padding: 2px 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  color: var(--cp-fg-dim);
+  text-align: left;
+}
+.cp-cmap-more:hover { color: var(--cp-fg); }
+.cp-cmap-more-body {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding-top: 2px;
+}
+.cp-cmap-fam { display: flex; flex-direction: column; gap: 5px; }
+.cp-cmap-fam-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: var(--cp-fg-dim);
+}
+
 /* Readme inside panels / the explainer modal */
 .markdown-body { color: var(--cp-fg-dim); font-size: 13px; line-height: 1.55; font-family: var(--cp-font); }
 .markdown-body a { color: var(--cp-accent); }

--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -121,7 +121,7 @@
 }
 /* Keep the OS-native dropdown popup readable on dark skins. */
 .cp-row select { color-scheme: dark; }
-[data-theme="light"] .cp-row select { color-scheme: light; }
+[data-scheme="light"] .cp-row select { color-scheme: light; }
 .cp-row select option {
   background: var(--panel-solid, #0c0c10);
   color: var(--cp-fg);

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import './ControlPanel.css';
+import { COLORMAPS, FAMILIES, themeMapsFor, gradientCss, type ColorFamily } from '../lib/colormapRegistry';
 
 /**
  * Form primitives — Section, Slider, Pills, Select, Checkbox — used inside
@@ -344,5 +345,86 @@ export function Checkbox({ label, checked, onChange }: CheckboxProps) {
       />
       <span>{label}</span>
     </label>
+  );
+}
+
+interface ColormapPickerProps {
+  /** The data's required family — declared by the view (sequential / divergent /
+   *  discrete / cyclic). The picker foregrounds this family's theme-recommended
+   *  maps and tucks the others behind an "advanced" disclosure. */
+  family: ColorFamily;
+  /** Current map id, or 'discrete' for the theme's --data palette. */
+  value: string;
+  onChange: (id: string) => void;
+  /** Active skin id (from useSkin()) — drives the recommendations + discrete palette. */
+  themeId: string;
+  reverse?: boolean;
+  onReverse?: (b: boolean) => void;
+}
+
+/**
+ * A `color`-tier panel control for DOM/2D apps: pick a colormap from the family
+ * the *data* requires (the family is the app's call; the theme + user pick within
+ * it). Mirrors the design-handoff reference: family header, a grid of recommended
+ * swatches, and an advanced disclosure to reach the other families (including
+ * Discrete = the live theme palette). Re-curates when `themeId` changes.
+ */
+export function ColormapPicker({ family, value, onChange, themeId, reverse = false, onReverse }: ColormapPickerProps) {
+  const [showMore, setShowMore] = useState(false);
+  const recommended = themeMapsFor(family, themeId);
+  const rest = Object.keys(COLORMAPS).filter(k => COLORMAPS[k].family === family && !recommended.includes(k));
+  const primary = [...recommended, ...rest];
+  const otherFamilies = (Object.keys(FAMILIES) as ColorFamily[]).filter(f => f !== family);
+
+  const swatch = (id: string) => {
+    const cm = COLORMAPS[id];
+    const isDiscrete = id === 'discrete';
+    const name = isDiscrete ? 'Theme palette' : cm?.name ?? id;
+    const cb = isDiscrete ? false : cm?.cb ?? false;
+    return (
+      <button
+        key={id}
+        type="button"
+        className={`cp-cmap-sw ${value === id ? 'cp-active' : ''}`}
+        onClick={() => onChange(id)}
+        title={name}
+        aria-pressed={value === id}
+      >
+        <span className="cp-cmap-bar" style={{ backgroundImage: gradientCss(id, reverse) }} />
+        <span className="cp-cmap-name">{name}{cb && <i className="cp-cmap-cb" title="colorblind-safe" aria-label="colorblind-safe" />}</span>
+      </button>
+    );
+  };
+
+  return (
+    <div className="cp-row cp-cmap">
+      <div className="cp-row-label">
+        <span>{FAMILIES[family].label}</span>
+        <span className="cp-row-value">{family}</span>
+      </div>
+      <div className="cp-cmap-note">this view needs {family} · {FAMILIES[family].note}</div>
+      <div className="cp-cmap-grid">{primary.map(swatch)}</div>
+      {onReverse && family !== 'discrete' && (
+        <label className="cp-cmap-rev">
+          <input type="checkbox" checked={reverse} onChange={e => onReverse(e.target.checked)} />
+          <span>Reverse</span>
+        </label>
+      )}
+      <button type="button" className="cp-cmap-more" onClick={() => setShowMore(v => !v)} aria-expanded={showMore}>
+        <span className={`cp-section-chevron ${showMore ? 'cp-open' : ''}`}>▸</span> Other families (advanced)
+      </button>
+      {showMore && (
+        <div className="cp-cmap-more-body">
+          {otherFamilies.map(f => (
+            <div key={f} className="cp-cmap-fam">
+              <div className="cp-cmap-fam-label">{FAMILIES[f].label}</div>
+              <div className="cp-cmap-grid">
+                {(f === 'discrete' ? ['discrete'] : Object.keys(COLORMAPS).filter(k => COLORMAPS[k].family === f)).map(swatch)}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/src/lib/__tests__/colormapRegistry.test.ts
+++ b/src/lib/__tests__/colormapRegistry.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  COLORMAPS,
+  discreteStops,
+  gradientCss,
+  mapStops,
+  sampleStops,
+  themeMapsFor,
+} from '../colormapRegistry';
+
+describe('themeMapsFor', () => {
+  it('always resolves the discrete family to the theme token palette', () => {
+    expect(themeMapsFor('discrete', 'dark')).toEqual(['discrete']);
+    expect(themeMapsFor('discrete', 'no-such-theme')).toEqual(['discrete']);
+  });
+
+  it('returns the curated maps for a known theme + family (default first)', () => {
+    expect(themeMapsFor('sequential', 'dark')).toEqual(['viridis', 'mako']);
+    expect(themeMapsFor('divergent', 'neon')[0]).toBe('coolwarm');
+    // the 3 new skins are curated too
+    expect(themeMapsFor('sequential', 'mirage')).toEqual(['magma', 'mako']);
+  });
+
+  it('falls back to every map in the family when the theme is unknown', () => {
+    const seq = themeMapsFor('sequential', 'no-such-theme');
+    expect(seq).toEqual(Object.keys(COLORMAPS).filter(k => COLORMAPS[k].family === 'sequential'));
+    expect(seq).toContain('viridis');
+    expect(seq.length).toBeGreaterThan(2); // more than the curated pair
+  });
+});
+
+describe('mapStops', () => {
+  it('returns a known map’s stops', () => {
+    expect(mapStops('viridis')).toBe(COLORMAPS.viridis.stops);
+  });
+  it('falls back to rdbu for an unknown id', () => {
+    expect(mapStops('bogus')).toBe(COLORMAPS.rdbu.stops);
+  });
+});
+
+describe('discreteStops (reads --data-1..7 live)', () => {
+  afterEach(() => { vi.unstubAllGlobals(); });
+
+  it('returns [] with no window (node / SSR)', () => {
+    expect(discreteStops()).toEqual([]);
+  });
+
+  it('parses --data-1..7 from getComputedStyle (trims whitespace)', () => {
+    const palette = ['#111111', '#222222', '#333333', '#444444', '#555555', '#666666', '#777777'];
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', { documentElement: {} });
+    vi.stubGlobal('getComputedStyle', () => ({
+      getPropertyValue: (k: string) => {
+        const m = /^--data-(\d)$/.exec(k);
+        return m ? `  ${palette[Number(m[1]) - 1]}  ` : '';
+      },
+    }));
+    expect(discreteStops()).toEqual(palette);
+    expect(mapStops('discrete')).toEqual(palette);
+  });
+
+  it('stops collecting at the first missing token', () => {
+    vi.stubGlobal('window', {});
+    vi.stubGlobal('document', { documentElement: {} });
+    vi.stubGlobal('getComputedStyle', () => ({
+      getPropertyValue: (k: string) => (k === '--data-1' ? '#abcabc' : ''),
+    }));
+    // --data-2 empty ⇒ loop continues but only collects non-empty; result keeps #abcabc
+    expect(discreteStops()).toEqual(['#abcabc']);
+  });
+});
+
+describe('gradientCss & sampleStops', () => {
+  it('builds a reversible CSS gradient', () => {
+    const fwd = gradientCss('viridis');
+    expect(fwd.startsWith('linear-gradient(90deg, ')).toBe(true);
+    expect(fwd).toContain(COLORMAPS.viridis.stops[0]);
+    const rev = gradientCss('viridis', true);
+    const last = COLORMAPS.viridis.stops[COLORMAPS.viridis.stops.length - 1];
+    const first = COLORMAPS.viridis.stops[0];
+    expect(rev.indexOf(last)).toBeLessThan(rev.indexOf(first));
+  });
+
+  it('samples N discrete classes by nearest anchor', () => {
+    expect(sampleStops('viridis', 1)).toEqual([COLORMAPS.viridis.stops[0]]);
+    const five = sampleStops('viridis', 5);
+    expect(five).toHaveLength(5);
+    expect(five[0]).toBe(COLORMAPS.viridis.stops[0]);
+    expect(five[4]).toBe(COLORMAPS.viridis.stops[COLORMAPS.viridis.stops.length - 1]);
+  });
+});

--- a/src/lib/colormapRegistry.ts
+++ b/src/lib/colormapRegistry.ts
@@ -1,0 +1,104 @@
+/**
+ * colormapRegistry — JS/CSS-side colormaps for DOM & 2D-canvas apps, typed by
+ * FAMILY (purpose). The data picks the family; the theme + user pick within it.
+ *
+ *   sequential  — ordered magnitude in one direction (counts, density, error)
+ *   divergent   — deviation from a meaningful midpoint (signed, rank-as-satisfaction)
+ *   discrete    — unordered categories (sides, clusters)  ← the theme's --data tokens
+ *   cyclic      — angles / phase that wrap (complex argument, hue, direction)
+ *
+ * Shader apps keep using lib/colormaps.ts (PALETTE_GLSL); names are kept in sync
+ * so "Viridis" matches on both sides.
+ */
+export type ColorFamily = 'sequential' | 'divergent' | 'discrete' | 'cyclic';
+
+export interface Colormap {
+  id: string;
+  name: string;
+  family: ColorFamily;
+  cb: boolean;        // colorblind-safe
+  stops: string[];    // hex anchors, low → high
+}
+
+export const COLORMAPS: Record<string, Colormap> = {
+  // sequential (perceptually uniform)
+  viridis: { id: 'viridis', name: 'Viridis', family: 'sequential', cb: true,  stops: ['#440154','#46327e','#365c8d','#277f8e','#1fa187','#4ac16d','#a0da39','#fde725'] },
+  mako:    { id: 'mako',    name: 'Mako',    family: 'sequential', cb: true,  stops: ['#0b0405','#272a4f','#36558f','#357ba3','#37ada4','#5fd0ac','#aae0bb','#def5e5'] },
+  magma:   { id: 'magma',   name: 'Magma',   family: 'sequential', cb: true,  stops: ['#000004','#1c1044','#4f127b','#812581','#b5367a','#e55064','#fb8761','#fec287'] },
+  amber:   { id: 'amber',   name: 'Amber',   family: 'sequential', cb: false, stops: ['#2a1403','#572200','#8a3a00','#b85c00','#dd8400','#f3ad33','#fcd070','#ffeeb0'] },
+  // divergent
+  rdbu:    { id: 'rdbu',    name: 'RdBu',    family: 'divergent',  cb: true,  stops: ['#b2182b','#d6604d','#f4a582','#fddbc7','#d1e5f0','#92c5de','#4393c3','#2166ac'] },
+  rdylbu:  { id: 'rdylbu',  name: 'RdYlBu',  family: 'divergent',  cb: true,  stops: ['#d73027','#f46d43','#fdae61','#fee090','#e0f3f8','#abd9e9','#74add1','#4575b4'] },
+  puor:    { id: 'puor',    name: 'PuOr',    family: 'divergent',  cb: true,  stops: ['#b35806','#e08214','#fdb863','#fee0b6','#d8daeb','#b2abd2','#8073ac','#542788'] },
+  brbg:    { id: 'brbg',    name: 'BrBG',    family: 'divergent',  cb: true,  stops: ['#8c510a','#bf812d','#dfc27d','#f6e8c3','#c7eae5','#80cdc1','#35978f','#01665e'] },
+  coolwarm:{ id: 'coolwarm',name: 'Coolwarm',family: 'divergent', cb: false, stops: ['#3b4cc0','#6788ee','#9abbff','#c9d7f0','#edd1c2','#f7a789','#e36a53','#b40426'] },
+  // cyclic
+  twilight:{ id: 'twilight',name: 'Twilight',family: 'cyclic',    cb: true,  stops: ['#e2d9e2','#9aa0c9','#5d6bb0','#3f3a6e','#48295a','#7c3a5b','#b9636a','#e0a98f','#e2d9e2'] },
+  // discrete is theme-supplied — see discreteStops()
+};
+
+export const FAMILIES: Record<ColorFamily, { label: string; note: string }> = {
+  sequential: { label: 'Perceptually uniform', note: 'ordered magnitude · one direction' },
+  divergent:  { label: 'Divergent',            note: 'deviation from a midpoint' },
+  discrete:   { label: 'Discrete',             note: "unordered categories · theme's data palette" },
+  cyclic:     { label: 'Cyclic',               note: 'angles / phase that wrap' },
+};
+
+/** Per-theme recommendations (default first). Discrete needs none (it's the tokens). */
+export const THEME_MAPS: Record<string, Partial<Record<ColorFamily, string[]>>> = {
+  dark:      { sequential: ['viridis','mako'],  divergent: ['rdbu','coolwarm'], cyclic: ['twilight'] },
+  light:     { sequential: ['amber','viridis'], divergent: ['rdbu','brbg'],     cyclic: ['twilight'] },
+  blueprint: { sequential: ['mako','viridis'],  divergent: ['coolwarm','rdbu'], cyclic: ['twilight'] },
+  phosphor:  { sequential: ['viridis','mako'],  divergent: ['brbg','rdbu'],     cyclic: ['twilight'] },
+  neon:      { sequential: ['mako','magma'],    divergent: ['coolwarm','puor'], cyclic: ['twilight'] },
+  daylight:  { sequential: ['viridis','mako'],  divergent: ['rdbu','rdylbu'],   cyclic: ['twilight'] },
+  primary:   { sequential: ['amber','magma'],   divergent: ['rdbu','coolwarm'], cyclic: ['twilight'] },
+  mirage:    { sequential: ['magma','mako'],    divergent: ['puor','coolwarm'], cyclic: ['twilight'] },
+};
+
+/** The active theme's discrete palette = its --data-1..7 tokens, read live. */
+export function discreteStops(): string[] {
+  if (typeof window === 'undefined') return [];
+  const cs = getComputedStyle(document.documentElement);
+  const out: string[] = [];
+  for (let i = 1; i <= 7; i++) {
+    const v = cs.getPropertyValue(`--data-${i}`).trim();
+    if (v) out.push(v);
+  }
+  return out;
+}
+
+export function mapStops(id: string): string[] {
+  if (id === 'discrete') return discreteStops();
+  return (COLORMAPS[id] ?? COLORMAPS.rdbu).stops;
+}
+
+/** Maps of a family this theme recommends (default first); 'discrete' special-cased. */
+export function themeMapsFor(family: ColorFamily, themeId: string): string[] {
+  if (family === 'discrete') return ['discrete'];
+  return THEME_MAPS[themeId]?.[family]
+    ?? Object.keys(COLORMAPS).filter(k => COLORMAPS[k].family === family);
+}
+
+/** A CSS gradient string for swatches/legends. */
+export function gradientCss(id: string, reverse = false): string {
+  const s = reverse ? mapStops(id).slice().reverse() : mapStops(id);
+  return `linear-gradient(90deg, ${s.join(',')})`;
+}
+
+/**
+ * Sample a map to a flat array of `n` hex colors by nearest-anchor lookup —
+ * enough for legends/swatches and for bucketing data into N classes (the common
+ * DOM use). For the discrete family this just returns the theme tokens (capped /
+ * cycled to n). No interpolation: callers that need continuous color should lerp
+ * the anchors themselves.
+ */
+export function sampleStops(id: string, n: number): string[] {
+  const s = mapStops(id);
+  if (s.length === 0 || n <= 0) return [];
+  if (id === 'discrete') return Array.from({ length: n }, (_, i) => s[i % s.length]);
+  return Array.from({ length: n }, (_, i) => {
+    const t = n === 1 ? 0 : i / (n - 1);
+    return s[Math.round(t * (s.length - 1))];
+  });
+}


### PR DESCRIPTION
Executes the **Claude Design** "design-system hardening" work order — *enforcement + the genuinely-missing pieces, not a redesign* — plus the refinements that came out of review and live testing. A single read-only **compliance audit** confirmed every per-app claim against source first; every changed app was screenshot-verified across skins.

## What's in it

**Tokens & skins**
- Semantic / elevation / data / `--font-scale` tokens on **every** skin; **3 new skins** (Daylight, Primary, Mirage) → 8 total.
- A `light` flag + `isLightSkin()`, a reactive `useThemeId()`, and a root `data-scheme` attribute; the lone `skin === 'light'` test removed.
- **`useSkin` made reactive** (derives from the live `data-theme`), so a skin change re-themes everything **live, no refresh** — fixes the gallery preview cards lagging until reload.

**Colormap registry**
- New typed, per-theme `lib/colormapRegistry.ts` (sequential / divergent / discrete / cyclic; *discrete* = the skin's `--data` tokens) + `<ColormapPicker>` + 10 unit tests. Shader apps stay on GLSL.

**Per-app compliance**
- **Stable Matching** (reference): transport deduped to the action strip, matrix routed through the registry, CSS tokenized; **light-on-light fixed** on the light skins (metric / lattice / narrate text → per-skin tokens).
- **Agentic Sorting**, **Counting the Ways**: transport deduped to the strip.
- **Trinary**: transport deduped; Observatory mode renamed **Explore** (clears the dark-skin name clash); Lab transport projected to a strip; **in-viz UI/HUD tokenized to the skin** (the first step of the cross-app pass — star scene + data colors intentionally deferred, see below).
- **Argand**: feed mode single-homed to the HUD (fullscreen-safe). **Correspondence**: path transport projected to a strip.
- **Gallery preview cards now theme per-skin** (generalizing the Counting-the-Ways pattern).

**Review fixes:** Argand fullscreen feed access; light-skin native `<select>` rendering (driven by `data-scheme`).

## Verification
`npm run build` / `lint` / `test` green (88 tests, +10 new); all 8 skins resolve `--data-1…7`; live skin-switch verified headless; Daylight + Primary screenshot-checked for contrast.

## Follow-up — *not* in this PR
The deeper goal ("every app's **visualization** tracks the skin, not just the chrome") is scoped as **theming v2** — light/dark-*paired* themes — in [`docs/sessions/.../2026-06-24-S02-plan-light-dark-theming.md`](docs/sessions/progress/youthful-cray-7m6z9d/2026-06-24-S02-plan-light-dark-theming.md). Trinary's UI tokenization here is the partial reference; its scene/data recolor, the other apps, Agentic's discrete-colormap adoption, and the Worlds' day/night skies all fold into v2, where a force-mode mechanism makes them clean.

Shared append-only files untouched; no new app added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UMQhbdez7HnK3aMLmwR8cB