### PR TITLE
Fractals: make df64 deep zoom actually visible (auto-raise iterations) + tests

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -100,9 +100,9 @@ animath/
     │   │                       #   (absorbs the former Roots z^(p/q) and
     │   │                       #    Multibranch sqrt/ln modes as variants)
     │   ├── PlaneTransform/      # f as a transformation of the colored plane
-    │   ├── FractalsGPU/         # GPU Mandelbrot / Julia / Burning Ship / Tricorn; Precision toggle (Standard float32 ↔ Extended df64 emulated-double for deep zoom past the ~1e5× float32 wall — method + the "limits of computation" write-up in DEEP_ZOOM.md, surfaced in the ? modal)
+    │   ├── FractalsGPU/         # GPU Mandelbrot / Julia / Burning Ship / Tricorn; Precision toggle (Standard float32 ↔ Extended df64 emulated-double for deep zoom past the ~1e5× float32 wall — method + the "limits of computation" write-up in DEEP_ZOOM.md, surfaced in the ? modal) + Auto-raise iterations with zoom (deep zoom needs many more iterations or it reads as flat interior, hiding the precision gain; MAX_ITER 4000). Standalone GPU/visual deep-zoom tests: scripts/df64-gpu-probe.mjs (pass/fail) + scripts/df64-image-probe.mjs (before/after tiles)
     │   ├── Fractals/            # legacy CPU 2D fractals (routed at #/fractals-cpu)
-    │   ├── Correspondence/      # Mandelbrot ↔ Julia split-pane explorer; shares the Precision toggle (Standard float32 ↔ Extended df64) on both panes (FractalPane), method documented in FractalsGPU/DEEP_ZOOM.md
+    │   ├── Correspondence/      # Mandelbrot ↔ Julia split-pane explorer; shares the Precision toggle (Standard float32 ↔ Extended df64) on both panes (FractalPane), method documented in FractalsGPU/DEEP_ZOOM.md; also shares Auto-raise iterations with zoom
     │   ├── TopologyWalk/        # UNLISTED / being retired (Polygon Worlds supersedes it; absorbed its scene looks). Möbius corridor + flat torus / Klein bottle
     │   ├── TrinaryStars/        # three-body planet sandbox (Observatory) + ensemble Lab
     │   │                        #   (Trinary.tsx hosts both as tabs; engine in lib/nbody)

