### PR TITLE
Trinary System: survivable default launches + safe-orbit finder, recovery, and engine tests

### DIFF
--- a/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
+++ b/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
@@ -5,12 +5,12 @@ date: 2026-07-17
 title: Trinary System review — safe default launches
 branch: claude/trinary-system-review-59t0w1
 slug: trinary-system-review
-status: in-progress
+status: complete
 build: passing
 followup: null
 pr: null
 app: trinary
-next: Discuss broader review suggestions with Dan (safe-radius derivation, chaos legibility).
+next: Optional follow-ups — tune default speed/ε if the fan-out still reads slow; consider a general "Find a stable orbit" affordance beyond the failure hint.
 ---
 
 # Trinary System review — safe default launches
@@ -28,6 +28,30 @@ unrelated app branches — Division Bells, Solid Worlds, Argand — nothing to
 continue here.)
 
 ## Working notes
+
+### 🟡 milestone · 14:30 — All six review suggestions implemented + verified
+**Why:** Dan said "fix them all." Each is now landed, built, tested, and driven.
+
+1. **Systematic safe launch** — a *derived* radius proved unreliable (Pythagorean
+   ejects a star → excursion→∞; Binary is hierarchical), and a bare single-probe
+   finds chaotic knife-edges (an r that survives at v dies at v±0.01). So added
+   `findStableLaunch(stars, target, opts)` — an engine helper that sweeps radius
+   outward, uses the local circular speed, and returns the first orbit that keeps
+   a real *clearance* margin from every star across a long probe. Pure, adapts to
+   current masses, tested (asserts the returned orbit genuinely survives).
+2. **Chaos legibility** — default `speed` 1 → 1.5× so the ghost fan-out reads sooner.
+3. **Pythagorean copy** — blurb now frames the planet as a witness, not a resident.
+4. **Graceful failure** — when the planet falls into a star, a hint toast appears
+   over the scene with a one-click **Find a stable orbit** button (also added to
+   the Planet-launch panel). Drove it with Puppeteer: bad launch (r=1.5) → planet
+   destroyed → click → launch becomes r=3.25 → **planet bound, paradise 100%**.
+5. **Naming** — `Observatory.tsx` (the analysis HUD) renamed to `AnalysisHUD.tsx`.
+6. **Engine tests** — added `integrator.test.ts` (symplectic energy bound, momentum
+   conservation, frozen-planet no-op; analyzer destroyed/habitable classification)
+   and extended `scenarios.test.ts` (findStableLaunch survivability, circularSpeed).
+
+`npm test` → 263 passed; `npm run build` clean; lint 0 errors. Verified visually
+across all four scenarios + the failure/recovery flow.
 
 ### 🟡 milestone · 13:05 — Fix applied, verified visually + regression-tested
 **Why:** Close the loop — the fix must be real (not just simulated) and locked in.
@@ -89,9 +113,11 @@ than incinerated.
 ### 🟣 decision · 12:45 — Fix all four launch defaults, not just the default scenario
 **Why:** Any scenario a user clicks is a "first impression"; three were broken.
 
-## Suggestions for improvement (broader review)
+## Suggestions for improvement (broader review) — all implemented
 
-Captured while reviewing; to discuss/prioritize with Dan. Ordered by value.
+All six were implemented this session (see the 14:30 milestone). Original notes
+kept below for the reasoning; #1 landed as an *empirical* finder rather than a
+closed-form derivation, because the physics defeats a derived radius.
 
 1. **Derive the safe launch radius instead of hardcoding it** (root cause of this
    bug). Each scenario hand-picks a `radius`; three were wrong. A helper that

--- a/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
+++ b/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
@@ -1,0 +1,149 @@
+---
+kind: progress
+session: 2026-07-17-S01
+date: 2026-07-17
+title: Trinary System review — safe default launches
+branch: claude/trinary-system-review-59t0w1
+slug: trinary-system-review
+status: in-progress
+build: passing
+followup: null
+pr: null
+app: trinary
+next: Discuss broader review suggestions with Dan (safe-radius derivation, chaos legibility).
+---
+
+# Trinary System review — safe default launches
+
+## Session purpose
+
+The Trinary System's out-of-the-box experience is a failure: on first load the
+planet falls into a star within ~2 sim-seconds ("explodes in the sun"). Give the
+default a better start, then review the app in general and suggest improvements.
+
+## Previous session
+
+First tracked session on this branch. (Latest handoffs across the repo are
+unrelated app branches — Division Bells, Solid Worlds, Argand — nothing to
+continue here.)
+
+## Working notes
+
+### 🟡 milestone · 13:05 — Fix applied, verified visually + regression-tested
+**Why:** Close the loop — the fix must be real (not just simulated) and locked in.
+
+Changed the four `launch` defaults in `src/lib/nbody/scenarios.ts`, rebuilt, and
+screenshotted each scenario headless after ~15–22s of simulation:
+
+- **Figure-Eight** (default): planet bound, HABITABLE, paradise 100% — a wide arc
+  well clear of the figure-eight loop. (Was: destroyed at t≈2.4.)
+- **Moth**: planet bound, HABITABLE, paradise 85%.
+- **Pythagorean**: planet bound and witnessing the violent stellar encounter
+  (tangled trails, one star flung out), climate timeline a rich paradise→chaotic mix.
+
+Added `src/lib/nbody/__tests__/scenarios.test.ts` (the engine had **zero** tests):
+integrates each scenario's default launch through the real leapfrog and asserts
+the planet isn't destroyed early (with a margin over the kill radius), holds the
+default scenario to a stricter long-run "bound" bar, and covers `recenter` /
+`launchPlanet` geometry. `npm test` → 253 passed; `npm run build` clean.
+
+### 🔵 finding · 12:20 — Three of four scenario launch defaults destroy the planet
+**Why:** Confirm the reported failure and check whether it's isolated to the default.
+
+Re-implemented the exact `nbody` leapfrog + `launchPlanet` geometry in a
+standalone script and simulated every scenario's shipped launch default:
+
+| Scenario | Current launch | Fate |
+|---|---|---|
+| Figure-Eight (default) | bary, r=1.8, v=1.1 | **destroyed** at t≈2.4 |
+| Moth | bary, r=2.2, v=1.1 | **destroyed** at t≈2.4 |
+| Pythagorean | bary, r=4.0, v=1.6 | **destroyed** at t≈7.5 |
+| Binary + Star | binary, r=1.6, v=1.1 | bound (fine) |
+
+The planets launch *inside* the region the stars sweep through, so a close pass
+consumes them almost immediately. Only Binary + Star (a genuine circumbinary
+orbit well outside a tight inner pair) survives.
+
+### 🔵 finding · 12:40 — Survivable launches exist for all but keep chaos legible
+**Why:** A safe default must still show the app's headline demo — ghosts fanning out.
+
+Scanned radius × speed × launch-angle, measuring long-run fate (T=1200), the
+12-ghost cloud-spread growth, and orbit framing. Chosen launches (verified bound
+past any realistic viewing window, angle 0):
+
+| Scenario | New launch | Fate @ T=1200 | min star dist |
+|---|---|---|---|
+| Figure-Eight | bary, r=3.2, v=1.0 | bound | 1.75 |
+| Moth | bary, r=3.5, v=0.95 | bound | 1.12 |
+| Pythagorean | bary, r=5.0, v=0.55 | survives to t≈1124, then ejected | 0.29 |
+| Binary + Star | binary, r=1.6, v=1.1 | bound (unchanged) | 1.03 |
+
+Trade-off noted: very wide circumbinary orbits (r≥4) survive but are too regular
+— the ghost cloud barely fans out, so the chaos demo falls flat. r≈3.2 keeps a
+visible fan-out (cloud spread ~0.16 by t≈120) while staying safe. Pythagorean is
+inherently destructive (Burrau's problem — three stars fall from rest and eject
+one of their own); no in-frame orbit survives forever, but r=5/v=0.55 lets the
+planet witness the whole spectacle and end by being flung into the dark rather
+than incinerated.
+
+### 🟣 decision · 12:45 — Fix all four launch defaults, not just the default scenario
+**Why:** Any scenario a user clicks is a "first impression"; three were broken.
+
+## Suggestions for improvement (broader review)
+
+Captured while reviewing; to discuss/prioritize with Dan. Ordered by value.
+
+1. **Derive the safe launch radius instead of hardcoding it** (root cause of this
+   bug). Each scenario hand-picks a `radius`; three were wrong. A helper that
+   returns a radius as a multiple of the stars' max excursion from the barycenter
+   (say 2.5–3×) would make *every* current and future scenario safe by
+   construction, and the per-scenario number becomes an optional override. The new
+   test guards the current values but doesn't prevent a future scenario shipping a
+   fresh bad one.
+
+2. **The chaos demo is slow to read at the default speed.** The headline effect —
+   the ghost cloud fanning out — takes ~80 sim-time to become visually obvious at
+   `speed = 1`, and the ghosts are nearly coincident on first load (see the
+   screenshots: no visible fan yet at t≈8–12). Options: bump the default `speed`
+   to ~1.5×, raise the default ghost `ε` slightly, or auto-scatter once after a
+   few seconds. Worth a quick experiment — it's the app's signature moment.
+
+3. **Pythagorean is inherently destructive.** Even with the new witness orbit the
+   planet is eventually ejected (t≈1124). That's physically honest (Burrau's
+   problem *is* about the stars destroying their own configuration), but the blurb
+   sells it as a place to "launch the planet." Consider copy that frames the planet
+   as a witness to violence rather than a resident — sets the right expectation.
+
+4. **Graceful failure UX.** When the reference planet dies there's a flare and the
+   sky view detonates, but no nudge toward recovery. If a launch dies within a few
+   sim-seconds, a one-line hint ("try a wider orbit, or the ◯ Circular orbit speed
+   button") would turn a dead end into a teaching moment. The "Circular orbit
+   speed" button already exists and is the right escape hatch — surface it.
+
+5. **Naming friction (minor).** `Observatory.tsx` is the analysis HUD, but the
+   user-facing *view* is labeled "Explore" and the old name "Observatory" still
+   shows as the persisted mode id and in a skin display name — three meanings for
+   one word (the code comments already flag this). A rename pass would reduce
+   confusion for the next editor.
+
+6. **Engine test coverage (partly addressed).** This session added the first
+   `nbody` tests (scenario survivability + geometry). The integrator itself
+   (energy conservation of the symplectic scheme over a long run) and the analyzer
+   (climate/era classification) are still untested and are good candidates.
+
+## Self-reflection
+
+**What went well:** Reproduced the failure quantitatively before touching code
+(standalone re-impl of the engine), which turned "the planet explodes" into a
+measurable fate + min-distance and let me scan the launch space for a fix that
+*also* preserves the chaos demo rather than just moving the planet far away.
+Verified visually (headless screenshots) and locked the fix with the engine's
+first tests.
+
+**What to watch:** The launch radii are still magic numbers — suggestion #1 is the
+real fix. And I widened Moth/Pythagorean beyond the reported default; those are
+lower-traffic but were equally broken, so the scope creep is justified and covered
+by the new test.
+
+**Follow-up value:** MEDIUM — the default is fixed and tested, but the safe-radius
+derivation (#1) and chaos legibility (#2) are worth a follow-up session.

--- a/src/animations/TrinaryStars/AnalysisHUD.tsx
+++ b/src/animations/TrinaryStars/AnalysisHUD.tsx
@@ -63,7 +63,7 @@ function insolBar(s: Snapshot): { pos: number; loPos: number; hiPos: number } {
   return { pos: map(s.S), loPos: map(s.Slo), hiPos: map(s.Shi) };
 }
 
-export default function Observatory({ snapshot }: { snapshot: Snapshot | null }) {
+export default function AnalysisHUD({ snapshot }: { snapshot: Snapshot | null }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   // Read tokens from inside the forced-dark scene subtree so the timeline tracks

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -52,6 +52,12 @@ function readScenePalette(el: Element): ScenePalette {
 }
 const TRAIL_MAX = 2000; // points stored per body; visible length is a live slider.
 const VEL_SCALE = 1;    // sim-units of drag → units of launch speed.
+/** Max launch radius the Start-radius control can represent. The safe-orbit
+ *  finder is bounded to this so a recovered launch is always shown and preserved
+ *  by the slider (a larger result would clamp on the next drag, back into a
+ *  possibly-unsafe orbit); when nothing survives within range, onFindStable falls
+ *  back to the scenario's safe default (always ≤ this). */
+const MAX_RADIUS = 8;
 const SAMPLE_DT = 0.05; // sim-time between classifier samples of the reference planet.
 
 /** Sim plane lives at world y = 0 so the camera can look down on it like a floor. */
@@ -827,7 +833,12 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   const onFindStable = () => {
     const sc = getScenario(presetId);
     const stars = buildStars(sc, massMul);
-    const found = findStableLaunch(stars, target, { starSoft, dt: sc.system.dt, rKill: Math.max(collisionRadius, 1e-4) });
+    const found = findStableLaunch(stars, target, {
+      starSoft, dt: sc.system.dt, rKill: Math.max(collisionRadius, 1e-4),
+      // Bound the search to the Start-radius control so the result is always
+      // representable (and preserved on a later slider drag).
+      largestRadius: MAX_RADIUS,
+    });
     setCustom(null);
     if (found) {
       setPlanetRadiusState(found.radius);
@@ -937,7 +948,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         value={target}
         onChange={setTarget}
       />
-      <Slider label="Start radius" value={planetRadius} min={0.1} max={8} step={0.05}
+      <Slider label="Start radius" value={planetRadius} min={0.1} max={MAX_RADIUS} step={0.05}
         onChange={setPlanetRadius} format={v => v.toFixed(2)} />
       <Slider label="Start speed" value={planetSpeed} min={0} max={3} step={0.05}
         onChange={setPlanetSpeed} format={v => v.toFixed(2)} />

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -5,10 +5,11 @@ import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../chrome/workspace/types';
 import { Slider, Pills, Select, NumberInput } from '../../components/ControlPanel';
 import {
-  step, cloudSpread, lyapunovRenorm, SCENARIOS, getScenario, buildStars, orbitFrame, launchPlanet, Analyzer, DEFAULT_CLASSIFY,
+  step, cloudSpread, lyapunovRenorm, SCENARIOS, getScenario, buildStars, launchPlanet,
+  circularSpeed, findStableLaunch, Analyzer, DEFAULT_CLASSIFY,
   type SimState, type Planet, type Star, type TargetId, type ClassifyParams, type Snapshot,
 } from '@/lib/nbody';
-import Observatory from './Observatory';
+import AnalysisHUD from './AnalysisHUD';
 import SkyView, { type SkyData } from './SkyView';
 import { usePersistentState, clearPersistedState } from '../../lib/usePersistentState';
 import { Scheme } from '../../chrome/Scheme';
@@ -212,7 +213,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   const [planetSpeed, setPlanetSpeedState] = usePersistentState(PK('planetSpeed'), getScenario(presetId).launch.speed);
   const [massMul, setMassMul] = usePersistentState<number[]>(fromLink ? null : PK('massMul'), [navNum(Q, 'm0', 1), navNum(Q, 'm1', 1), navNum(Q, 'm2', 1)]); // per-star mass multipliers
   const [starSoft, setStarSoft] = usePersistentState(fromLink ? null : PK('starSoft'), navNum(Q, 'ss', getScenario(presetId).system.softening)); // close-encounter softening
-  const [speed, setSpeed] = usePersistentState(PK('speed'), 1);          // sim-seconds per real-second
+  const [speed, setSpeed] = usePersistentState(PK('speed'), 1.5);        // sim-seconds per real-second (1.5× so the ghost cloud's fan-out reads sooner)
   const [trailLen, setTrailLen] = usePersistentState(PK('trailLen'), 500);
   const [showTrails, setShowTrails] = usePersistentState(PK('showTrails'), true);
   const [frameCenter, setFrameCenter] = usePersistentState(PK('frameCenter'), 'bary'); // reference-frame origin
@@ -814,9 +815,29 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   // Set the launch speed to the local circular speed √(M/r) for the target.
   const onAutoCircular = () => {
     const stars = buildStars(getScenario(presetId), massMul);
-    const f = orbitFrame(stars, target);
-    const v = Math.sqrt(f.mass / Math.max(0.05, planetRadius));
+    const v = circularSpeed(stars, target, planetRadius);
     setPlanetSpeed(Math.round(v / 0.05) * 0.05);
+  };
+
+  // Empirically find a launch (radius + circular speed) whose planet stays clear
+  // of every star for a long probe — the reliable "safe orbit" in a chaotic field
+  // (a derived radius fails: stars get ejected, hierarchical systems orbit a
+  // sub-system). Adapts to the *current* masses/target. Falls back to the
+  // scenario's verified-safe default launch if the current target admits none.
+  const onFindStable = () => {
+    const sc = getScenario(presetId);
+    const stars = buildStars(sc, massMul);
+    const found = findStableLaunch(stars, target, { starSoft, dt: sc.system.dt, rKill: Math.max(collisionRadius, 1e-4) });
+    setCustom(null);
+    if (found) {
+      setPlanetRadiusState(found.radius);
+      setPlanetSpeedState(found.speed);
+    } else {
+      // No stable orbit around the current target → restore the scenario default.
+      setTargetState(sc.launch.target);
+      setPlanetRadiusState(sc.launch.radius);
+      setPlanetSpeedState(sc.launch.speed);
+    }
   };
 
   const onTogglePlace = () => {
@@ -920,14 +941,19 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         onChange={setPlanetRadius} format={v => v.toFixed(2)} />
       <Slider label="Start speed" value={planetSpeed} min={0} max={3} step={0.05}
         onChange={setPlanetSpeed} format={v => v.toFixed(2)} />
-      <button style={{ ...btnStyle, width: '100%', flex: 'none' }} onClick={onAutoCircular}>
-        ◯ Circular orbit speed
-      </button>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <button style={btnStyle} onClick={onAutoCircular}>
+          ◯ Circular speed
+        </button>
+        <button style={btnStyle} onClick={onFindStable}>
+          ✓ Find a stable orbit
+        </button>
+      </div>
       <button style={{ ...placeBtnStyle, width: '100%', flex: 'none', marginTop: 6 }} onClick={onTogglePlace}>
         {placeMode ? '✛ Placing — click + drag on the scene' : '✛ Place planet by hand'}
       </button>
       <div style={note}>
-        Radius &amp; speed are measured from the body you orbit. Pick a star for a tight inner (S-type) orbit; the barycenter or inner binary for a wide one. Custom mode pins the exact x/y/vx/vy shown in the System panel.
+        Radius &amp; speed are measured from the body you orbit. Pick a star for a tight inner (S-type) orbit; the barycenter or inner binary for a wide one. <b>Find a stable orbit</b> searches outward for a launch that stays clear of every star. Custom mode pins the exact x/y/vx/vy shown in the System panel.
       </div>
     </>
   );
@@ -1077,9 +1103,28 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
               {placeMode && <div style={{ color: 'var(--accent)' }}>click + drag to launch</div>}
             </div>
 
+            {/* Graceful-failure hint: when the planet has fallen into a star, offer
+                a one-click route back to a survivable orbit instead of a dead end. */}
+            {labSnap?.planetFate === 'destroyed' && (
+              <div style={{
+                position: 'absolute', left: '50%', bottom: 128, transform: 'translateX(-50%)',
+                display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px',
+                background: 'var(--panel)', border: '1px solid var(--danger)', borderRadius: 10,
+                color: 'var(--fg)', font: '13px/1.4 system-ui', boxShadow: '0 6px 24px rgba(0,0,0,0.35)',
+                backdropFilter: 'blur(6px)', maxWidth: 'min(90%, 460px)', zIndex: 5,
+              }}>
+                <span>☄ Your planet fell into a star.</span>
+                <button
+                  style={{ ...btnStyle, flex: 'none', padding: '8px 12px', borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
+                  onClick={onFindStable}>
+                  ✓ Find a stable orbit
+                </button>
+              </div>
+            )}
+
             {skyOn && <SkyView dataRef={skyRef} dayLen={dayLen} tilt={tilt} />}
 
-            <Observatory snapshot={labSnap} />
+            <AnalysisHUD snapshot={labSnap} />
           </div>
         </Scheme>
       ),

--- a/src/lib/nbody/__tests__/integrator.test.ts
+++ b/src/lib/nbody/__tests__/integrator.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildStars, getScenario, launchPlanet, step, Analyzer, DEFAULT_CLASSIFY,
+  type SimState, type Star,
+} from '../index';
+
+/** Total mechanical energy of the (softened) three-star system — the quantity a
+ *  symplectic leapfrog is supposed to keep bounded. */
+function systemEnergy(stars: Star[], soft: number): number {
+  const s2 = soft * soft;
+  let ke = 0;
+  for (const s of stars) ke += 0.5 * s.mass * (s.vx * s.vx + s.vy * s.vy);
+  let pe = 0;
+  for (let i = 0; i < stars.length; i++) {
+    for (let j = i + 1; j < stars.length; j++) {
+      const dx = stars[j].x - stars[i].x, dy = stars[j].y - stars[i].y;
+      pe -= stars[i].mass * stars[j].mass / Math.sqrt(dx * dx + dy * dy + s2);
+    }
+  }
+  return ke + pe;
+}
+
+function totalMomentum(stars: Star[]): { px: number; py: number } {
+  let px = 0, py = 0;
+  for (const s of stars) { px += s.mass * s.vx; py += s.mass * s.vy; }
+  return { px, py };
+}
+
+describe('leapfrog integrator', () => {
+  it('keeps total energy bounded over a long figure-eight run (symplectic)', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const sim: SimState = { stars, planets: [], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    const E0 = systemEnergy(stars, sc.system.softening);
+    let maxDrift = 0;
+    const steps = Math.round(50 / sc.system.dt);
+    for (let i = 0; i < steps; i++) {
+      step(sim, sc.system.dt);
+      maxDrift = Math.max(maxDrift, Math.abs((systemEnergy(stars, sc.system.softening) - E0) / E0));
+    }
+    // A symplectic scheme oscillates energy but does not drift secularly; a few
+    // parts in 10³ over thousands of steps is the expected bound (not < eps).
+    expect(maxDrift).toBeLessThan(0.02);
+  });
+
+  it('conserves total momentum (recentered systems stay put)', () => {
+    const sc = getScenario('pythagorean');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const sim: SimState = { stars, planets: [], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    for (let i = 0; i < 5000; i++) step(sim, sc.system.dt);
+    const { px, py } = totalMomentum(stars);
+    expect(Math.hypot(px, py)).toBeLessThan(1e-9);
+  });
+
+  it('leaves a frozen (alive:false) planet untouched', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const frozen = { ...launchPlanet(stars, 'bary', 3.2, 1.0), alive: false as const };
+    const before = { x: frozen.x, y: frozen.y, vx: frozen.vx, vy: frozen.vy };
+    const sim: SimState = { stars, planets: [frozen], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    for (let i = 0; i < 500; i++) step(sim, sc.system.dt);
+    expect(frozen.x).toBe(before.x);
+    expect(frozen.vy).toBe(before.vy);
+  });
+});
+
+describe('Analyzer classification', () => {
+  it('reports the planet destroyed after it is driven into a star', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    // Launch straight at the central star with no tangential speed → it plunges in.
+    const planet = { ...launchPlanet(stars, 'bary', 1.2, 0), alive: true };
+    const analyzer = new Analyzer({ ...DEFAULT_CLASSIFY, rKill: 0.12 }, stars, planet);
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let sampleT = 0;
+    for (let i = 0; i < Math.round(30 / sc.system.dt); i++) {
+      step(sim, sc.system.dt);
+      if (sim.t >= sampleT) { analyzer.push(sim.t, stars, planet); sampleT = sim.t + 0.05; }
+    }
+    const snap = analyzer.snapshot();
+    expect(snap.planetFate).toBe('destroyed');
+    expect(snap.events.some(e => e.kind === 'planet-destroyed')).toBe(true);
+  });
+
+  it('accumulates habitable time for a planet launched at the reference insolation', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    // A safe wide circular orbit: insolation stays near S_ref ⇒ habitable band.
+    const planet = { ...launchPlanet(stars, 'bary', 3.2, 1.0), alive: true };
+    const analyzer = new Analyzer(DEFAULT_CLASSIFY, stars, planet);
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let sampleT = 0;
+    for (let i = 0; i < Math.round(60 / sc.system.dt); i++) {
+      step(sim, sc.system.dt);
+      if (sim.t >= sampleT) { analyzer.push(sim.t, stars, planet); sampleT = sim.t + 0.05; }
+    }
+    const snap = analyzer.snapshot();
+    expect(snap.planetFate).toBe('bound');
+    expect(snap.habitableFraction).toBeGreaterThan(0.5);
+  });
+});

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SCENARIOS, buildStars, launchPlanet, orbitFrame, recenter, getScenario,
+  step, minStarDist, planetEnergy,
+  type SimState, type Planet,
+} from '../index';
+
+/**
+ * The Observatory's first impression is a planet dropped into a star system.
+ * Historically several scenarios shipped launch defaults that dropped the planet
+ * *inside* the stars' path, so it fell into a star within a couple of time units
+ * ("explodes in the sun") — a broken opening. These tests pin each scenario's
+ * default launch to the same collision test the live app uses (rKill = 0.12),
+ * integrating with the real engine, so a bad default can't regress unnoticed.
+ */
+
+const R_KILL = 0.12; // matches the Observatory's default collision radius.
+
+/** Run a scenario's default launch through the real integrator for `T` sim-time,
+ *  reporting the planet's fate the way the live analyzer does. */
+function flyDefault(scenarioId: string, T: number) {
+  const sc = getScenario(scenarioId);
+  const stars = buildStars(sc, [1, 1, 1]);
+  const { target, radius, speed } = sc.launch;
+  const planet: Planet = { ...launchPlanet(stars, target, radius, speed), alive: true };
+  const sim: SimState = {
+    stars, planets: [planet], t: 0,
+    dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05,
+  };
+  const dt = sc.system.dt;
+  const steps = Math.round(T / dt);
+  let minDist = Infinity;
+  let fate: 'bound' | 'destroyed' | 'ejected' = 'bound';
+  for (let i = 0; i < steps; i++) {
+    step(sim, dt);
+    const d = minStarDist(planet, stars);
+    if (d < minDist) minDist = d;
+    if (d < R_KILL) { fate = 'destroyed'; break; }
+    const rBary = Math.hypot(planet.x, planet.y);
+    if (rBary > 16 && planetEnergy(planet, stars, sim.starSoft * sim.starSoft) > 0) {
+      fate = 'ejected'; break;
+    }
+  }
+  return { fate, minDist, tEnd: sim.t };
+}
+
+describe('scenario launch defaults', () => {
+  // The opening act: no scenario should incinerate its planet on the way in.
+  // 60 time units is far longer than any realistic first-look viewing window.
+  it.each(SCENARIOS.map(s => s.id))('%s default launch is not destroyed early', id => {
+    const { fate, minDist } = flyDefault(id, 60);
+    expect(fate).not.toBe('destroyed');
+    // A comfortable margin over the kill radius, not a knife-edge grazing pass.
+    expect(minDist).toBeGreaterThan(R_KILL * 1.5);
+  });
+
+  // Figure-Eight is the app's default scenario — the very first thing a visitor
+  // sees — so hold it to a stricter bar: bound (not merely un-destroyed) for a
+  // long run.
+  it('the default scenario (Figure-Eight) keeps the planet bound long-term', () => {
+    expect(SCENARIOS[0].id).toBe('figure8');
+    const { fate, tEnd } = flyDefault('figure8', 300);
+    expect(fate).toBe('bound');
+    expect(tEnd).toBeGreaterThanOrEqual(300);
+  });
+});
+
+describe('recenter', () => {
+  it('zeroes net momentum and the center of mass', () => {
+    const stars = recenter([
+      { x: 1, y: 2, vx: 0.3, vy: -0.1, ax: 0, ay: 0, mass: 2 },
+      { x: -1, y: 0, vx: -0.2, vy: 0.4, ax: 0, ay: 0, mass: 1 },
+      { x: 0, y: -1, vx: 0.1, vy: 0.5, ax: 0, ay: 0, mass: 3 },
+    ]);
+    let M = 0, cx = 0, cy = 0, px = 0, py = 0;
+    for (const s of stars) { M += s.mass; cx += s.mass * s.x; cy += s.mass * s.y; px += s.mass * s.vx; py += s.mass * s.vy; }
+    expect(cx / M).toBeCloseTo(0, 12);
+    expect(cy / M).toBeCloseTo(0, 12);
+    expect(px / M).toBeCloseTo(0, 12);
+    expect(py / M).toBeCloseTo(0, 12);
+  });
+});
+
+describe('launchPlanet geometry', () => {
+  it('places the planet at the requested radius, moving tangentially around the target', () => {
+    const stars = buildStars(getScenario('binary'), [1, 1, 1]);
+    const f = orbitFrame(stars, 'binary');
+    const radius = 1.6, speed = 1.1;
+    const p = launchPlanet(stars, 'binary', radius, speed);
+    // Offset from the target is `radius` along +x.
+    expect(Math.hypot(p.x - f.cx, p.y - f.cy)).toBeCloseTo(radius, 10);
+    // Velocity relative to the target has magnitude `speed` and is perpendicular
+    // to the radial offset (tangential launch).
+    const rvx = p.vx - f.cvx, rvy = p.vy - f.cvy;
+    expect(Math.hypot(rvx, rvy)).toBeCloseTo(speed, 10);
+    const dot = (p.x - f.cx) * rvx + (p.y - f.cy) * rvy;
+    expect(dot).toBeCloseTo(0, 10);
+  });
+});

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -124,4 +124,16 @@ describe('findStableLaunch', () => {
     for (let i = 0; i < steps; i++) { step(sim, sc.system.dt); minDist = Math.min(minDist, minStarDist(planet, s)); }
     expect(minDist).toBeGreaterThan(0.3);
   });
+
+  it('never returns a radius beyond largestRadius (must stay in the UI control range)', () => {
+    // The recovery UI caps Start radius at 8; a result past it would clamp on the
+    // next slider drag, back toward an unsafe orbit. The finder must respect the
+    // bound and return null (→ caller falls back to the safe scenario default)
+    // rather than an out-of-range orbit. Pythagorean around Star 3 is the case
+    // the reviewer flagged (unconstrained search wanted r≈11.5).
+    const sc = getScenario('pythagorean');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const found = findStableLaunch(stars, 's2', { starSoft: sc.system.softening, dt: sc.system.dt, largestRadius: 8 });
+    if (found) expect(found.radius).toBeLessThanOrEqual(8);
+  });
 });

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   SCENARIOS, buildStars, launchPlanet, orbitFrame, recenter, getScenario,
+  circularSpeed, findStableLaunch,
   step, minStarDist, planetEnergy,
-  type SimState, type Planet,
+  type SimState, type Planet, type Star, type TargetId,
 } from '../index';
 
 /**
@@ -95,5 +96,32 @@ describe('launchPlanet geometry', () => {
     expect(Math.hypot(rvx, rvy)).toBeCloseTo(speed, 10);
     const dot = (p.x - f.cx) * rvx + (p.y - f.cy) * rvy;
     expect(dot).toBeCloseTo(0, 10);
+  });
+
+  it('circularSpeed is √(M/r) about the target', () => {
+    const stars = buildStars(getScenario('figure8'), [1, 1, 1]);
+    const f = orbitFrame(stars, 'bary');
+    expect(circularSpeed(stars, 'bary', 3)).toBeCloseTo(Math.sqrt(f.mass / 3), 10);
+  });
+});
+
+describe('findStableLaunch', () => {
+  // The empirical safe-orbit finder (backs the "Find a stable orbit" button and
+  // the fell-into-a-star recovery hint). Its contract: whatever it returns must
+  // actually survive — with clearance, not a chaotic knife-edge.
+  it.each(SCENARIOS.map(s => s.id))('returns a genuinely surviving orbit for %s', id => {
+    const sc = getScenario(id);
+    const stars = buildStars(sc, [1, 1, 1]);
+    const target: TargetId = sc.launch.target;
+    const found = findStableLaunch(stars, target, { starSoft: sc.system.softening, dt: sc.system.dt });
+    expect(found).not.toBeNull();
+    // Re-fly the returned launch independently and confirm it stays clear.
+    const s: Star[] = buildStars(sc, [1, 1, 1]);
+    const planet: Planet = { ...launchPlanet(s, target, found!.radius, found!.speed), alive: true };
+    const sim: SimState = { stars: s, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let minDist = Infinity;
+    const steps = Math.round(120 / sc.system.dt);
+    for (let i = 0; i < steps; i++) { step(sim, sc.system.dt); minDist = Math.min(minDist, minStarDist(planet, s)); }
+    expect(minDist).toBeGreaterThan(0.3);
   });
 });

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -56,13 +56,36 @@ describe('scenario launch defaults', () => {
   });
 
   // Figure-Eight is the app's default scenario — the very first thing a visitor
-  // sees — so hold it to a stricter bar: bound (not merely un-destroyed) for a
-  // long run.
-  it('the default scenario (Figure-Eight) keeps the planet bound long-term', () => {
+  // sees — so hold it to a stricter, two-sided bar. The launch is tuned to the
+  // EDGE of stability: (a) the planet survives the whole realistic viewing
+  // window, and (b) the ghost swarm visibly branches early — the app's headline
+  // demo must not require minutes of watching.
+  it('the default scenario (Figure-Eight) survives the viewing window', () => {
     expect(SCENARIOS[0].id).toBe('figure8');
     const { fate, tEnd } = flyDefault('figure8', 300);
     expect(fate).toBe('bound');
     expect(tEnd).toBeGreaterThanOrEqual(300);
+  });
+
+  it('the default launch sits near the edge: a 1e-3 ghost diverges by t=150', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const { target, radius, speed } = sc.launch;
+    const ref: Planet = { ...launchPlanet(stars, target, radius, speed), alive: true };
+    // Same offset the Observatory's default ghost spread uses (ε = 10^-3).
+    const ghost: Planet = { ...ref, x: ref.x + 1e-3 };
+    const sim: SimState = {
+      stars, planets: [ref, ghost], t: 0,
+      dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05,
+    };
+    let divT: number | null = null;
+    const steps = Math.round(150 / sc.system.dt);
+    for (let i = 0; i < steps; i++) {
+      step(sim, sc.system.dt);
+      if (Math.hypot(ghost.x - ref.x, ghost.y - ref.y) > 0.5) { divT = sim.t; break; }
+    }
+    expect(divT).not.toBeNull();
+    expect(divT!).toBeLessThan(150);
   });
 });
 

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -94,7 +94,11 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0022,
       softening: 0.01,
     },
-    launch: { target: 'bary', radius: 1.8, speed: 1.1 },
+    // A wide circumbinary (P-type) orbit that clears the stars' figure-eight loop:
+    // survives indefinitely, yet the breathing inner triple still fans the ghost
+    // cloud out over time. A closer launch (the old r=1.8) fell into a star in ~2
+    // time units — chaos, but a dead planet before you'd seen anything.
+    launch: { target: 'bary', radius: 3.2, speed: 1.0 },
   },
   {
     id: 'moth',
@@ -105,7 +109,10 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0004,
       softening: 0.0025,
     },
-    launch: { target: 'bary', radius: 2.2, speed: 1.1 },
+    // The Moth choreography is larger and more delicate than the figure-eight, so
+    // the planet needs a wider berth (old r=2.2 fell in almost at once). A gently
+    // sub-circular circumbinary orbit rides the whole regular era.
+    launch: { target: 'bary', radius: 3.5, speed: 0.95 },
   },
   {
     id: 'pythagorean',
@@ -121,7 +128,12 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0016,
       softening: 0.04,
     },
-    launch: { target: 'bary', radius: 4.0, speed: 1.6 },
+    // Burrau's problem is violently destructive — the stars fall from rest and one
+    // is eventually ejected — so no close orbit survives. A wide, slow launch keeps
+    // the planet clear of the initial collapse: it witnesses the whole spectacle
+    // and is flung into the dark much later, rather than incinerated at once (old
+    // r=4/v=1.6 fell in by t≈7).
+    launch: { target: 'bary', radius: 5.0, speed: 0.55 },
   },
   {
     id: 'binary',

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -95,11 +95,13 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0022,
       softening: 0.01,
     },
-    // A wide circumbinary (P-type) orbit that clears the stars' figure-eight loop:
-    // survives indefinitely, yet the breathing inner triple still fans the ghost
-    // cloud out over time. A closer launch (the old r=1.8) fell into a star in ~2
-    // time units — chaos, but a dead planet before you'd seen anything.
-    launch: { target: 'bary', radius: 3.2, speed: 1.0 },
+    // A circumbinary (P-type) orbit tuned to the EDGE of stability: close enough
+    // that the ghost cloud visibly branches by t≈84 (vs t≈334 for the safer
+    // r=3.2/v=1.0), yet never destroyed from any launch angle — the reference
+    // planet dances through close passes (min star distance ≈0.96) and is finally
+    // ejected around t≈427, a long chaotic life ending as a frozen wanderer, not
+    // a fireball. (The old r=1.8/v=1.1 fell into a star in ~2 time units.)
+    launch: { target: 'bary', radius: 3.2, speed: 0.95 },
   },
   {
     id: 'moth',

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -13,7 +13,8 @@
  * fresh array so the simulation can be re-seeded deterministically on reset.
  */
 
-import type { Planet, Star } from './integrator';
+import { step, type Planet, type SimState, type Star } from './integrator';
+import { planetEnergy } from './analysis/classify';
 
 /** What the planet is launched into orbit around:
  *  the system barycenter, one specific star, or the inner two-star binary. */
@@ -117,7 +118,7 @@ export const SCENARIOS: Scenario[] = [
   {
     id: 'pythagorean',
     name: 'Pythagorean',
-    blurb: "Burrau's problem: stars of mass 3, 4 and 5 fall together from rest, swing through violent close passes, and eject one of their own.",
+    blurb: "Burrau's problem: stars of mass 3, 4 and 5 fall together from rest, swing through violent close passes, and eject one of their own. Your planet is a witness, not a resident — it rides a wide orbit through the fireworks and is eventually flung into the dark.",
     system: {
       // Masses 3,4,5 at the vertices of a 3-4-5 right triangle, starting at rest.
       makeStars: () => recenter([
@@ -204,4 +205,71 @@ export function launchPlanet(
     vy: f.cvy + dir * speed * ca,
     ax: 0, ay: 0,
   };
+}
+
+/** The local circular-orbit speed √(M/r) around a target body at `radius`. */
+export function circularSpeed(stars: Star[], target: TargetId, radius: number): number {
+  const f = orbitFrame(stars, target);
+  return Math.sqrt(f.mass / Math.max(0.05, radius));
+}
+
+export interface StableLaunchOptions {
+  /** Softening length for star–star interactions (matches the live sim). */
+  starSoft: number;
+  /** Integrator step. */
+  dt: number;
+  /** Collision radius that counts as "destroyed". */
+  rKill?: number;
+  /** How far a planet must always stay from the nearest star to count as safe
+   *  (an absolute clearance — bigger ⇒ rounder, more robustly-bound orbits, and
+   *  crucially avoids chaotic knife-edge survivors). */
+  minClear?: number;
+  /** Sim-time to integrate each candidate. Long enough to reject slow decays. */
+  probeTime?: number;
+  smallestRadius?: number;
+  largestRadius?: number;
+  radiusStep?: number;
+}
+
+/**
+ * Empirically find a launch that survives — the only reliable "safe orbit" in a
+ * chaotic star field, where a derived radius fails (a star may be ejected to
+ * infinity; a hierarchical system's planet orbits a sub-system) and a single
+ * bare-survival probe lands on knife-edge orbits that a rounding-sized nudge
+ * destroys. Sweeps the launch radius outward, using the local circular speed at
+ * each, and returns the first whose planet stays bound **and** never comes within
+ * `minClear` of a star across `probeTime`. Values are rounded to the control
+ * steps the UI uses, so the returned orbit behaves exactly as previewed. Returns
+ * `null` if nothing in range qualifies. Pure — integrates a private copy.
+ */
+export function findStableLaunch(
+  stars: Star[], target: TargetId, opts: StableLaunchOptions,
+): { radius: number; speed: number } | null {
+  const {
+    starSoft, dt, rKill = 0.12, minClear = 0.5, probeTime = 140,
+    smallestRadius = 1.0, largestRadius = 16, radiusStep = 0.25,
+  } = opts;
+  const round2 = (x: number) => Math.round(x * 100) / 100;
+  const ss2 = starSoft * starSoft;
+  const steps = Math.round(probeTime / dt);
+
+  for (let r = smallestRadius; r <= largestRadius + 1e-9; r += radiusStep) {
+    const radius = round2(r);
+    const speed = round2(circularSpeed(stars, target, radius));
+    // Fresh star copy per candidate (the stars evolve during the probe).
+    const s: Star[] = stars.map(st => ({ ...st }));
+    const planet = launchPlanet(s, target, radius, speed);
+    const sim: SimState = { stars: s, planets: [planet], t: 0, dtBase: dt, G: 1, starSoft, planetSoft: 0.05 };
+    let ok = true;
+    for (let i = 0; i < steps; i++) {
+      step(sim, dt);
+      let dmin = Infinity;
+      for (const st of s) { const d = Math.hypot(st.x - planet.x, st.y - planet.y); if (d < dmin) dmin = d; }
+      if (dmin < Math.max(rKill, minClear)) { ok = false; break; }
+      // Unbound-and-far ⇒ this radius won't settle into an orbit.
+      if (Math.hypot(planet.x, planet.y) > largestRadius + 4 && planetEnergy(planet, s, ss2) > 0) { ok = false; break; }
+    }
+    if (ok) return { radius, speed };
+  }
+  return null;
 }


### PR DESCRIPTION
## What & why

The Trinary System opened on a failure: the default planet fell into a star within ~2 sim-seconds ("explodes in the sun"). Investigating showed three of the four scenarios shipped launch defaults that dropped the planet *inside* the region the stars sweep through. This PR fixes that and addresses the broader review that followed.

## Changes

**Safe launch defaults** (`src/lib/nbody/scenarios.ts`) — found by scanning radius × speed × launch-angle through the real leapfrog for long-run fate while keeping the ghost-cloud fan-out legible (a too-wide orbit survives but reads as regular):

| Scenario | Old → New | Result |
|---|---|---|
| Figure-Eight (default) | r=1.8, v=1.1 → **r=3.2, v=0.95** | destroyed t≈2.4 → edge-of-stability: ghosts branch at t≈84, never destroyed from any angle, late ejection ~t≈427 |
| Moth | r=2.2, v=1.1 → **r=3.5, v=0.95** | destroyed t≈2.4 → bound past t=1200 |
| Pythagorean | r=4.0, v=1.6 → **r=5.0, v=0.55** | destroyed t≈7.5 → witnesses the collapse, ejected ~t=1124 |
| Binary + Star | unchanged (already fine) | bound |

The Figure-Eight default is deliberately tuned to the **edge of stability**: a first pass (r=3.2, v=1.0) was safely bound but too regular — the ghost swarm took ~334 time units to visibly branch. At v=0.95 the swarm branches 4× sooner (t≈84 at the app's default ε=10⁻³) while never being destroyed from any of 8 tested launch angles; nearby faster-branching candidates (r=3.0–3.1) die within t≈9–28 from some angles — past the edge, not on it. The planet's eventual fate is a late ejection (~t≈427): a long chaotic life ending as a frozen wanderer, not a fireball.

**`findStableLaunch` engine helper** — empirically finds a survivable orbit (sweeps radius at the local circular speed, requires a clearance margin from every star over a long probe). A *derived* radius is unreliable here — Pythagorean ejects a star (excursion → ∞) and Binary is hierarchical — and a bare survival probe lands on chaotic knife-edges, so "find one that provably stays clear" is the robust approach. Bounded to the Start-radius control's range so a recovered launch is always representable (Codex review finding).

**Graceful failure/recovery** — when the planet falls into a star, a hint appears over the scene with a one-click **Find a stable orbit** button (also added to the Planet-launch panel). Adapts to the current masses/target, falling back to the scenario's safe default if the target admits none.

**Chaos legibility** — default sim speed 1 → 1.5× so the ghost fan-out reads sooner.

**Copy** — Pythagorean blurb reframes the planet as a witness to the violence, not a resident.

**Naming** — `Observatory.tsx` (the analysis HUD) → `AnalysisHUD.tsx`, ending the three-way "Observatory" collision (file / mode id / skin name).

**Engine tests** (the `nbody` engine previously had none) — `integrator.test.ts` (symplectic energy bound, momentum conservation, frozen-planet no-op; analyzer destroyed/habitable classification) and `scenarios.test.ts` (every scenario default survives with margin, the default scenario's two-sided edge contract — bound through T=300 **and** a 10⁻³ ghost diverging before t=150 — `findStableLaunch` survivability + radius bound, `circularSpeed`, `launchPlanet` geometry, `recenter`).

## Verification

- `npm test` → all pass · `npm run build` clean · lint 0 errors
- Verified visually (headless screenshots) across all four scenarios; the edge-tuned default shows cloud spread 5.15e-1 with visibly separated ghosts at sim t≈74 (~50 real seconds at 1.5×), vs 1.6e-1 (one fused dot) before
- Drove the recovery flow end-to-end with Puppeteer: bad launch (r=1.5) → planet destroyed → click **Find a stable orbit** → launch becomes r=3.25 → planet bound and habitable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7qW9gEW5LQ5SCo5G9KEGg