--- a/docs/sessions/handoff/fractal-df64-precise-fix/2026-06-29-S01.md
+++ b/docs/sessions/handoff/fractal-df64-precise-fix/2026-06-29-S01.md
@@ -1,0 +1,129 @@
+---
+kind: handoff
+session: 2026-06-29-S01
+date: 2026-06-29
+title: Fractal deep zoom — df64 extended precision, auto-iterations, scale key
+branch: claude/fractal-df64-precise-fix
+slug: fractal-df64-precise-fix
+status: completed
+build: passed
+followup: LOW
+pr: 243
+app: fractals, correspondence
+signals: visual-unverified
+next: Merge #243 (auto-iterations) so deep zoom renders; then quad-float or perturbation for depth past the ~1e13× df64 wall.
+---
+
+# Fractal deep zoom — df64 extended precision, auto-iterations, scale key
+
+## Summary
+
+The fractal viewers (FractalsGPU and Correspondence) now zoom far past the
+single-precision wall using **df64 emulated double precision** (PR #242, merged),
+and deep zoom now actually *shows* detail because iterations **auto-scale with
+zoom** (PR #243, open). A `DEEP_ZOOM.md` explainer documents the method and the
+limits of finite-bit computation. This session also added a **scale readout**
+(the real unit size at the current zoom) and a **TODO** for going past the df64
+wall via quad-float or perturbation theory. Build is green; the only caveat is
+that all deep-zoom verification was done headless (SwiftShader), not on real
+hardware.
+
+## What changed
+
+Two PRs, one continuous arc:
+
+- **PR #242 (merged to `main`)** — df64 extended precision. Each coordinate is
+  carried as an unevaluated `(hi, lo)` pair of float32s; `dfAdd`/`dfMul` are
+  error-free transformations (two-sum, Dekker two-product). A Standard/Extended
+  toggle picks float32 vs df64. Shipped with `DEEP_ZOOM.md`.
+- **PR #243 (open, this branch)** — the fix for "no improvement," plus this
+  session's additions:
+  - **Auto-raise iterations with zoom** (default on, both apps). The df64
+    arithmetic was correct all along; the reason deep zoom looked unchanged was
+    the default 100-iteration cap (max 1000) — at depth, escape counts run into
+    the thousands, so every deep point hit the cap and rendered as flat interior
+    regardless of precision. Now the cap scales with `log2(zoom)`; ceiling raised
+    to 4000.
+  - **Scale key** — the Viewport readout shows the view's true math width and
+    per-pixel size (e.g. `Scale: 4.0000 wide · 0.0058/px`).
+  - **`TODO(deep-zoom)`** — documents the path past the df64 wall.
+
+The df64 wall was **measured** (not just theorized): df64 tracks a float64 CPU
+reference through ~1e13×, then pixelates at ~1e14× — exactly where two stacked
+float32s (~14 digits) run out.
+
+## Key files
+
+| File | Role |
+|---|---|
+| [`src/animations/FractalsGPU/FractalsGPU.tsx`](https://github.com/piyarsquare/animath/blob/fc4623d18a82d0a5d0f2d8898c63ab1f5a542029/src/animations/FractalsGPU/FractalsGPU.tsx) | df64 shader (Standard/Extended), `suggestedIter`/auto-iter, scale readout, `TODO(deep-zoom)` |
+| [`src/animations/Correspondence/FractalPane.tsx`](https://github.com/piyarsquare/animath/blob/fc4623d18a82d0a5d0f2d8898c63ab1f5a542029/src/animations/Correspondence/FractalPane.tsx) | shared two-pane df64 shader; loops use constant bound + dynamic break (MAX_ITER 4000) |
+| [`src/animations/Correspondence/Correspondence.tsx`](https://github.com/piyarsquare/animath/blob/fc4623d18a82d0a5d0f2d8898c63ab1f5a542029/src/animations/Correspondence/Correspondence.tsx) | precision toggle, auto-iter, scale readout for the deeper pane |
+| [`src/animations/FractalsGPU/DEEP_ZOOM.md`](https://github.com/piyarsquare/animath/blob/fc4623d18a82d0a5d0f2d8898c63ab1f5a542029/src/animations/FractalsGPU/DEEP_ZOOM.md) | the explainer: finite precision, why df64 is legitimate, the wall, perturbation beyond |
+| [`scripts/df64-gpu-probe.mjs`](https://github.com/piyarsquare/animath/blob/fc4623d18a82d0a5d0f2d8898c63ab1f5a542029/scripts/df64-gpu-probe.mjs) | deterministic GPU pass/fail: df64 vs float32 vs float64 reference |
+| [`scripts/df64-image-probe.mjs`](https://github.com/piyarsquare/animath/blob/fc4623d18a82d0a5d0f2d8898c63ab1f5a542029/scripts/df64-image-probe.mjs) | before/after tiles (`ZOOM`/`MAXITER` env) for visual verification |
+
+## Open / not done
+
+- **Merge #243.** Until it lands, `main` (only #242) still shows flat/black at
+  deep zoom because iterations don't auto-scale — i.e. the original "no
+  improvement" symptom persists on `main`.
+- **Deep zoom past ~1e13×** (the `TODO(deep-zoom)`): quad-float (more headroom,
+  ~1e28×, self-contained) or perturbation + reference orbit (effectively
+  unlimited; needs a CPU reference orbit, glitch detection/rebasing, bignum past
+  ~1e15×). The user agreed the perturbation math is interesting — likely the next
+  session.
+- **Real-hardware check.** All deep-zoom verification was headless SwiftShader.
+  df64 relies on the GLSL compiler not reassociating floats; conformant drivers
+  don't, and SwiftShader confirmed correct, but a real-GPU spot-check is worth
+  doing (`signals: visual-unverified`).
+
+## Context
+
+- The scale/zoom readouts live in the **Viewport** panel, which is not in the
+  default "Essentials" layout — open it from the rail to see them.
+- The probes are standalone (no app, no debug hook): `node scripts/df64-gpu-probe.mjs`
+  for a verdict, `ZOOM=1e7 node scripts/df64-image-probe.mjs <dir>` for tiles.
+- df64 (~14 digits) is actually slightly *less* precise than a single JS float64
+  (~16 digits); we use it because WebGL fragment shaders have no real double. The
+  app's view state is float64, so the shader's df64 is the binding limit.
+
+## Self-reflection
+
+1. **What would you do with another session?** Build the perturbation-theory
+   deep-zoom engine (reference orbit + δ recurrence + glitch detection) — the
+   genuinely unlimited path and the one the user flagged as interesting. Quad-float
+   is a smaller intermediate step if a full engine is too much.
+2. **What would you change about what you produced?** The first PR (#242) shipped
+   df64 without verifying the *experience* — only the math and compilation. I
+   should have rendered a real deep-zoom before/after image then, which would have
+   caught the iteration-cap blocker immediately instead of after the user reported
+   it.
+3. **What were you not asked that you think is important?** Whether to merge #243
+   before extending further — it should go in first, or `main` keeps showing the
+   "no improvement" symptom. Also whether the legacy CPU fractals app wants the
+   same auto-iter treatment.
+4. **What did we both overlook (the first time)?** That precision and iterations
+   are *independent* limits: fixing one without the other leaves deep zoom looking
+   broken. The explainer now states this explicitly.
+5. **What did you find difficult?** Driving the real app to a precise deep
+   boundary point — blind wheel-zoom kept drifting into flat regions, and reading
+   pixels back from a WebGL canvas (no `preserveDrawingBuffer`) returned empty
+   buffers, making my first metrics bogus. Full-window screenshots + a temporary
+   `setView` debug hook were what made it reliable.
+6. **What would have made this task easier?** A built-in way to set an exact view
+   (URL params or a coordinate input). I used a throwaway debug hook; a permanent
+   "go to coordinate / zoom" control would help both users and testing — worth
+   considering alongside the deep-zoom engine.
+7. **How did you verify this, and does each passing check test the user-visible
+   claim?** Methods: `npm run build` (green, real gate), `npm run lint` (0 errors),
+   standalone GPU readback probe (df64 vs float64 truth — tests the arithmetic
+   claim directly), and headless full-window screenshots of the real app at exact
+   deep views (tests the user-visible "Extended resolves detail" claim). All
+   rendering was **headless SwiftShader**, not a real GPU — the visual claims are
+   verified in software, hence `signals: visual-unverified`. The scale readout was
+   confirmed by screenshot (`Scale: 4.0000 wide · 0.0058/px`).
+8. **Follow-up value:** LOW — the shipped work is complete and verified; the main
+   open item (merge #243) and the deep-zoom engine are clearly scoped follow-ups,
+   not corrections.
+</content>

--- a/docs/sessions/progress/fractal-df64-precise-fix/2026-06-29-S01.md
+++ b/docs/sessions/progress/fractal-df64-precise-fix/2026-06-29-S01.md
@@ -1,0 +1,84 @@
+---
+kind: progress
+session: 2026-06-29-S01
+date: 2026-06-29
+title: Fractal deep zoom — df64 extended precision, auto-iterations, scale key
+branch: claude/fractal-df64-precise-fix
+slug: fractal-df64-precise-fix
+status: completed
+build: passed
+followup: LOW
+pr: 243
+app: fractals, correspondence
+signals: visual-unverified
+next: Merge #243 (auto-iterations) so deep zoom renders; then quad-float or perturbation for depth past the ~1e13× df64 wall.
+---
+
+# Fractal deep zoom — df64 extended precision, auto-iterations, scale key
+
+## Session purpose
+
+Make the fractal viewers zoom past the float32 resolution wall, explain the
+method in a code-explainer document, and figure out why the first attempt
+appeared to do nothing. Then add a "scale" readout of the current unit size, and
+record a TODO for going deeper still.
+
+## Previous session
+
+First tracked session on this branch. Builds on PR #242 (the initial df64
+implementation, merged to `main` earlier this session on branch
+`claude/fractal-plot-resolution-fyhm0q`).
+
+## Working notes
+
+### 🟡 milestone · 19:40 — Scale key + deep-zoom TODO shipped; session wrapped
+**Why:** the user's one requested addition for this session, plus a recorded path forward.
+
+Added a **scale readout** to the Viewport panel (FractalsGPU) and Correspondence:
+the view's true math-coordinate width and per-pixel size (e.g.
+`Scale: 4.0000 wide · 0.0058/px`), so the actual unit size is legible at any
+zoom — complementing the relative `Zoom: N×`. Added `TODO(deep-zoom)` in
+`FractalsGPU.tsx` documenting the two ways past the df64 wall (quad-float;
+perturbation + reference orbit, with the δ-from-reference recurrence and its
+catches). Committed `fc4623d`, pushed to #243.
+
+### 🔵 finding · 19:10 — Mapped the df64 wall: ~1e13–1e14× (visually + numerically)
+**Why:** to answer "are we at a hard limit?" with data, not theory.
+
+A standalone GPU strip sweep (`scripts/df64-gpu-probe.mjs` logic, extended)
+shows df64 tracking a float64 CPU reference essentially perfectly through 1e13×,
+degrading at 1e14×. A visual zoom-ladder at the seahorse-valley boundary
+(`−0.7436438870371587 + 0.1318259042053119 i`) is crisp at 1e8/1e11/1e13× and
+breaks into square pixel blocks at 1e14×, fully collapsed at 1e15×. So df64 is a
+genuine, predictable wall (~14 digits). Going deeper needs quad-float or
+perturbation theory — recorded as the TODO.
+
+### 🟢 code · 18:30 — Fix: auto-raise iterations with zoom (the real blocker)
+**Why:** df64 was correct, but the default 100-iteration cap made deep zoom render as flat interior, hiding the gain entirely.
+
+Added "Auto-raise with zoom" (default on) to both FractalsGPU and Correspondence:
+the iteration cap scales with `log2(zoom)`. Raised the ceiling (shader `MAX_ITER`
+1000→4000, slider max to match; FractalPane loops moved to constant-bound +
+dynamic break). Verified end-to-end via a temporary debug hook: at 1e7× the
+seahorse valley is giant blocks in Standard and fully resolved in Extended,
+automatically. PR #243.
+
+### 🔵 finding · 17:45 — Diagnosed "no improvement": iterations, not arithmetic
+**Why:** the user reported the merged df64 (PR #242) showed no visible improvement.
+
+Built standalone GPU readback tests (no app, no flaky navigation):
+`df64-gpu-probe.mjs` proved df64 reproduces the float64 truth where float32
+collapses — the arithmetic was never the problem. `df64-image-probe.mjs` (before/
+after tiles) exposed the real cause: at deep zoom escape counts run into the
+thousands, but the default cap was 100 (max 1000), so every deep point hit the
+cap and rendered as solid interior regardless of precision.
+
+### 🟡 milestone · 16:30 — df64 deep zoom + DEEP_ZOOM.md explainer merged (#242)
+**Why:** the original request — zoom past the float32 wall and explain why it is legitimate.
+
+Implemented emulated double precision (two stacked float32s, error-free
+two-sum/two-product) in FractalsGPU and Correspondence's shared FractalPane,
+with a Standard/Extended toggle. Wrote `DEEP_ZOOM.md` (ComplexParticles-style
+explainer: finite mantissa, machine epsilon, why the error-free transforms are
+exact, df64's own wall, perturbation beyond). Merged to `main` as PR #242.
+</content>

--- a/scripts/df64-gpu-probe.mjs
+++ b/scripts/df64-gpu-probe.mjs
@@ -1,0 +1,192 @@
+// GPU df64 diagnostic. Renders a deep-zoom Mandelbrot strip with the SAME df64
+// GLSL the app ships, reads the escape counts back, and compares the float32
+// path (hp=0) and the df64 path (hp=1) against a CPU float64 reference.
+//
+// If df64 works on this GPU/driver: the hp=1 row tracks the float64 truth
+// (many distinct values, short runs), while hp=0 is blocky (long identical
+// runs) and disagrees with the truth.
+//
+// If the shader compiler has optimized the error-free transforms away: hp=1
+// looks just like hp=0 (both blocky, both disagree with truth) — that is the
+// classic GPU df64 failure and tells us the source needs the optimizer
+// defeated.
+import puppeteer from 'puppeteer';
+
+const args = ['--headless=new','--use-gl=angle','--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader','--no-sandbox','--disable-dev-shm-usage'];
+const browser = await puppeteer.launch({ args });
+const page = await browser.newPage();
+page.on('console', m => console.log('[page]', m.text()));
+page.on('pageerror', e => console.log('[pageerror]', e.message));
+
+// Deep-zoom center on the seahorse-valley boundary, width well past the float32
+// wall (~1e5×) but inside the df64 ceiling (~1e13×).
+const CENTER_X = -0.743643838;
+const CENTER_Y = 0.13182590421;
+const WIDTH = 2e-8;            // zoom ~2e8×
+const N = 256;                 // pixels across the strip
+const MAX_ITER = 2000;
+
+const result = await page.evaluate(({ CENTER_X, CENTER_Y, WIDTH, N, MAX_ITER }) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = N; canvas.height = 1;
+  const gl = canvas.getContext('webgl2');
+  if (!gl) return { error: 'no webgl2' };
+
+  const vs = `#version 300 es
+    in vec2 p; void main(){ gl_Position = vec4(p, 0.0, 1.0); }`;
+
+  const fs = `#version 300 es
+    precision highp float;
+    uniform vec2 centerHi, centerLo;
+    uniform float width;
+    uniform int maxIter;
+    uniform int hp;
+    uniform float n;
+    out vec4 frag;
+
+    vec2 dfAdd(vec2 a, vec2 b){
+      float t1 = a.x + b.x;
+      float e  = t1 - a.x;
+      float t2 = ((b.x - e) + (a.x - (t1 - e))) + a.y + b.y;
+      float hi = t1 + t2;
+      float lo = t2 - (hi - t1);
+      return vec2(hi, lo);
+    }
+    vec2 dfMul(vec2 a, vec2 b){
+      float split = 4097.0;
+      float cona = a.x * split;
+      float conb = b.x * split;
+      float a1 = cona - (cona - a.x);
+      float b1 = conb - (conb - b.x);
+      float a2 = a.x - a1;
+      float b2 = b.x - b1;
+      float c11 = a.x * b.x;
+      float c21 = a2 * b2 - (((c11 - a1 * b1) - a2 * b1) - a1 * b2);
+      float c2 = a.x * b.y + a.y * b.x;
+      float t1 = c11 + c2;
+      float e = t1 - c11;
+      float t2 = ((c2 - e) + (c11 - (t1 - e))) + c21 + a.y * b.y;
+      float hi = t1 + t2;
+      float lo = t2 - (hi - t1);
+      return vec2(hi, lo);
+    }
+    vec2 dfNeg(vec2 a){ return vec2(-a.x, -a.y); }
+
+    void main(){
+      float u = (gl_FragCoord.x - 0.5) / n;   // 0..1 across the strip
+      float ox = (u - 0.5) * width;
+      int i = 0;
+      if(hp == 0){
+        vec2 c = vec2(centerHi.x + ox, centerHi.y);
+        vec2 z = vec2(0.0);
+        for(i=0;i<maxIter;i++){
+          if(dot(z,z) > 4.0) break;
+          z = vec2(z.x*z.x - z.y*z.y, 2.0*z.x*z.y) + c;
+        }
+      } else {
+        vec2 cr = dfAdd(vec2(centerHi.x, centerLo.x), vec2(ox, 0.0));
+        vec2 ci = vec2(centerHi.y, centerLo.y);
+        vec2 zr = vec2(0.0), zi = vec2(0.0);
+        for(i=0;i<maxIter;i++){
+          vec2 mag = dfAdd(dfMul(zr,zr), dfMul(zi,zi));
+          if(mag.x > 4.0) break;
+          vec2 nr = dfAdd(dfAdd(dfMul(zr,zr), dfNeg(dfMul(zi,zi))), cr);
+          vec2 ni = dfAdd(dfMul(dfMul(vec2(2.0,0.0), zr), zi), ci);
+          zr = nr; zi = ni;
+        }
+      }
+      float r = mod(float(i), 256.0) / 255.0;
+      float g = floor(float(i) / 256.0) / 255.0;
+      frag = vec4(r, g, 0.0, 1.0);
+    }`;
+
+  const compile = (type, src) => {
+    const s = gl.createShader(type); gl.shaderSource(s, src); gl.compileShader(s);
+    if (!gl.getShaderParameter(s, gl.COMPILE_STATUS)) throw new Error(gl.getShaderInfoLog(s));
+    return s;
+  };
+  const prog = gl.createProgram();
+  gl.attachShader(prog, compile(gl.VERTEX_SHADER, vs));
+  gl.attachShader(prog, compile(gl.FRAGMENT_SHADER, fs));
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) return { error: gl.getProgramInfoLog(prog) };
+  gl.useProgram(prog);
+
+  const buf = gl.createBuffer();
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 3,-1, -1,3]), gl.STATIC_DRAW);
+  const loc = gl.getAttribLocation(prog, 'p');
+  gl.enableVertexAttribArray(loc);
+  gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
+  // df64 split of the center coords (hi, lo).
+  const split = v => { const hi = Math.fround(v); return [hi, v - hi]; };
+  const [cxHi, cxLo] = split(CENTER_X);
+  const [cyHi, cyLo] = split(CENTER_Y);
+
+  const readRow = (hp) => {
+    gl.uniform2f(gl.getUniformLocation(prog, 'centerHi'), cxHi, cyHi);
+    gl.uniform2f(gl.getUniformLocation(prog, 'centerLo'), cxLo, cyLo);
+    gl.uniform1f(gl.getUniformLocation(prog, 'width'), WIDTH);
+    gl.uniform1i(gl.getUniformLocation(prog, 'maxIter'), MAX_ITER);
+    gl.uniform1f(gl.getUniformLocation(prog, 'n'), N);
+    gl.uniform1i(gl.getUniformLocation(prog, 'hp'), hp);
+    gl.viewport(0, 0, N, 1);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+    const px = new Uint8Array(N * 4);
+    gl.readPixels(0, 0, N, 1, gl.RGBA, gl.UNSIGNED_BYTE, px);
+    const out = [];
+    for (let k = 0; k < N; k++) out.push(px[k*4] + px[k*4+1]*256);
+    return out;
+  };
+
+  return { single: readRow(0), double: readRow(1) };
+}, { CENTER_X, CENTER_Y, WIDTH, N, MAX_ITER });
+
+await browser.close();
+
+if (result.error) { console.log('ERROR:', result.error); process.exit(1); }
+
+// CPU float64 reference for the same 256 coordinates.
+function escTruth(cx, cy, m){ let zx=0,zy=0,i=0; for(;i<m;i++){ if(zx*zx+zy*zy>4) break; const nx=zx*zx-zy*zy+cx; const ny=2*zx*zy+cy; zx=nx; zy=ny; } return i; }
+const truth = [];
+for (let k = 0; k < N; k++) {
+  const u = (k + 0.5) / N;
+  const cx = CENTER_X + (u - 0.5) * WIDTH;
+  truth.push(escTruth(cx, CENTER_Y, MAX_ITER));
+}
+
+const stats = (row) => {
+  const distinct = new Set(row).size;
+  let maxRun = 1, run = 1;
+  for (let k = 1; k < row.length; k++) { if (row[k] === row[k-1]) { run++; maxRun = Math.max(maxRun, run); } else run = 1; }
+  let matchTruth = 0;
+  for (let k = 0; k < row.length; k++) if (Math.abs(row[k] - truth[k]) <= 1) matchTruth++;
+  return { distinct, maxRun, matchTruth };
+};
+
+const zoom = 4 / WIDTH;
+console.log(`\ndeep-zoom strip: ${N}px, center (${CENTER_X}, ${CENTER_Y}), width ${WIDTH.toExponential(1)} (zoom ~${zoom.toExponential(1)}×), maxIter ${MAX_ITER}\n`);
+const tS = stats(result.single), tD = stats(result.double), tT = stats(truth);
+const fmt = (name, s) => `  ${name.padEnd(16)} distinct=${String(s.distinct).padStart(3)}  longestFlatRun=${String(s.maxRun).padStart(3)}  matchesTruth=${s.matchTruth}/${N}`;
+console.log(fmt('float64 truth', tT));
+console.log(fmt('GPU float32', tS));
+console.log(fmt('GPU df64', tD));
+
+console.log('\n  first 24 escape counts:');
+console.log('    truth :', truth.slice(0, 24).join(' '));
+console.log('    f32   :', result.single.slice(0, 24).join(' '));
+console.log('    df64  :', result.double.slice(0, 24).join(' '));
+
+// df64 works if it resolves the strip like the truth (many distinct values,
+// short flat runs) while float32 is blocky (few distinct, long runs). We judge
+// by STRUCTURE, not exact escape counts — tiny df64 rounding shifts the exact
+// escape iteration by ±1 deep in the orbit, which is invisible in the image.
+const df64Works = tD.maxRun < N / 4 && tD.distinct > tS.distinct * 5 && tS.maxRun > N / 2;
+const df64Dead  = tD.maxRun >= tS.maxRun * 0.8 && tD.distinct <= tS.distinct * 1.5;
+console.log('\n  VERDICT: ' + (df64Works
+  ? '✓ df64 WORKS on this GPU — it resolves the strip like the float64 truth, where float32 is blocky.'
+  : df64Dead
+    ? '✗ df64 is NOT helping — it behaves like float32. The compiler likely optimized away the error-free transforms.'
+    : '? inconclusive — inspect the numbers above.'));

--- a/scripts/df64-image-probe.mjs
+++ b/scripts/df64-image-probe.mjs
@@ -1,0 +1,87 @@
+// Render a deep-zoom Mandelbrot TILE in float32 vs df64, at a given iteration
+// cap, and save PNGs — to SEE whether df64 resolves detail and how many
+// iterations the depth needs. Args: ZOOM, MAXITER (env).
+import puppeteer from 'puppeteer';
+import { writeFileSync } from 'fs';
+
+const OUT = process.argv[2] ?? '/tmp';
+const ZOOM = Number(process.env.ZOOM ?? 1e7);
+const MAXITER = Number(process.env.MAXITER ?? 1000);
+const SIZE = 420;
+const CENTER_X = -0.743643887037151, CENTER_Y = 0.13182590420533;  // seahorse valley
+const WIDTH = 4 / ZOOM;
+
+const args = ['--headless=new','--use-gl=angle','--use-angle=swiftshader',
+  '--enable-unsafe-swiftshader','--no-sandbox','--disable-dev-shm-usage'];
+const browser = await puppeteer.launch({ args });
+const page = await browser.newPage();
+page.on('pageerror', e => console.log('[pageerror]', e.message));
+
+const data = await page.evaluate(({ CENTER_X, CENTER_Y, WIDTH, SIZE, MAXITER }) => {
+  const canvas = document.createElement('canvas');
+  canvas.width = SIZE; canvas.height = SIZE;
+  const gl = canvas.getContext('webgl');
+  const vs = `attribute vec2 position; attribute vec2 uv; varying vec2 vUv;
+    void main(){ vUv = uv; gl_Position = vec4(position,0.0,1.0); }`;
+  const fs = `
+    precision highp float;
+    varying vec2 vUv;
+    uniform vec2 centerHi, centerLo, span; uniform int maxIter, hp;
+    vec2 dfAdd(vec2 a, vec2 b){ float t1=a.x+b.x; float e=t1-a.x;
+      float t2=((b.x-e)+(a.x-(t1-e)))+a.y+b.y; float hi=t1+t2; float lo=t2-(hi-t1); return vec2(hi,lo); }
+    vec2 dfMul(vec2 a, vec2 b){ float s=4097.0; float ca=a.x*s,cb=b.x*s;
+      float a1=ca-(ca-a.x),b1=cb-(cb-b.x); float a2=a.x-a1,b2=b.x-b1;
+      float c11=a.x*b.x; float c21=a2*b2-(((c11-a1*b1)-a2*b1)-a1*b2);
+      float c2=a.x*b.y+a.y*b.x; float t1=c11+c2; float e=t1-c11;
+      float t2=((c2-e)+(c11-(t1-e)))+c21+a.y*b.y; float hi=t1+t2; float lo=t2-(hi-t1); return vec2(hi,lo); }
+    vec2 dfNeg(vec2 a){ return vec2(-a.x,-a.y); }
+    vec3 ramp(float t){ // simple cyclic color for escape bands
+      return 0.5 + 0.5*cos(6.2831*(t*0.05 + vec3(0.0,0.33,0.67))); }
+    void main(){
+      float ox=(vUv.x-0.5)*span.x; float oy=(vUv.y-0.5)*span.y;
+      int i=0;
+      if(hp==0){
+        vec2 c=vec2(centerHi.x+ox, centerHi.y+oy); vec2 z=vec2(0.0);
+        for(int it=0; it<6000; it++){ if(it>=maxIter) break; if(dot(z,z)>4.0) break;
+          z=vec2(z.x*z.x-z.y*z.y, 2.0*z.x*z.y)+c; i=it+1; }
+      } else {
+        vec2 cr=dfAdd(vec2(centerHi.x,centerLo.x), vec2(ox,0.0));
+        vec2 ci=dfAdd(vec2(centerHi.y,centerLo.y), vec2(oy,0.0));
+        vec2 zr=vec2(0.0), zi=vec2(0.0);
+        for(int it=0; it<6000; it++){ if(it>=maxIter) break;
+          vec2 mag=dfAdd(dfMul(zr,zr),dfMul(zi,zi)); if(mag.x>4.0) break;
+          vec2 nr=dfAdd(dfAdd(dfMul(zr,zr),dfNeg(dfMul(zi,zi))),cr);
+          vec2 ni=dfAdd(dfMul(dfMul(vec2(2.0,0.0),zr),zi),ci);
+          zr=nr; zi=ni; i=it+1; }
+      }
+      if(i>=maxIter) gl_FragColor=vec4(0.0,0.0,0.0,1.0);
+      else gl_FragColor=vec4(ramp(float(i)),1.0);
+    }`;
+  const comp=(t,s)=>{const sh=gl.createShader(t);gl.shaderSource(sh,s);gl.compileShader(sh);
+    if(!gl.getShaderParameter(sh,gl.COMPILE_STATUS))throw new Error(gl.getShaderInfoLog(sh));return sh;};
+  const prog=gl.createProgram(); gl.attachShader(prog,comp(gl.VERTEX_SHADER,vs));
+  gl.attachShader(prog,comp(gl.FRAGMENT_SHADER,fs)); gl.linkProgram(prog); gl.useProgram(prog);
+  const verts=new Float32Array([-1,-1,0,0, 1,-1,1,0, -1,1,0,1, -1,1,0,1, 1,-1,1,0, 1,1,1,1]);
+  const buf=gl.createBuffer(); gl.bindBuffer(gl.ARRAY_BUFFER,buf); gl.bufferData(gl.ARRAY_BUFFER,verts,gl.STATIC_DRAW);
+  const pL=gl.getAttribLocation(prog,'position'), uL=gl.getAttribLocation(prog,'uv');
+  gl.enableVertexAttribArray(pL); gl.vertexAttribPointer(pL,2,gl.FLOAT,false,16,0);
+  gl.enableVertexAttribArray(uL); gl.vertexAttribPointer(uL,2,gl.FLOAT,false,16,8);
+  const split=v=>{const hi=Math.fround(v);return [hi,v-hi];};
+  const [cxHi,cxLo]=split(CENTER_X), [cyHi,cyLo]=split(CENTER_Y);
+  const draw=(hp)=>{
+    gl.uniform2f(gl.getUniformLocation(prog,'centerHi'),cxHi,cyHi);
+    gl.uniform2f(gl.getUniformLocation(prog,'centerLo'),cxLo,cyLo);
+    gl.uniform2f(gl.getUniformLocation(prog,'span'),WIDTH,WIDTH);
+    gl.uniform1i(gl.getUniformLocation(prog,'maxIter'),MAXITER);
+    gl.uniform1i(gl.getUniformLocation(prog,'hp'),hp);
+    gl.viewport(0,0,SIZE,SIZE); gl.drawArrays(gl.TRIANGLES,0,6);
+    return canvas.toDataURL('image/png');
+  };
+  return { single: draw(0), double: draw(1) };
+}, { CENTER_X, CENTER_Y, WIDTH, SIZE, MAXITER });
+
+await browser.close();
+const save = (name, dataUrl) => { writeFileSync(`${OUT}/${name}`, Buffer.from(dataUrl.split(',')[1], 'base64')); console.log('wrote', name); };
+console.log(`zoom ~${ZOOM.toExponential(1)}×, maxIter ${MAXITER}`);
+save(`tile-f32.png`, data.single);
+save(`tile-df64.png`, data.double);

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -219,6 +219,10 @@ export default function Correspondence() {
         )}
         {precision === 'double' && <> — Extended (df64) precision, deep zoom.</>}
       </div>
+      <div className="am-hint">
+        {/* "scale key": the math-coordinate width of the deeper pane at this zoom. */}
+        Scale: {(() => { const w = 4 / deepZoom; return w >= 0.001 ? w.toFixed(4) : w.toExponential(2); })()} wide
+      </div>
     </div>
   );
 

--- a/src/animations/Correspondence/Correspondence.tsx
+++ b/src/animations/Correspondence/Correspondence.tsx
@@ -2,12 +2,23 @@ import { useState, useRef, useEffect } from 'react';
 import FractalPane, { Complex, ViewBounds } from './FractalPane';
 import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef } from '../../chrome/workspace/types';
-import { Slider, Select, NumberInput, Pills } from '../../components/ControlPanel';
+import { Slider, Select, NumberInput, Pills, Checkbox } from '../../components/ControlPanel';
 import { Kicker } from '../../chrome/readouts';
 import readmeText from './README.md?raw';
 import explainerText from './EXPLAINER.md?raw';
 import { PALETTE_OPTIONS, PALETTE_THEME, resolvePalette } from '../../lib/colormaps';
 import { useThemeId } from '../../chrome/skins';
+
+/** Hard ceiling on iterations (must match FractalPane's MAX_ITER). */
+const MAX_ITERATIONS = 4000;
+
+/** A reasonable iteration cap for a given zoom — deep zoom needs many more
+ *  iterations to resolve the boundary, otherwise it renders as flat interior
+ *  and the Extended-precision detail is invisible. Ramps with log2(zoom). */
+function suggestedIter(zoom: number): number {
+  const v = 100 + 110 * Math.max(0, Math.log2(Math.max(1, zoom)) - 2);
+  return Math.min(MAX_ITERATIONS, Math.max(100, Math.round(v / 10) * 10));
+}
 
 export default function Correspondence() {
   const baseView: ViewBounds = { xMin: -2.5, xMax: 1.5, yMin: -1.5, yMax: 1.5 };
@@ -15,6 +26,7 @@ export default function Correspondence() {
   const [juliaView, setJuliaView] = useState<ViewBounds>({ xMin: -2, xMax: 2, yMin: -2, yMax: 2 });
   const [c, setC] = useState<Complex>({ real: -0.7, imag: 0.27015 });
   const [iter, setIter] = useState(100);
+  const [autoIter, setAutoIter] = useState(true);
   const [precision, setPrecision] = useState<'single' | 'double'>('single');
   const themeId = useThemeId();
   const [paletteM, setPaletteM] = useState(PALETTE_THEME);
@@ -35,6 +47,17 @@ export default function Correspondence() {
 
   useEffect(() => { speedRef.current = speed; }, [speed]);
   useEffect(() => { playingRef.current = playing; }, [playing]);
+
+  // Auto-raise iterations with the deeper pane's zoom (until manual override),
+  // so deep zoom shows detail instead of a flat interior.
+  useEffect(() => {
+    if (!autoIter) return;
+    const zoom = Math.max(
+      4 / (mandelView.xMax - mandelView.xMin),
+      4 / (juliaView.xMax - juliaView.xMin),
+    );
+    setIter(suggestedIter(zoom));
+  }, [mandelView, juliaView, autoIter]);
   useEffect(() => { pausedRef.current = paused; }, [paused]);
 
   // Tap-to-pick is always armed (CHROME-REVIEW PR D, user decision a): tap is
@@ -177,9 +200,10 @@ export default function Correspondence() {
   );
   const iterationNode = (
     <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <Checkbox label="Auto-raise iterations with zoom" checked={autoIter} onChange={setAutoIter} />
       <Slider label="Max iterations" value={iter}
-        min={10} max={1000} step={10}
-        onChange={(v) => setIter(Math.max(1, Math.round(v)))}
+        min={10} max={MAX_ITERATIONS} step={10}
+        onChange={(v) => { setAutoIter(false); setIter(Math.max(1, Math.round(v))); }}
         format={v => String(v)} />
       <Pills label="Precision"
         options={[
@@ -202,7 +226,7 @@ export default function Correspondence() {
     { id: 'palettes', title: 'Palettes', arch: 'color', node: palettesNode, estHeight: 330 },
     { id: 'seed', title: 'Seed', arch: 'drive', node: seedNode, estHeight: 230 },
     { id: 'path', title: 'Path', arch: 'playback', node: pathNode, estHeight: 360 },
-    { id: 'iteration', title: 'Iteration', arch: 'quality', node: iterationNode, estHeight: 210 },
+    { id: 'iteration', title: 'Iteration', arch: 'quality', node: iterationNode, estHeight: 280 },
   ];
 
   const views: ViewDef[] = [

--- a/src/animations/Correspondence/EXPLAINER.md
+++ b/src/animations/Correspondence/EXPLAINER.md
@@ -43,6 +43,10 @@ of detail. The **Precision** toggle (Iteration panel) switches to **Extended**
 (df64 emulated double precision), carrying ~twice the digits to push the zoom
 wall out roughly ten-million-fold; the full method and the limits of computing
 with finite bits are written up in the **Fractals** app's *Deep zoom* note.
+Deep zoom also needs more **iterations** to resolve the boundary, so
+**Auto-raise iterations with zoom** (Iteration panel, on by default) scales them
+up as you dive — otherwise a deep view reads as flat interior whatever the
+precision.
 
 ## Possible sources & where to go further
 

--- a/src/animations/Correspondence/FractalPane.tsx
+++ b/src/animations/Correspondence/FractalPane.tsx
@@ -102,6 +102,8 @@ export default function FractalPane({
     uniform float offset;
     uniform int hp;          // 0 = single float32, 1 = extended (df64)
 
+    const int MAX_ITER = 4000;   // hard ceiling; maxIter is the dynamic cap
+
     // df64: an extended number is the unevaluated sum hi+lo of two float32s.
     // dfAdd / dfMul are error-free transformations (two-sum, Dekker
     // two-product) — they keep the rounding error in lo, roughly doubling the
@@ -144,8 +146,10 @@ export default function FractalPane({
         vec2 pos = vec2(centerHi.x + ox, centerHi.y + oy);
         vec2 z = fType==0 ? vec2(0.0) : pos;
         vec2 k = fType==0 ? pos : cHi;
-        for(i=0;i<maxIter;i++){
-          if(dot(z,z)>4.0) break;
+        i = maxIter;
+        for(int it=0; it<MAX_ITER; it++){
+          if(it>=maxIter) break;
+          if(dot(z,z)>4.0){ i = it; break; }
           vec2 zp = z;
           for(int p=1;p<10;p++){
             if(p>=power) break;
@@ -160,9 +164,11 @@ export default function FractalPane({
         vec2 zr, zi, kr, ki;
         if(fType==0){ zr=vec2(0.0); zi=vec2(0.0); kr=pr; ki=pi; }
         else { zr=pr; zi=pi; kr=vec2(cHi.x,cLo.x); ki=vec2(cHi.y,cLo.y); }
-        for(i=0;i<maxIter;i++){
+        i = maxIter;
+        for(int it=0; it<MAX_ITER; it++){
+          if(it>=maxIter) break;
           vec2 mag = dfAdd(dfMul(zr,zr), dfMul(zi,zi));
-          if(mag.x>4.0) break;
+          if(mag.x>4.0){ i = it; break; }
           vec2 ar=zr, ai=zi;
           vec2 qr=ar, qi=ai;
           for(int p=1;p<10;p++){

--- a/src/animations/FractalsGPU/DEEP_ZOOM.md
+++ b/src/animations/FractalsGPU/DEEP_ZOOM.md
@@ -147,6 +147,19 @@ program lives inside.
   the limit of two stacked floats — the genuine edge of what this representation
   can compute.
 
+### Iterations matter as much as precision
+
+Precision decides whether two nearby points get *different* coordinates;
+**iterations** decide whether the escape-time computation runs long enough to
+*tell them apart*. Escape times climb steeply with depth — a point that needs 80
+steps to escape near the surface may need 2000 in a deep valley. With too few
+iterations, every deep point hits the cap and is painted as solid interior, so a
+deep view looks like a flat blank no matter how much precision you have. (This is
+why extended precision can look like it "does nothing" at depth — the bottleneck
+is the iteration budget, not the arithmetic.) The **Iteration** panel's
+**Auto-raise with zoom** does this for you, scaling the cap up as you dive;
+turn it off to set the count by hand.
+
 ## Possible sources & where to go further
 
 Pointers for going deeper, not priority claims.

--- a/src/animations/FractalsGPU/EXPLAINER.md
+++ b/src/animations/FractalsGPU/EXPLAINER.md
@@ -31,7 +31,10 @@ iteration cap — is drawn solid.
 - **Power `k`** — the exponent in `zᵏ + c`. `k = 2` is the classic
   Mandelbrot; higher powers give `(k − 1)`-fold symmetry.
 - **Iterations** — how long we test each point before giving up. More
-  iterations resolve finer filaments but cost more time.
+  iterations resolve finer filaments but cost more time. Deep zoom needs *many*
+  more (escape times climb with depth), so **Auto-raise with zoom** (Iteration
+  panel, on by default) scales the count up as you dive — without it a deep view
+  reads as flat interior no matter the precision.
 - **Coloring mode** — escape velocity, limit magnitude, or a blend of both.
 - **Precision** (Viewport panel) — **Standard** is fast 32-bit float and
   pixelates somewhere past ~10⁵× zoom; **Extended** carries ~twice the digits

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -37,6 +37,22 @@ function suggestedIter(zoom: number): number {
   return Math.min(MAX_ITERATIONS, Math.max(100, Math.round(v / 10) * 10));
 }
 
+// TODO(deep-zoom): go past the df64 wall (~1e13-1e14x zoom, measured). Extended
+// (df64) carries ~14 digits, so neighboring pixels collapse to the same
+// coordinate beyond there (see DEEP_ZOOM.md "Extended has a wall too"). Two ways
+// deeper, in rough order of effort:
+//   1. Quad-float (4 stacked float32s, ~29 digits -> ~1e28x). Same compensated-
+//      arithmetic idea as df64, just more of it; ~4-10x slower. Self-contained.
+//   2. Perturbation + reference orbit -- the real fix, effectively unlimited
+//      depth. Compute ONE reference orbit Z_n at high precision on the CPU, then
+//      iterate only each pixel's deviation d from it on the GPU in plain float:
+//          d_{n+1} = 2*Z_n*d_n + d_n^2 + D       (D = pixel offset from reference)
+//      d stays tiny, so no per-pixel high precision is needed. Requires: a CPU
+//      reference orbit (bignum past ~1e15x), glitch detection (Pauldelbrot) +
+//      rebasing for pixels that diverge from the reference, and optionally
+//      series approximation to skip early iterations. The math is written up in
+//      DEEP_ZOOM.md; this is the architecturally interesting follow-up.
+
 const FORMULAS: Record<FractalType, string> = {
   mandelbrot: 'z_{n+1} = z_n^k + c',
   julia: 'z_{n+1} = z_n^k + c',
@@ -570,6 +586,12 @@ export default function FractalsGPU() {
   // value somewhere around 1e5×; df64 ("Extended") carries ~14 and pushes that
   // wall out by roughly 1e7×. See DEEP_ZOOM.md.
   const singleWall = zoom > 1e5;
+  // The "scale key": the real size of what's on screen at this zoom — the view's
+  // math-coordinate width, and the size one pixel covers.
+  const spanX = view.xMax - view.xMin;
+  const canvasW = rendererRef.current?.domElement?.clientWidth ?? 0;
+  const perPx = canvasW > 0 ? spanX / canvasW : 0;
+  const fmtScale = (v: number) => (v >= 0.001 ? v.toFixed(4) : v.toExponential(2));
   const viewportNode = (
     <>
       <button className="am-mini" style={{ width: '100%' }} onClick={reset}>
@@ -591,6 +613,9 @@ export default function FractalsGPU() {
           <> — past Standard precision; switch to <strong>Extended</strong> to keep resolving detail.</>
         )}
         {precision === 'double' && <> — Extended (df64) precision, deep zoom.</>}
+      </div>
+      <div className="am-hint">
+        Scale: {fmtScale(spanX)} wide{perPx > 0 && <> · {fmtScale(perPx)}/px</>}
       </div>
     </>
   );

--- a/src/animations/FractalsGPU/FractalsGPU.tsx
+++ b/src/animations/FractalsGPU/FractalsGPU.tsx
@@ -25,6 +25,18 @@ function splitDouble(value: number): [number, number] {
   return [hi, value - hi];
 }
 
+/** Hard ceiling on iterations (must match the shader's MAX_ITER). */
+const MAX_ITERATIONS = 4000;
+
+/** A reasonable iteration cap for a given zoom factor. Deep zoom needs many
+ *  more iterations to resolve the boundary (escape times grow with depth), so
+ *  this ramps up with log2(zoom) — without it, a deep view renders as a flat
+ *  interior and the Extended-precision detail is invisible. */
+function suggestedIter(zoom: number): number {
+  const v = 100 + 110 * Math.max(0, Math.log2(Math.max(1, zoom)) - 2);
+  return Math.min(MAX_ITERATIONS, Math.max(100, Math.round(v / 10) * 10));
+}
+
 const FORMULAS: Record<FractalType, string> = {
   mandelbrot: 'z_{n+1} = z_n^k + c',
   julia: 'z_{n+1} = z_n^k + c',
@@ -68,7 +80,7 @@ const fragmentShader = `
   uniform float offset;
   uniform int hp;          // 0 = single float32, 1 = extended (df64)
 
-  const int MAX_ITER = 1000;
+  const int MAX_ITER = 4000;
   const int MAX_POWER = 100;
 
   // ---- df64: an "extended" number is the unevaluated sum hi+lo of two float32s.
@@ -242,6 +254,11 @@ export default function FractalsGPU() {
    *  float (fast, pixelates past ~1e5× zoom); 'double' is df64 emulated double
    *  precision (≈14 digits, deep zoom — see DEEP_ZOOM.md), ~10× slower. */
   const [precision, setPrecision] = useState<'single' | 'double'>('single');
+  /** Auto-raise the iteration count as you zoom in. Deep zoom needs far more
+   *  iterations to resolve the boundary; with too few, everything reads as
+   *  interior (black) and any precision gain is invisible. The slider becomes a
+   *  manual override (dragging it turns Auto off). */
+  const [autoIter, setAutoIter] = useState(true);
 
   const normalizeView = useCallback((v: typeof view, canvas: HTMLCanvasElement) => {
     const aspect = canvas.width / canvas.height;
@@ -429,8 +446,16 @@ export default function FractalsGPU() {
     const canvas = rendererRef.current?.domElement;
     if (!canvas) return;
     setView(normalizeView(INITIAL_VIEW, canvas));
-    setIter(100);
+    setAutoIter(true);
   }, [normalizeView]);
+
+  // Auto-raise iterations with zoom (until the user takes manual control). This
+  // is what makes a deep zoom actually show detail instead of a flat interior.
+  useEffect(() => {
+    if (!autoIter) return;
+    const zoom = INITIAL_WIDTH / (view.xMax - view.xMin);
+    setIter(suggestedIter(zoom));
+  }, [view, autoIter]);
 
   useEffect(() => {
     if (animating) {
@@ -609,14 +634,19 @@ export default function FractalsGPU() {
 
   const iterationNode = (
     <>
+      <Checkbox label="Auto-raise with zoom" checked={autoIter} onChange={setAutoIter} />
       <Slider label="Max iterations" value={iter}
-        min={10} max={1000} step={10}
-        onChange={(v) => setIter(Math.max(1, Math.round(v)))}
+        min={10} max={MAX_ITERATIONS} step={10}
+        onChange={(v) => { setAutoIter(false); setIter(Math.max(1, Math.round(v))); }}
         format={v => String(v)} />
       <Slider label="Start iteration" value={startIter}
         min={0} max={500} step={1}
         onChange={(v) => setStartIter(Math.max(0, Math.round(v)))}
         format={v => String(v)} />
+      <div className="am-hint">
+        Deep zoom needs more iterations to resolve the boundary — leave
+        <strong> Auto</strong> on, or raise this yourself.
+      </div>
     </>
   );
 
@@ -625,7 +655,7 @@ export default function FractalsGPU() {
     { id: 'viewport', title: 'Viewport', arch: 'domain', node: viewportNode, estHeight: 230 },
     { id: 'palette', title: 'Palette', arch: 'color', node: paletteNode, estHeight: 280 },
     { id: 'trace', title: 'Trace', arch: 'drive', node: traceNode, estHeight: 130 },
-    { id: 'iteration', title: 'Iteration', arch: 'quality', node: iterationNode, estHeight: 150 },
+    { id: 'iteration', title: 'Iteration', arch: 'quality', node: iterationNode, estHeight: 240 },
   ];
 
   const views: ViewDef[] = [


### PR DESCRIPTION
## TL;DR

The df64 extended-precision path (PR #242) was **correct all along** — but deep zoom looked like it did nothing because of a *second, independent* limit: **iterations**. This PR diagnoses that with reproducible tests and fixes it by auto-scaling the iteration count with zoom.

## The investigation

After the report that deep zoom showed "no improvement," I built standalone GPU tests (no app, no flaky UI navigation):

- **`scripts/df64-gpu-probe.mjs`** renders a deep-zoom strip with the shipped df64 GLSL, reads the escape counts back, and compares **float32 / df64 / a float64 CPU reference**. Result at 2×10⁸×: float32 collapses the whole strip to one value; **df64 tracks the float64 truth almost exactly** (1070, 1070, 1070, 1071… vs truth 1070, 1070, 1070, 1071…). → the arithmetic was never the problem.
- **`scripts/df64-image-probe.mjs`** renders before/after tiles. This exposed the real culprit: at 1e7× the **escape counts are ~1000–2000**, but the default iteration cap is **100** (max 1000). Every deep point hits the cap and is painted as solid interior, so a deep view is a **flat blank regardless of precision** — toggling Extended appeared to do nothing.

End-to-end confirmation (headless WebGL, exact deep view): at 1e7× on the seahorse valley, Standard is giant blocks; Extended at 100 iterations is **black**; Extended with adequate iterations resolves **full filament detail**.

## The fix (both FractalsGPU and Correspondence)

- **"Auto-raise with zoom"** (Iteration panel, on by default): the iteration cap scales with `log2(zoom)`, so a deep dive automatically gets enough iterations to resolve the boundary. Dragging the slider takes manual control (turns Auto off); Reset re-enables it.
- **Raise the ceiling:** shader `MAX_ITER` 1000 → 4000 and the slider max to match. `FractalPane`'s loops moved to a constant bound + dynamic break (robust at the higher cap), preserving escape-count semantics.
- **Docs:** `DEEP_ZOOM.md` and both EXPLAINERs now explain that *iterations matter as much as precision* at depth.

## Answering "how do we test it?"

The two probes are committed as the reusable answer:
- `node scripts/df64-gpu-probe.mjs` → deterministic ✓/✗ ("df64 WORKS on this GPU…").
- `node scripts/df64-image-probe.mjs <dir>` (env `ZOOM`, `MAXITER`) → writes `tile-f32.png` / `tile-df64.png` for a visual before/after.

## Verification

- Build green, lint clean (0 errors, no new warnings).
- Default views unchanged (regression-checked); deep-zoom Extended now resolves detail automatically in both apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Jhq5DB92Wdz6RKaG4LnEwC)_