### PR TITLE
Trinary System overhaul: survivable edge-tuned defaults, legibility redesign, emphasis vocabulary, test suite + bug fixes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -248,10 +248,17 @@ rendering **one component**:
 ### Control primitives (import from `components/ControlPanel`)
 
 `Slider`, `Pills` (segmented buttons), `Select` (dropdown), `Checkbox`,
-`RangeSlider`, `NumberInput` (+ a legacy `Section`). These are the standard
-building blocks for panel bodies, styled by `ControlPanel.css` on the theme
-tokens (`--cp-*` vars alias `--fg`/`--accent`/…). Use them instead of
-hand-rolling inputs so every app looks consistent.
+`RangeSlider`, `NumberInput`, `Button` (closed emphasis variants
+`primary | secondary | ghost | danger | toggle` — **at most one `primary` per
+panel**, icons from `chrome/icons` only, never emoji), `Kicker` (mono uppercase
+group label), `Note` (quiet 11px explainer prose) (+ `Section`, the in-panel
+disclosure fold). These are the standard building blocks for panel bodies,
+styled by `ControlPanel.css` on the theme tokens (`--cp-*` vars alias
+`--fg`/`--accent`/…). Use them instead of hand-rolling inputs so every app looks
+consistent. **Accent is budgeted** (DESIGN-SPEC §4.2): it marks things you touch
+or that are on — thumbs, active pills, primary buttons, rail active state —
+never passive readouts. The desktop rail shows a label under each panel icon
+(`SectionDef.railLabel` overrides `title` when it won't fit ~38px).
 
 ## Theming (v2): identity × mode — apps must track the skin
 

--- a/docs/redesign/DESIGN-SPEC.md
+++ b/docs/redesign/DESIGN-SPEC.md
@@ -156,6 +156,40 @@ Analyze-tier content so labs feel consistent.
 
 Google Fonts import is in `theme.css`. The **Phosphor** skin overrides display+UI to Space Mono.
 
+### 4.1 In-panel type scale (2026-07)
+
+Panel bodies use a **four-level scale**, each with a shared primitive — no ad-hoc inline
+header styles:
+
+1. **Panel title** — the window header (Display font, 12.5px/700).
+2. **`Kicker`** (`components/ControlPanel`) — mono uppercase group label inside a body.
+3. **Row label** — `.cp-row-label` (12.5px/600), what every control primitive renders.
+4. **`Note`** (`components/ControlPanel`) — quiet 11px/1.5 explanatory prose under a group.
+
+### 4.2 Emphasis vocabulary — the `Button` primitive (2026-07)
+
+In-panel verbs use the shared **`Button`** (`components/ControlPanel`) with a **closed
+variant set**: `primary | secondary | ghost | danger | toggle`. Icons come from the closed
+stroke set (`chrome/icons.tsx`) — never emoji glyphs.
+
+**Grammar (the answer to "nothing stands out"):**
+
+- **At most one `primary` per panel** — the panel's one main verb, accent-filled. This
+  mirrors the action strip's one-primary-per-app rule.
+- **Accent is budgeted**: it belongs to things you *touch* or that are *on* — slider thumbs,
+  active pills, primary buttons, the rail's active state. Passive state (numeric readouts,
+  header archetype icons) speaks in `--fg`/`--dim`. Don't spend accent on decoration; a
+  primary verb must be the loudest element on screen.
+- `danger` marks destructive verbs (wiping saved state or results); `toggle` + `active`
+  marks armed modes (e.g. click-to-place).
+
+### 4.3 Rail labels (2026-07)
+
+The desktop vertical rail shows a persistent ~8px title under each icon (`.am-ws-rail-lbl`).
+The archetype icon remains the closed vocabulary; the label adds per-panel identity so apps
+with more panels than archetypes don't render adjacent identical glyphs. The horizontal
+(immersive) rail stays icon-only; the phone dock already labels icons.
+
 ## 5. Skins (design tokens)
 
 One attribute — `data-theme` on the root — restyles everything. Each skin is a token block in

--- a/docs/sessions/progress/trinary-legibility/2026-07-17-S01-legibility-redesign.md
+++ b/docs/sessions/progress/trinary-legibility/2026-07-17-S01-legibility-redesign.md
@@ -38,6 +38,34 @@ fossilized implementation history; (D) copy drifted from the theming-v2 scene.
 
 ## Working notes
 
+### 🟢 code · 03:00 — Application test suite (36 new tests) + two bugs it caught
+**Why:** Dan: "please write a test suite for this application. I think there are
+some issues." Tests were written against the code's own documented claims.
+
+New suites (301 tests total pass): `analysis.test.ts` (scalars, events,
+Analyzer timeline invariants, a synthetic Paradise system), `reversibility.test.ts`
+(the leapfrog's exact time-reversibility), `lab/__tests__/lab.test.ts` (seeded
+reproducibility contracts, Aggregator vs brute force, the batch runners'
+"bit-identical" claim held to exact equality — it holds), `frame.test.ts`
+(rotating-frame transform extracted to `frame.ts`: isometry, no mirror,
+align-to-+x). Two real issues surfaced and fixed:
+
+1. **`findStableLaunch` off-grid results** — rounded to 0.01 while the sliders
+   step 0.05, so a recovered speed could drift on the next drag. Now snaps to
+   the control grid *before* probing.
+2. **Persistence resurrects the fatal launch** — returning visitors hold
+   pre-fix `planetRadius/planetSpeed` in localStorage, so the safe defaults
+   never reach them and the planet still explodes (very likely the "current
+   starting point is a failure" experience on any browser that visited before
+   the fix). New `migrateLegacyLaunch()` maps exact legacy defaults to the
+   current safe launch once at mount (Auto mode only; hand-tuned values
+   untouched). Verified end-to-end with a seeded browser.
+
+Earlier this session the default was also re-tuned to the edge of stability
+(r=3.2, v=0.95 — ghosts branch at t≈84, late ejection t≈427; committed to the
+PR #249 branch and merged here). Note: PR #249 alone fixes *fresh* visitors;
+the migration in this branch is what fixes *returning* ones.
+
 ### 🟢 code · 19:00 — Chrome: the emphasis vocabulary (root cause A + B)
 **Why:** "Nothing stands out" is chrome-level and unfixable per-app.
 

--- a/docs/sessions/progress/trinary-legibility/2026-07-17-S01-legibility-redesign.md
+++ b/docs/sessions/progress/trinary-legibility/2026-07-17-S01-legibility-redesign.md
@@ -1,0 +1,132 @@
+---
+kind: progress
+session: 2026-07-17-S01
+date: 2026-07-17
+title: Trinary legibility redesign — emphasis vocabulary + panel restructure
+branch: claude/trinary-legibility
+slug: trinary-legibility
+status: complete
+build: passing
+followup: null
+pr: null
+app: trinary, chrome
+next: Dan reviews the emphasis grammar + task layouts; then migrate other apps' buttons to the Button primitive.
+---
+
+# Trinary legibility redesign — emphasis vocabulary + panel restructure
+
+## Session purpose
+
+Dan: "controls were built because I was chasing an idea and they are not readily
+apparent to a new user and not easy to traverse the app… there is nothing that
+'stands out' in the control space except an occasional run button — something
+there might require changing [at] the level of the entire design language."
+
+This session carries out the best recommendations of the 38-finding verified
+design review (see the `trinary-system-review` branch's S01 report and the
+workflow synthesis). Stacked on `claude/trinary-system-review-59t0w1` (PR #249).
+
+## Previous session
+
+`trinary-system-review/2026-07-17-S01` — fixed the fatal launch defaults, added
+the safe-orbit finder + recovery, first engine tests (PR #249, CI green). The
+five-lens review workflow (64 raw → 38 verified findings, 0 refuted) and its
+synthesis diagnosed four root causes: (A) the design language can display but
+cannot *point* (one accent channel, fully spent on passive state); (B) the
+closed 11-icon vocabulary resolves archetypes, not panels; (C) control placement
+fossilized implementation history; (D) copy drifted from the theming-v2 scene.
+
+## Working notes
+
+### 🟢 code · 19:00 — Chrome: the emphasis vocabulary (root cause A + B)
+**Why:** "Nothing stands out" is chrome-level and unfixable per-app.
+
+- **`Button` primitive** (`components/ControlPanel`): closed variants
+  `primary | secondary | ghost | danger | toggle`, icons only from the closed
+  chrome stroke set. Grammar written into DESIGN-SPEC §4.2: **at most one
+  primary per panel** (mirrors the strip's one-primary-per-app rule).
+- **Accent rebudget**: slider readouts `--accent`→`--fg`; panel/view header
+  archetype icons →`--dim`. Accent now marks only touch/on: thumbs, active
+  pills, primary buttons, rail active state. The primary verb is now the
+  loudest element on screen — by construction.
+- **Rail labels**: persistent ~8px per-panel title under each desktop rail icon
+  (`SectionDef.railLabel` overrides when the title won't fit; the phone dock
+  already proved labels fit the language). Ten panels no longer collapse into
+  three identical glyph pairs.
+- **Type scale**: `Kicker` promoted into ControlPanel (readouts re-exports),
+  new `Note` primitive; four-level scale documented (§4.1). Panel bodies get an
+  always-visible thin scrollbar when overflowing (no more mid-sentence cuts).
+
+### 🟢 code · 19:25 — Trinary Wave 1+2: de-fossilize the app (root causes C + D)
+**Why:** Place controls where the user's model is, not where the code grew.
+
+- **One panel owns the launch**: x/y/vx/vy spinboxes moved from System into
+  Planet launch behind a `Section` fold ("Exact launch state") with a live
+  pinned/auto status Kicker; System shrinks to scenario pills + blurb.
+  **Find a stable orbit** is the panel's primary Button, with an inline result
+  status line ("Found: radius 2.35 at speed 0.80 — launched." / the fallback).
+- **Panel consolidation 10→9**: Trails folded into "Viewpoint & trails" (one
+  slider, 0=off); Settings merged into Sim (danger-variant reset Button); new
+  drive-tier **Hands-on** panel (Place = toggle Button, Scatter) projected into
+  the strip: **Pause · Place · Scatter · Restart**.
+- **Task-named layouts** (StableMatching precedent): Sandbox (opens the Ghost
+  swarm — the headline experiment — on day one), **Ghost swarm**, **Climate &
+  sky**, **Rotating frames**; the auto "Everything" remains the full spread.
+- **Renames**: "Chaos demo"→"Ghost swarm", "Perturbation ε"→"Ghost spread ε",
+  "Luminosity exponent β"→"Brightness vs mass (β)", "Calm threshold"→"Orbit
+  calmness cutoff", "Star size (collision)"→"Collision radius",
+  "Softening"→"Close-pass smoothing", Star A/B/C→Star 1/2/3 (BasinMap), strip
+  Reset→Restart.
+- **De-fossilized copy**: tour/EXPLAINER no longer name pre-theming colors
+  ("pink ghosts" → "faint ghost copies hugging the bright planet"); star-mass
+  sliders carry token-colored swatch dots (`--data-1/4/6`) instead of wrong
+  color names ("Star 1 · gold" was a *blue* star); Lab notes name the marks,
+  not their hues.
+- **Feedback fixes**: Sky sliders auto-enable the sky view; placing a planet
+  now exits place mode and unpauses; HUD moved top-right (clear of the panel
+  column; offset below the phone chrome bar).
+- **Non-destructive knobs**: `Analyzer.retune()` — climate sliders re-label the
+  running world live (band re-derived from the same launch S_ref) instead of
+  hard-resetting the physics; the Lab keeps a finished census on screen with a
+  "previous run" banner when settings change instead of silently wiping
+  minutes of compute (only explicit Reset or a fresh Run discards it).
+
+### 🟡 milestone · 19:45 — Verified visually, all green
+**Why:** The review was screenshot-driven; the fix must be too.
+
+Headless screenshots (desktop Sandbox + task layouts + Lab + phone) confirm:
+labeled rail, the accent-primary "Find a stable orbit" standing out exactly as
+intended, analysis strip unobstructed, HUD readable on phone, Layouts menu
+reading as a map of destinations. `npm run build` clean · `npm test` 265 passed
+(new `Analyzer.retune` test) · lint 0 errors.
+
+## Deferred (Dan's open questions from the synthesis)
+
+1. **Immersive Observatory** — full-stage stars change the app's feel; needs
+   Dan's call (the overlap bug it would dissolve is mitigated by the HUD move).
+2. **Launch-speed units** (absolute vs ×circular to match the Lab) — changes a
+   long-standing control's meaning.
+3. **`role: 'start'` on SectionDef** — deferred per the synthesis's bet that
+   Button + rebudget + task layouts make the entry point emergent.
+4. **Chrome tour framework** (anchored spotlights) and the Explore↔Lab bridge —
+   Wave 3, own session.
+
+## Self-reflection
+
+**What went well:** The workflow review's verified findings made this session
+mechanical — every change traces to a confirmed problem, and the synthesis's
+"smallest set that solves it" discipline kept the chrome addition to one
+primitive + one budget rule + one label row. The screenshot loop caught three
+real regressions (clipped primary button, buried analysis strip, truncated rail
+labels) before commit.
+
+**What to watch:** The accent rebudget touches every app's readouts — a
+repo-wide visual change shipped from a Trinary branch. It looks right in the
+default skin; other skins/modes were not exhaustively screenshotted. The Lab's
+stale-census banner keeps the *snapshot* but not resumability — Run always
+starts fresh after a config change; if Dan wants true resume that's engine work.
+
+**Follow-up value:** HIGH — the Button primitive + accent budget are repo-wide
+conventions now documented in DESIGN-SPEC/CLAUDE.md; other apps (StableMatching
+`.sm2-btn`, DivisionBells `.db-btn`, Argand) should migrate, and the deferred
+open questions need Dan's answers.

--- a/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
+++ b/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
@@ -5,12 +5,12 @@ date: 2026-07-17
 title: Trinary System review — safe default launches
 branch: claude/trinary-system-review-59t0w1
 slug: trinary-system-review
-status: in-progress
+status: complete
 build: passing
 followup: null
 pr: null
 app: trinary
-next: Discuss broader review suggestions with Dan (safe-radius derivation, chaos legibility).
+next: Optional follow-ups — tune default speed/ε if the fan-out still reads slow; consider a general "Find a stable orbit" affordance beyond the failure hint.
 ---
 
 # Trinary System review — safe default launches
@@ -28,6 +28,30 @@ unrelated app branches — Division Bells, Solid Worlds, Argand — nothing to
 continue here.)
 
 ## Working notes
+
+### 🟡 milestone · 14:30 — All six review suggestions implemented + verified
+**Why:** Dan said "fix them all." Each is now landed, built, tested, and driven.
+
+1. **Systematic safe launch** — a *derived* radius proved unreliable (Pythagorean
+   ejects a star → excursion→∞; Binary is hierarchical), and a bare single-probe
+   finds chaotic knife-edges (an r that survives at v dies at v±0.01). So added
+   `findStableLaunch(stars, target, opts)` — an engine helper that sweeps radius
+   outward, uses the local circular speed, and returns the first orbit that keeps
+   a real *clearance* margin from every star across a long probe. Pure, adapts to
+   current masses, tested (asserts the returned orbit genuinely survives).
+2. **Chaos legibility** — default `speed` 1 → 1.5× so the ghost fan-out reads sooner.
+3. **Pythagorean copy** — blurb now frames the planet as a witness, not a resident.
+4. **Graceful failure** — when the planet falls into a star, a hint toast appears
+   over the scene with a one-click **Find a stable orbit** button (also added to
+   the Planet-launch panel). Drove it with Puppeteer: bad launch (r=1.5) → planet
+   destroyed → click → launch becomes r=3.25 → **planet bound, paradise 100%**.
+5. **Naming** — `Observatory.tsx` (the analysis HUD) renamed to `AnalysisHUD.tsx`.
+6. **Engine tests** — added `integrator.test.ts` (symplectic energy bound, momentum
+   conservation, frozen-planet no-op; analyzer destroyed/habitable classification)
+   and extended `scenarios.test.ts` (findStableLaunch survivability, circularSpeed).
+
+`npm test` → 263 passed; `npm run build` clean; lint 0 errors. Verified visually
+across all four scenarios + the failure/recovery flow.
 
 ### 🟡 milestone · 13:05 — Fix applied, verified visually + regression-tested
 **Why:** Close the loop — the fix must be real (not just simulated) and locked in.
@@ -89,9 +113,11 @@ than incinerated.
 ### 🟣 decision · 12:45 — Fix all four launch defaults, not just the default scenario
 **Why:** Any scenario a user clicks is a "first impression"; three were broken.
 
-## Suggestions for improvement (broader review)
+## Suggestions for improvement (broader review) — all implemented
 
-Captured while reviewing; to discuss/prioritize with Dan. Ordered by value.
+All six were implemented this session (see the 14:30 milestone). Original notes
+kept below for the reasoning; #1 landed as an *empirical* finder rather than a
+closed-form derivation, because the physics defeats a derived radius.
 
 1. **Derive the safe launch radius instead of hardcoding it** (root cause of this
    bug). Each scenario hand-picks a `radius`; three were wrong. A helper that

--- a/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
+++ b/docs/sessions/progress/trinary-system-review/2026-07-17-S01-trinary-review-and-safe-default.md
@@ -1,0 +1,149 @@
+---
+kind: progress
+session: 2026-07-17-S01
+date: 2026-07-17
+title: Trinary System review — safe default launches
+branch: claude/trinary-system-review-59t0w1
+slug: trinary-system-review
+status: in-progress
+build: passing
+followup: null
+pr: null
+app: trinary
+next: Discuss broader review suggestions with Dan (safe-radius derivation, chaos legibility).
+---
+
+# Trinary System review — safe default launches
+
+## Session purpose
+
+The Trinary System's out-of-the-box experience is a failure: on first load the
+planet falls into a star within ~2 sim-seconds ("explodes in the sun"). Give the
+default a better start, then review the app in general and suggest improvements.
+
+## Previous session
+
+First tracked session on this branch. (Latest handoffs across the repo are
+unrelated app branches — Division Bells, Solid Worlds, Argand — nothing to
+continue here.)
+
+## Working notes
+
+### 🟡 milestone · 13:05 — Fix applied, verified visually + regression-tested
+**Why:** Close the loop — the fix must be real (not just simulated) and locked in.
+
+Changed the four `launch` defaults in `src/lib/nbody/scenarios.ts`, rebuilt, and
+screenshotted each scenario headless after ~15–22s of simulation:
+
+- **Figure-Eight** (default): planet bound, HABITABLE, paradise 100% — a wide arc
+  well clear of the figure-eight loop. (Was: destroyed at t≈2.4.)
+- **Moth**: planet bound, HABITABLE, paradise 85%.
+- **Pythagorean**: planet bound and witnessing the violent stellar encounter
+  (tangled trails, one star flung out), climate timeline a rich paradise→chaotic mix.
+
+Added `src/lib/nbody/__tests__/scenarios.test.ts` (the engine had **zero** tests):
+integrates each scenario's default launch through the real leapfrog and asserts
+the planet isn't destroyed early (with a margin over the kill radius), holds the
+default scenario to a stricter long-run "bound" bar, and covers `recenter` /
+`launchPlanet` geometry. `npm test` → 253 passed; `npm run build` clean.
+
+### 🔵 finding · 12:20 — Three of four scenario launch defaults destroy the planet
+**Why:** Confirm the reported failure and check whether it's isolated to the default.
+
+Re-implemented the exact `nbody` leapfrog + `launchPlanet` geometry in a
+standalone script and simulated every scenario's shipped launch default:
+
+| Scenario | Current launch | Fate |
+|---|---|---|
+| Figure-Eight (default) | bary, r=1.8, v=1.1 | **destroyed** at t≈2.4 |
+| Moth | bary, r=2.2, v=1.1 | **destroyed** at t≈2.4 |
+| Pythagorean | bary, r=4.0, v=1.6 | **destroyed** at t≈7.5 |
+| Binary + Star | binary, r=1.6, v=1.1 | bound (fine) |
+
+The planets launch *inside* the region the stars sweep through, so a close pass
+consumes them almost immediately. Only Binary + Star (a genuine circumbinary
+orbit well outside a tight inner pair) survives.
+
+### 🔵 finding · 12:40 — Survivable launches exist for all but keep chaos legible
+**Why:** A safe default must still show the app's headline demo — ghosts fanning out.
+
+Scanned radius × speed × launch-angle, measuring long-run fate (T=1200), the
+12-ghost cloud-spread growth, and orbit framing. Chosen launches (verified bound
+past any realistic viewing window, angle 0):
+
+| Scenario | New launch | Fate @ T=1200 | min star dist |
+|---|---|---|---|
+| Figure-Eight | bary, r=3.2, v=1.0 | bound | 1.75 |
+| Moth | bary, r=3.5, v=0.95 | bound | 1.12 |
+| Pythagorean | bary, r=5.0, v=0.55 | survives to t≈1124, then ejected | 0.29 |
+| Binary + Star | binary, r=1.6, v=1.1 | bound (unchanged) | 1.03 |
+
+Trade-off noted: very wide circumbinary orbits (r≥4) survive but are too regular
+— the ghost cloud barely fans out, so the chaos demo falls flat. r≈3.2 keeps a
+visible fan-out (cloud spread ~0.16 by t≈120) while staying safe. Pythagorean is
+inherently destructive (Burrau's problem — three stars fall from rest and eject
+one of their own); no in-frame orbit survives forever, but r=5/v=0.55 lets the
+planet witness the whole spectacle and end by being flung into the dark rather
+than incinerated.
+
+### 🟣 decision · 12:45 — Fix all four launch defaults, not just the default scenario
+**Why:** Any scenario a user clicks is a "first impression"; three were broken.
+
+## Suggestions for improvement (broader review)
+
+Captured while reviewing; to discuss/prioritize with Dan. Ordered by value.
+
+1. **Derive the safe launch radius instead of hardcoding it** (root cause of this
+   bug). Each scenario hand-picks a `radius`; three were wrong. A helper that
+   returns a radius as a multiple of the stars' max excursion from the barycenter
+   (say 2.5–3×) would make *every* current and future scenario safe by
+   construction, and the per-scenario number becomes an optional override. The new
+   test guards the current values but doesn't prevent a future scenario shipping a
+   fresh bad one.
+
+2. **The chaos demo is slow to read at the default speed.** The headline effect —
+   the ghost cloud fanning out — takes ~80 sim-time to become visually obvious at
+   `speed = 1`, and the ghosts are nearly coincident on first load (see the
+   screenshots: no visible fan yet at t≈8–12). Options: bump the default `speed`
+   to ~1.5×, raise the default ghost `ε` slightly, or auto-scatter once after a
+   few seconds. Worth a quick experiment — it's the app's signature moment.
+
+3. **Pythagorean is inherently destructive.** Even with the new witness orbit the
+   planet is eventually ejected (t≈1124). That's physically honest (Burrau's
+   problem *is* about the stars destroying their own configuration), but the blurb
+   sells it as a place to "launch the planet." Consider copy that frames the planet
+   as a witness to violence rather than a resident — sets the right expectation.
+
+4. **Graceful failure UX.** When the reference planet dies there's a flare and the
+   sky view detonates, but no nudge toward recovery. If a launch dies within a few
+   sim-seconds, a one-line hint ("try a wider orbit, or the ◯ Circular orbit speed
+   button") would turn a dead end into a teaching moment. The "Circular orbit
+   speed" button already exists and is the right escape hatch — surface it.
+
+5. **Naming friction (minor).** `Observatory.tsx` is the analysis HUD, but the
+   user-facing *view* is labeled "Explore" and the old name "Observatory" still
+   shows as the persisted mode id and in a skin display name — three meanings for
+   one word (the code comments already flag this). A rename pass would reduce
+   confusion for the next editor.
+
+6. **Engine test coverage (partly addressed).** This session added the first
+   `nbody` tests (scenario survivability + geometry). The integrator itself
+   (energy conservation of the symplectic scheme over a long run) and the analyzer
+   (climate/era classification) are still untested and are good candidates.
+
+## Self-reflection
+
+**What went well:** Reproduced the failure quantitatively before touching code
+(standalone re-impl of the engine), which turned "the planet explodes" into a
+measurable fate + min-distance and let me scan the launch space for a fix that
+*also* preserves the chaos demo rather than just moving the planet far away.
+Verified visually (headless screenshots) and locked the fix with the engine's
+first tests.
+
+**What to watch:** The launch radii are still magic numbers — suggestion #1 is the
+real fix. And I widened Moth/Pythagorean beyond the reported default; those are
+lower-traffic but were equally broken, so the scope creep is justified and covered
+by the new test.
+
+**Follow-up value:** MEDIUM — the default is fixed and tested, but the safe-radius
+derivation (#1) and chaos legibility (#2) are worth a follow-up session.

--- a/src/animations/TrinaryStars/AnalysisHUD.tsx
+++ b/src/animations/TrinaryStars/AnalysisHUD.tsx
@@ -63,7 +63,7 @@ function insolBar(s: Snapshot): { pos: number; loPos: number; hiPos: number } {
   return { pos: map(s.S), loPos: map(s.Slo), hiPos: map(s.Shi) };
 }
 
-export default function Observatory({ snapshot }: { snapshot: Snapshot | null }) {
+export default function AnalysisHUD({ snapshot }: { snapshot: Snapshot | null }) {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const rootRef = useRef<HTMLDivElement>(null);
   // Read tokens from inside the forced-dark scene subtree so the timeline tracks

--- a/src/animations/TrinaryStars/EXPLAINER.md
+++ b/src/animations/TrinaryStars/EXPLAINER.md
@@ -23,9 +23,10 @@ It's **sensitive dependence on initial conditions**, the fingerprint of
 the same path… for a while. Then a close pass by a star **amplifies** the gap,
 the next pass amplifies it again, and the tiny initial difference explodes.
 
-> Turn up the **ghost planets** and give them a tiny **perturbation ε**. Watch
-> the cloud stay together, then suddenly smear across the whole system. The
-> moment it scatters is the moment the future became unknowable.
+> Open the **Ghost swarm** panel: turn up the **ghost planets** and shrink the
+> **ghost spread ε**. Watch the cloud stay together, then suddenly smear across
+> the whole system. The moment it scatters is the moment the future became
+> unknowable.
 
 That smear grows roughly **exponentially** in time — the rate is called the
 *Lyapunov exponent*. Exponential growth means precision is hopeless: to predict
@@ -63,8 +64,8 @@ on the scene to set the launch point and velocity arrow yourself.
 
 - **Bright spheres** are the three stars, full participants in the gravity —
   they pull on each other and on the planets.
-- The **cyan planet** is the reference world. The **pink ghosts** start almost
-  exactly where it does; their divergence *is* the unpredictability.
+- The **bright planet** is the reference world. The **faint ghosts** hugging it
+  start almost exactly where it does; their divergence *is* the unpredictability.
 - **Trails** show recent history. The planets are *test masses* — they feel the
   stars but don't tug back — so every ghost samples the identical star field,
   isolating chaos from noise.

--- a/src/animations/TrinaryStars/Trinary.tsx
+++ b/src/animations/TrinaryStars/Trinary.tsx
@@ -66,11 +66,11 @@ const TOUR_STEPS: TourStep[] = [
   },
   {
     title: 'Watch chaos unfold',
-    body: 'The planet launches with a swarm of near-identical pink “ghost” copies. They start together, then fan out and scatter — sensitive dependence on initial conditions erasing any prediction of the future.',
+    body: 'The planet launches with a swarm of faint “ghost” copies hugging it — near-identical worlds. They start together, then fan out and scatter — sensitive dependence on initial conditions erasing any prediction of the future. The Ghost swarm panel tunes how many, and how close they start.',
   },
   {
     title: 'Look around, tune it',
-    body: 'Drag to orbit the camera. The rail panels let you change star masses, set the habitable climate band, or even stand on the planet’s surface and watch the suns wheel overhead. Pick the “Advanced” layout (top bar) to open every knob at once.',
+    body: 'Drag to orbit the camera. The rail panels let you change star masses, set the habitable climate band, or even stand on the planet’s surface and watch the suns wheel overhead. The Layout menu (top bar) has one arrangement per activity — Ghost swarm, Climate & sky, Rotating frames — and “Everything” opens every knob.',
   },
   {
     title: 'Open the Lab',

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -52,6 +52,12 @@ function readScenePalette(el: Element): ScenePalette {
 }
 const TRAIL_MAX = 2000; // points stored per body; visible length is a live slider.
 const VEL_SCALE = 1;    // sim-units of drag → units of launch speed.
+/** Max launch radius the Start-radius control can represent. The safe-orbit
+ *  finder is bounded to this so a recovered launch is always shown and preserved
+ *  by the slider (a larger result would clamp on the next drag, back into a
+ *  possibly-unsafe orbit); when nothing survives within range, onFindStable falls
+ *  back to the scenario's safe default (always ≤ this). */
+const MAX_RADIUS = 8;
 const SAMPLE_DT = 0.05; // sim-time between classifier samples of the reference planet.
 
 /** Sim plane lives at world y = 0 so the camera can look down on it like a floor. */
@@ -827,7 +833,12 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   const onFindStable = () => {
     const sc = getScenario(presetId);
     const stars = buildStars(sc, massMul);
-    const found = findStableLaunch(stars, target, { starSoft, dt: sc.system.dt, rKill: Math.max(collisionRadius, 1e-4) });
+    const found = findStableLaunch(stars, target, {
+      starSoft, dt: sc.system.dt, rKill: Math.max(collisionRadius, 1e-4),
+      // Bound the search to the Start-radius control so the result is always
+      // representable (and preserved on a later slider drag).
+      largestRadius: MAX_RADIUS,
+    });
     setCustom(null);
     if (found) {
       setPlanetRadiusState(found.radius);
@@ -937,7 +948,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         value={target}
         onChange={setTarget}
       />
-      <Slider label="Start radius" value={planetRadius} min={0.1} max={8} step={0.05}
+      <Slider label="Start radius" value={planetRadius} min={0.1} max={MAX_RADIUS} step={0.05}
         onChange={setPlanetRadius} format={v => v.toFixed(2)} />
       <Slider label="Start speed" value={planetSpeed} min={0} max={3} step={0.05}
         onChange={setPlanetSpeed} format={v => v.toFixed(2)} />

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -5,10 +5,11 @@ import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../chrome/workspace/types';
 import { Slider, Pills, Select, NumberInput } from '../../components/ControlPanel';
 import {
-  step, cloudSpread, lyapunovRenorm, SCENARIOS, getScenario, buildStars, orbitFrame, launchPlanet, Analyzer, DEFAULT_CLASSIFY,
+  step, cloudSpread, lyapunovRenorm, SCENARIOS, getScenario, buildStars, launchPlanet,
+  circularSpeed, findStableLaunch, Analyzer, DEFAULT_CLASSIFY,
   type SimState, type Planet, type Star, type TargetId, type ClassifyParams, type Snapshot,
 } from '@/lib/nbody';
-import Observatory from './Observatory';
+import AnalysisHUD from './AnalysisHUD';
 import SkyView, { type SkyData } from './SkyView';
 import { usePersistentState, clearPersistedState } from '../../lib/usePersistentState';
 import { Scheme } from '../../chrome/Scheme';
@@ -212,7 +213,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   const [planetSpeed, setPlanetSpeedState] = usePersistentState(PK('planetSpeed'), getScenario(presetId).launch.speed);
   const [massMul, setMassMul] = usePersistentState<number[]>(fromLink ? null : PK('massMul'), [navNum(Q, 'm0', 1), navNum(Q, 'm1', 1), navNum(Q, 'm2', 1)]); // per-star mass multipliers
   const [starSoft, setStarSoft] = usePersistentState(fromLink ? null : PK('starSoft'), navNum(Q, 'ss', getScenario(presetId).system.softening)); // close-encounter softening
-  const [speed, setSpeed] = usePersistentState(PK('speed'), 1);          // sim-seconds per real-second
+  const [speed, setSpeed] = usePersistentState(PK('speed'), 1.5);        // sim-seconds per real-second (1.5× so the ghost cloud's fan-out reads sooner)
   const [trailLen, setTrailLen] = usePersistentState(PK('trailLen'), 500);
   const [showTrails, setShowTrails] = usePersistentState(PK('showTrails'), true);
   const [frameCenter, setFrameCenter] = usePersistentState(PK('frameCenter'), 'bary'); // reference-frame origin
@@ -814,9 +815,29 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   // Set the launch speed to the local circular speed √(M/r) for the target.
   const onAutoCircular = () => {
     const stars = buildStars(getScenario(presetId), massMul);
-    const f = orbitFrame(stars, target);
-    const v = Math.sqrt(f.mass / Math.max(0.05, planetRadius));
+    const v = circularSpeed(stars, target, planetRadius);
     setPlanetSpeed(Math.round(v / 0.05) * 0.05);
+  };
+
+  // Empirically find a launch (radius + circular speed) whose planet stays clear
+  // of every star for a long probe — the reliable "safe orbit" in a chaotic field
+  // (a derived radius fails: stars get ejected, hierarchical systems orbit a
+  // sub-system). Adapts to the *current* masses/target. Falls back to the
+  // scenario's verified-safe default launch if the current target admits none.
+  const onFindStable = () => {
+    const sc = getScenario(presetId);
+    const stars = buildStars(sc, massMul);
+    const found = findStableLaunch(stars, target, { starSoft, dt: sc.system.dt, rKill: Math.max(collisionRadius, 1e-4) });
+    setCustom(null);
+    if (found) {
+      setPlanetRadiusState(found.radius);
+      setPlanetSpeedState(found.speed);
+    } else {
+      // No stable orbit around the current target → restore the scenario default.
+      setTargetState(sc.launch.target);
+      setPlanetRadiusState(sc.launch.radius);
+      setPlanetSpeedState(sc.launch.speed);
+    }
   };
 
   const onTogglePlace = () => {
@@ -920,14 +941,19 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         onChange={setPlanetRadius} format={v => v.toFixed(2)} />
       <Slider label="Start speed" value={planetSpeed} min={0} max={3} step={0.05}
         onChange={setPlanetSpeed} format={v => v.toFixed(2)} />
-      <button style={{ ...btnStyle, width: '100%', flex: 'none' }} onClick={onAutoCircular}>
-        ◯ Circular orbit speed
-      </button>
+      <div style={{ display: 'flex', gap: 6 }}>
+        <button style={btnStyle} onClick={onAutoCircular}>
+          ◯ Circular speed
+        </button>
+        <button style={btnStyle} onClick={onFindStable}>
+          ✓ Find a stable orbit
+        </button>
+      </div>
       <button style={{ ...placeBtnStyle, width: '100%', flex: 'none', marginTop: 6 }} onClick={onTogglePlace}>
         {placeMode ? '✛ Placing — click + drag on the scene' : '✛ Place planet by hand'}
       </button>
       <div style={note}>
-        Radius &amp; speed are measured from the body you orbit. Pick a star for a tight inner (S-type) orbit; the barycenter or inner binary for a wide one. Custom mode pins the exact x/y/vx/vy shown in the System panel.
+        Radius &amp; speed are measured from the body you orbit. Pick a star for a tight inner (S-type) orbit; the barycenter or inner binary for a wide one. <b>Find a stable orbit</b> searches outward for a launch that stays clear of every star. Custom mode pins the exact x/y/vx/vy shown in the System panel.
       </div>
     </>
   );
@@ -1077,9 +1103,28 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
               {placeMode && <div style={{ color: 'var(--accent)' }}>click + drag to launch</div>}
             </div>
 
+            {/* Graceful-failure hint: when the planet has fallen into a star, offer
+                a one-click route back to a survivable orbit instead of a dead end. */}
+            {labSnap?.planetFate === 'destroyed' && (
+              <div style={{
+                position: 'absolute', left: '50%', bottom: 128, transform: 'translateX(-50%)',
+                display: 'flex', alignItems: 'center', gap: 12, padding: '10px 14px',
+                background: 'var(--panel)', border: '1px solid var(--danger)', borderRadius: 10,
+                color: 'var(--fg)', font: '13px/1.4 system-ui', boxShadow: '0 6px 24px rgba(0,0,0,0.35)',
+                backdropFilter: 'blur(6px)', maxWidth: 'min(90%, 460px)', zIndex: 5,
+              }}>
+                <span>☄ Your planet fell into a star.</span>
+                <button
+                  style={{ ...btnStyle, flex: 'none', padding: '8px 12px', borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
+                  onClick={onFindStable}>
+                  ✓ Find a stable orbit
+                </button>
+              </div>
+            )}
+
             {skyOn && <SkyView dataRef={skyRef} dayLen={dayLen} tilt={tilt} />}
 
-            <Observatory snapshot={labSnap} />
+            <AnalysisHUD snapshot={labSnap} />
           </div>
         </Scheme>
       ),

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -7,10 +7,11 @@ import { Slider, Pills, Select, NumberInput, Button, Kicker, Note, Section } fro
 import { usePhone } from '../../chrome/usePhone';
 import {
   step, cloudSpread, lyapunovRenorm, SCENARIOS, getScenario, buildStars, launchPlanet,
-  circularSpeed, findStableLaunch, Analyzer, DEFAULT_CLASSIFY,
-  type SimState, type Planet, type Star, type TargetId, type ClassifyParams, type Snapshot,
+  circularSpeed, findStableLaunch, migrateLegacyLaunch, Analyzer, DEFAULT_CLASSIFY,
+  type SimState, type Planet, type TargetId, type ClassifyParams, type Snapshot,
 } from '@/lib/nbody';
 import AnalysisHUD from './AnalysisHUD';
+import { frameTransform } from './frame';
 import SkyView, { type SkyData } from './SkyView';
 import { usePersistentState, clearPersistedState } from '../../lib/usePersistentState';
 import { Scheme } from '../../chrome/Scheme';
@@ -139,37 +140,7 @@ function navNum(u: URLSearchParams, k: string, d: number) { const v = u.get(k); 
 /** localStorage key namespace for the Observatory's persisted settings. */
 const PK = (field: string) => `trinary:${field}`;
 
-/** Anchor point (in sim coords) for a reference-frame selector: a star, a pair's
- *  center of mass, or the system barycenter. */
-function frameAnchor(stars: Star[], key: string): { x: number; y: number } {
-  const com = (idx: number[]) => {
-    let M = 0, x = 0, y = 0;
-    for (const i of idx) { const s = stars[i]; M += s.mass; x += s.mass * s.x; y += s.mass * s.y; }
-    return { x: x / M, y: y / M };
-  };
-  switch (key) {
-    case 's0': return { x: stars[0].x, y: stars[0].y };
-    case 's1': return { x: stars[1].x, y: stars[1].y };
-    case 's2': return { x: stars[2].x, y: stars[2].y };
-    case 'c01': return com([0, 1]);
-    case 'c02': return com([0, 2]);
-    case 'c12': return com([1, 2]);
-    default: return com([0, 1, 2]); // barycenter
-  }
-}
-
-/** A pure view transform: put `center` at the origin, and (unless align='none')
- *  rotate so the direction to `align` lies on +x. Physics is unchanged. */
-function frameTransform(stars: Star[], center: string, align: string): (x: number, y: number) => { x: number; y: number } {
-  const C = frameAnchor(stars, center);
-  let c = 1, s = 0;
-  if (align !== 'none') {
-    const A = frameAnchor(stars, align);
-    const ang = Math.atan2(A.y - C.y, A.x - C.x);
-    c = Math.cos(ang); s = Math.sin(ang);
-  }
-  return (x, y) => { const dx = x - C.x, dy = y - C.y; return { x: dx * c + dy * s, y: -dx * s + dy * c }; };
-}
+// Reference-frame view transforms live in frame.ts (pure, unit-tested).
 
 const FRAME_ANCHORS = [
   { value: 'bary', label: 'Barycenter' },
@@ -241,6 +212,19 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
 
   const preset = getScenario(presetId);
   const isPhone = usePhone(); // phone re-chrome: the floating top bar overlays the view
+
+  // Returning visitors carry persisted launches from before the safe-default
+  // fixes — their stored settings silently resurrect the old planet-into-star
+  // failure. Migrate an EXACT legacy default to the current safe launch, once,
+  // and only in Auto mode (hand-tuned values and pinned launches are untouched).
+  const migratedRef = useRef(false);
+  useEffect(() => {
+    if (migratedRef.current) return;
+    migratedRef.current = true;
+    if (fromLink || customRef.current) return;
+    const m = migrateLegacyLaunch(presetId, planetRadius, planetSpeed);
+    if (m) { setPlanetRadiusState(m.radius); setPlanetSpeedState(m.speed); }
+  }, [fromLink, presetId, planetRadius, planetSpeed, setPlanetRadiusState, setPlanetSpeedState]);
 
   // The collision radius also bounds the analyzer's "destroyed" test so the era
   // timeline agrees with what you see consumed on screen.

--- a/src/animations/TrinaryStars/TrinaryStars.tsx
+++ b/src/animations/TrinaryStars/TrinaryStars.tsx
@@ -3,7 +3,8 @@ import * as THREE from 'three';
 import Canvas3D from '@/components/Canvas3D';
 import Workspace from '../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../chrome/workspace/types';
-import { Slider, Pills, Select, NumberInput } from '../../components/ControlPanel';
+import { Slider, Pills, Select, NumberInput, Button, Kicker, Note, Section } from '../../components/ControlPanel';
+import { usePhone } from '../../chrome/usePhone';
 import {
   step, cloudSpread, lyapunovRenorm, SCENARIOS, getScenario, buildStars, launchPlanet,
   circularSpeed, findStableLaunch, Analyzer, DEFAULT_CLASSIFY,
@@ -239,6 +240,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   const skyRef = useRef<SkyData | null>(null);
 
   const preset = getScenario(presetId);
+  const isPhone = usePhone(); // phone re-chrome: the floating top bar overlays the view
 
   // The collision radius also bounds the analyzer's "destroyed" test so the era
   // timeline agrees with what you see consumed on screen.
@@ -269,7 +271,7 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   };
 
   // Imperative handles populated by onMount and called by control effects/buttons.
-  const api = useRef<{ reset: () => void; scatter: () => void; applyPalette: (p: ScenePalette) => void } | null>(null);
+  const api = useRef<{ reset: () => void; scatter: () => void; applyPalette: (p: ScenePalette) => void; retune: (c: ClassifyParams) => void } | null>(null);
   // Live scene palette (theming v2): read from the forced-dark tokens; the canvas
   // engine reads this ref so frame-built planets pick up the current colors.
   const paletteRef = useRef<ScenePalette>(SCENE_FALLBACK);
@@ -504,7 +506,12 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
       scene.add(grid);
     }
 
-    api.current = { reset, scatter, applyPalette };
+    api.current = {
+      reset, scatter, applyPalette,
+      // Re-tune the running classifier (habitable band, calm test, kill radius)
+      // without touching the physics — climate knobs re-label, never restart.
+      retune: (c: ClassifyParams) => { analyzer?.retune(c); },
+    };
     reset();
 
     // --- Orbit camera (drag to rotate, wheel to zoom) ---
@@ -589,8 +596,12 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         placing = false;
         arrow.visible = false;
         customRef.current = { x: placeStart.x, y: placeStart.y, vx: draftVel.vx, vy: draftVel.vy };
-        setCustomState(customRef.current); // mirror for the System spinboxes
+        setCustomState(customRef.current); // mirror for the exact-launch spinboxes
         reset();
+        // A successful placement is a launch: disarm the tool and let it fly,
+        // instead of leaving the scene armed + frozen with no visible way out.
+        setPlaceMode(false);
+        setPaused(false);
         try { el.releasePointerCapture(e.pointerId); } catch { /* ignore */ }
         return;
       }
@@ -777,7 +788,13 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   // changes also clear any hand-placed launch via their wrapped setters.)
   useEffect(() => {
     api.current?.reset();
-  }, [presetId, target, ghostCount, epsExp, planetRadius, planetSpeed, massMul, starSoft, lumExp, habLo, habHi, calmThresh]);
+  }, [presetId, target, ghostCount, epsExp, planetRadius, planetSpeed, massMul, starSoft]);
+
+  // Climate knobs re-label the running world, they never restart it: re-tune the
+  // live classifier (band, calm test, kill radius) and leave the physics alone.
+  useEffect(() => {
+    api.current?.retune({ ...DEFAULT_CLASSIFY, lumExp, habLo, habHi, calmThresh, rKill: Math.max(collisionRadius, 1e-4) });
+  }, [lumExp, habLo, habHi, calmThresh, collisionRadius]);
 
   // Wrapped setters: any change that redefines the launch drops a pinned one.
   const setPlanetRadius = (v: number) => { setCustom(null); setPlanetRadiusState(v); };
@@ -807,9 +824,13 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
     api.current?.reset();
   };
 
+  // One-line feedback from the last "Find a stable orbit" run (transient UI).
+  const [findStatus, setFindStatus] = useState<string | null>(null);
+
   const onPickPreset = (id: string) => {
     const p = getScenario(id);
     setCustom(null);
+    setFindStatus(null);
     setPresetId(id);
     setTargetState(p.launch.target);
     setPlanetRadiusState(p.launch.radius);
@@ -843,11 +864,13 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
     if (found) {
       setPlanetRadiusState(found.radius);
       setPlanetSpeedState(found.speed);
+      setFindStatus(`Found: radius ${found.radius.toFixed(2)} at speed ${found.speed.toFixed(2)} — launched.`);
     } else {
       // No stable orbit around the current target → restore the scenario default.
       setTargetState(sc.launch.target);
       setPlanetRadiusState(sc.launch.radius);
       setPlanetSpeedState(sc.launch.speed);
+      setFindStatus('No stable orbit within reach of that target — restored this scenario’s safe launch instead.');
     }
   };
 
@@ -865,20 +888,6 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
     ...(preset.system.hasBinary ? [{ value: 'binary' as TargetId, label: 'Inner binary' }] : []),
   ];
 
-  const btnStyle: React.CSSProperties = {
-    padding: '10px 14px', borderRadius: 6, border: '1px solid var(--cp-border, #2a3550)',
-    background: 'var(--panel-2)', color: 'var(--cp-fg, #e8edf6)', cursor: 'pointer', fontSize: 14, flex: 1,
-  };
-  const placeBtnStyle: React.CSSProperties = {
-    ...btnStyle,
-    background: placeMode ? 'var(--accent-soft)' : 'var(--panel-2)',
-    borderColor: placeMode ? 'var(--accent)' : 'var(--cp-border, #2a3550)',
-  };
-
-  const note: React.CSSProperties = {
-    font: '11px/1.5 system-ui', color: 'var(--cp-fg-dim, #93a2bd)', padding: '2px',
-  };
-
   /* ---- archetype panels (PARAM-MAP §6; rows ported from the old drawer) ---- */
 
   // Spinboxes show the active launch state: the pinned one if present, else the
@@ -886,6 +895,18 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
   const ic = custom ?? autoIC;
   const show = (v: number) => Number(v.toFixed(4));
 
+  // A token-colored dot matching each star's scene color (--data-1/4/6), so the
+  // mass sliders point at the stars by COLOR, not by a hardcoded color name that
+  // drifts when the skin changes.
+  const starDot = (token: string) => (
+    <span style={{
+      display: 'inline-block', width: 8, height: 8, borderRadius: 8,
+      background: `var(--${token})`, marginRight: 6, verticalAlign: 'baseline',
+    }} />
+  );
+
+  // The System panel is just the subject: which star system. The planet's exact
+  // launch state lives with the rest of the launch controls (Planet launch).
   const systemNode = (
     <>
       <Pills
@@ -896,41 +917,27 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
       <div style={{ font: '12px/1.5 system-ui', color: 'var(--cp-fg-dim, #93a2bd)', padding: '4px 2px' }}>
         {preset.blurb}
       </div>
-      <div style={{
-        font: '600 10px/1.4 ui-monospace, monospace', letterSpacing: 0.6, textTransform: 'uppercase',
-        color: 'var(--cp-fg-dim, #93a2bd)', margin: '8px 0 0',
-      }}>
-        Custom planet — {custom ? 'pinned launch state' : 'auto launch (edit to pin)'}
-      </div>
-      <NumberInput label="x" value={show(ic.x)} onChange={editCustom('x')} step={0.05} />
-      <NumberInput label="y" value={show(ic.y)} onChange={editCustom('y')} step={0.05} />
-      <NumberInput label="vx" value={show(ic.vx)} onChange={editCustom('vx')} step={0.05} />
-      <NumberInput label="vy" value={show(ic.vy)} onChange={editCustom('vy')} step={0.05} />
-      <div style={note}>
-        The planet’s exact start position &amp; velocity. Editing a value pins the launch (mode flips to Custom in the Planet launch panel); hand-placing or a Destiny-map link pins it too.
-      </div>
     </>
   );
 
   const starsNode = (
     <>
-      <Slider label="Star 1 mass · gold" value={massMul[0]} min={0.1} max={4} step={0.05}
+      <Slider label={<>{starDot('data-1')}Star 1 mass</>} value={massMul[0]} min={0.1} max={4} step={0.05}
         onChange={v => setStarMass(0, v)} format={v => (baseMasses[0] * v).toFixed(2)} />
-      <Slider label="Star 2 mass · orange" value={massMul[1]} min={0.1} max={4} step={0.05}
+      <Slider label={<>{starDot('data-4')}Star 2 mass</>} value={massMul[1]} min={0.1} max={4} step={0.05}
         onChange={v => setStarMass(1, v)} format={v => (baseMasses[1] * v).toFixed(2)} />
-      <Slider label="Star 3 mass · blue" value={massMul[2]} min={0.1} max={4} step={0.05}
+      <Slider label={<>{starDot('data-6')}Star 3 mass</>} value={massMul[2]} min={0.1} max={4} step={0.05}
         onChange={v => setStarMass(2, v)} format={v => (baseMasses[2] * v).toFixed(2)} />
-      <Slider label="Softening" value={starSoft} min={0.005} max={0.3} step={0.005}
+      <Slider label="Close-pass smoothing" value={starSoft} min={0.005} max={0.3} step={0.005}
         onChange={setStarSoft} format={v => v.toFixed(3)} />
-      <Slider label="Star size (collision)" value={collisionRadius} min={0} max={0.5} step={0.01}
+      <Slider label="Collision radius" value={collisionRadius} min={0} max={0.5} step={0.01}
         onChange={setCollisionRadius} format={v => (v === 0 ? 'off' : v.toFixed(2))} />
-      <button style={{ ...btnStyle, width: '100%', flex: 'none' }}
-        onClick={() => { setMassMul([1, 1, 1]); setStarSoft(preset.system.softening); }}>
-        ⟲ Reset star masses
-      </button>
-      <div style={note}>
-        Equal masses keep a preset’s character (just faster); uneven ones detune it — e.g. nudge a mass to watch the figure-eight fall into chaos. Softening sets how gently close passes are smoothed. Star size sets how close a planet must come to be consumed (0 = passes through).
-      </div>
+      <Button variant="ghost" icon="reset" onClick={() => { setMassMul([1, 1, 1]); setStarSoft(preset.system.softening); }}>
+        Reset star masses
+      </Button>
+      <Note>
+        Equal masses keep a preset’s character (just faster); uneven ones detune it — e.g. nudge a mass to watch the figure-eight fall into chaos. Close-pass smoothing sets how gently near-collisions are softened. Collision radius sets how close a planet must come to be consumed (0 = passes through).
+      </Note>
     </>
   );
 
@@ -952,36 +959,43 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         onChange={setPlanetRadius} format={v => v.toFixed(2)} />
       <Slider label="Start speed" value={planetSpeed} min={0} max={3} step={0.05}
         onChange={setPlanetSpeed} format={v => v.toFixed(2)} />
-      <div style={{ display: 'flex', gap: 6 }}>
-        <button style={btnStyle} onClick={onAutoCircular}>
-          ◯ Circular speed
-        </button>
-        <button style={btnStyle} onClick={onFindStable}>
-          ✓ Find a stable orbit
-        </button>
-      </div>
-      <button style={{ ...placeBtnStyle, width: '100%', flex: 'none', marginTop: 6 }} onClick={onTogglePlace}>
-        {placeMode ? '✛ Placing — click + drag on the scene' : '✛ Place planet by hand'}
-      </button>
-      <div style={note}>
-        Radius &amp; speed are measured from the body you orbit. Pick a star for a tight inner (S-type) orbit; the barycenter or inner binary for a wide one. <b>Find a stable orbit</b> searches outward for a launch that stays clear of every star. Custom mode pins the exact x/y/vx/vy shown in the System panel.
-      </div>
+      <Button variant="primary" onClick={onFindStable}
+        title="Search outward for a launch that stays clear of every star">
+        Find a stable orbit
+      </Button>
+      <Button onClick={onAutoCircular} title="Set speed to the local circular-orbit speed √(M/r)">
+        Circular speed
+      </Button>
+      {findStatus && <Note style={{ color: 'var(--cp-fg)' }}>{findStatus}</Note>}
+      <Section title="Exact launch state" defaultOpen={custom != null}>
+        <Kicker style={{ margin: 0 }}>{custom ? 'Pinned — sliders above will replace it' : 'Auto — edit a value to pin'}</Kicker>
+        <NumberInput label="x" value={show(ic.x)} onChange={editCustom('x')} step={0.05} />
+        <NumberInput label="y" value={show(ic.y)} onChange={editCustom('y')} step={0.05} />
+        <NumberInput label="vx" value={show(ic.vx)} onChange={editCustom('vx')} step={0.05} />
+        <NumberInput label="vy" value={show(ic.vy)} onChange={editCustom('vy')} step={0.05} />
+        <Note>
+          The planet’s exact start position &amp; velocity. Editing a value pins the launch (the mode pill flips to Custom); hand-placing or a Destiny-map link pins it too. Touching Orbit around / radius / speed unpins.
+        </Note>
+      </Section>
+      <Note>
+        Radius &amp; speed are measured from the body you orbit. Pick a star for a tight inner (S-type) orbit; the barycenter or inner binary for a wide one.
+      </Note>
     </>
   );
 
   const climateNode = (
     <>
-      <Slider label="Habitable floor (×ref)" value={habLo} min={0.1} max={1} step={0.05}
+      <Slider label="Habitable floor (×launch light)" value={habLo} min={0.1} max={1} step={0.05}
         onChange={setHabLo} format={v => v.toFixed(2)} />
-      <Slider label="Habitable ceiling (×ref)" value={habHi} min={1} max={6} step={0.25}
+      <Slider label="Habitable ceiling (×launch light)" value={habHi} min={1} max={6} step={0.25}
         onChange={setHabHi} format={v => v.toFixed(2)} />
-      <Slider label="Luminosity exponent β" value={lumExp} min={0.5} max={4} step={0.5}
+      <Slider label="Brightness vs mass (β)" value={lumExp} min={0.5} max={4} step={0.5}
         onChange={setLumExp} format={v => v.toFixed(1)} />
-      <Slider label="Calm threshold" value={calmThresh} min={0.01} max={0.2} step={0.01}
+      <Slider label="Orbit calmness cutoff" value={calmThresh} min={0.01} max={0.2} step={0.01}
         onChange={setCalmThresh} format={v => v.toFixed(2)} />
-      <div style={note}>
-        The habitable band is set relative to the planet’s starlight at launch (L = mᵝ). The timeline under the Orbit view classifies every moment as Paradise / Warm·precarious / Calm·barren / Chaotic.
-      </div>
+      <Note>
+        The habitable band is measured against the starlight the planet gets at launch (each star shines as massᵝ). These knobs re-label the timeline under the Orbit view (Paradise / Warm·precarious / Calm·barren / Chaotic) live — they never restart the run.
+      </Note>
     </>
   );
 
@@ -994,15 +1008,18 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         onChange={v => setSkyOn(v === 1)}
       />
       <Slider label="Day length (spin)" value={dayLen} min={0.1} max={3} step={0.1}
-        onChange={setDayLen} format={v => v.toFixed(1)} />
+        onChange={v => { if (!skyOn) setSkyOn(true); setDayLen(v); }} format={v => v.toFixed(1)} />
       <Slider label="Axial tilt (seasons)" value={tilt} min={0} max={0.6} step={0.05}
-        onChange={setTilt} format={v => v.toFixed(2)} />
-      <div style={note}>
-        Stand on the planet and watch the suns wheel overhead. Spin sets the day; tilt makes their noon height drift over the (chaotic, irregular) year. The sky’s color tracks the climate — frozen dark to searing white.
-      </div>
+        onChange={v => { if (!skyOn) setSkyOn(true); setTilt(v); }} format={v => v.toFixed(2)} />
+      <Note>
+        Stand on the planet and watch the suns wheel overhead. Spin sets the day; tilt makes their noon height drift over the (chaotic, irregular) year. The sky’s color tracks the climate — frozen dark to searing white. Touching a slider turns the sky view on.
+      </Note>
     </>
   );
 
+  // Reference frame + trails: one panel about HOW you watch the motion (both
+  // are pure view choices; trails even reset on a frame change — they belong
+  // together, not as a two-control orphan panel).
   const frameNode = (
     <>
       <Select label="Center on" value={frameCenter} onChange={setFrameCenter} options={FRAME_ANCHORS} />
@@ -1010,81 +1027,84 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
         options={[{ value: 'none', label: 'None (inertial)' }, ...FRAME_ANCHORS]} />
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 6, marginTop: 2 }}>
         {FRAME_PRESETS.map(p => (
-          <button key={p.label} style={{ ...btnStyle, flex: 'none', padding: '6px 10px', fontSize: 12 }}
-            onClick={() => { setFrameCenter(p.c); setFrameAlign(p.a); }}>{p.label}</button>
+          <Button key={p.label} style={{ width: 'auto', flex: 'none', padding: '6px 10px', fontSize: 12 }}
+            onClick={() => { setFrameCenter(p.c); setFrameAlign(p.a); }}>{p.label}</Button>
         ))}
-        <button style={{ ...btnStyle, flex: 'none', padding: '6px 10px', fontSize: 12 }}
+        <Button variant="ghost" icon="reset" style={{ width: 'auto', flex: 'none', padding: '6px 10px', fontSize: 12 }}
           disabled={frameCenter === 'bary' && frameAlign === 'none'}
-          onClick={() => { setFrameCenter('bary'); setFrameAlign('none'); }}>⟲ Reset frame</button>
+          onClick={() => { setFrameCenter('bary'); setFrameAlign('none'); }}>Reset frame</Button>
       </div>
-      <div style={note}>
+      <Kicker>Trails</Kicker>
+      <Slider label="Trail length" value={showTrails ? trailLen : 0} min={0} max={TRAIL_MAX} step={50}
+        onChange={v => { setShowTrails(v > 0); if (v > 0) setTrailLen(v); }}
+        format={v => (v === 0 ? 'off' : `${v}`)} />
+      <Note>
         A pure viewpoint — the physics is unchanged. In a rotating frame the planet appears to swerve (the Coriolis / centrifugal look), which is exactly how co-orbital, Trojan and horseshoe paths become visible. Trails reset when you change the frame.
-      </div>
+      </Note>
     </>
   );
 
-  const trailsNode = (
-    <>
-      <Slider label="Trail length" value={trailLen} min={0} max={TRAIL_MAX} step={50}
-        onChange={setTrailLen} format={v => (v === 0 ? 'off' : `${v}`)} />
-      <Pills
-        label="Trails"
-        options={[{ value: 1, label: 'On' }, { value: 0, label: 'Off' }]}
-        value={showTrails ? 1 : 0}
-        onChange={v => setShowTrails(v === 1)}
-      />
-    </>
-  );
-
-  const chaosNode = (
+  // The headline experiment: the swarm of near-identical ghost worlds whose
+  // fan-out IS sensitive dependence. Named for what you see, not the theory.
+  const swarmNode = (
     <>
       <Slider label="Ghost planets" value={ghostCount} min={1} max={120} step={1}
         onChange={setGhostCount} format={v => `${v}`} />
-      <Slider label="Perturbation ε" value={epsExp} min={-5} max={-1} step={0.5}
+      <Slider label="Ghost spread ε" value={epsExp} min={-5} max={-1} step={0.5}
         onChange={setEpsExp} format={v => `10^${v.toFixed(1)}`} />
-      <button style={{ ...btnStyle, width: '100%', flex: 'none', marginTop: 4 }}
-        onClick={() => api.current?.scatter()}>✦ Scatter ghosts here</button>
+      <Note>
+        Every ghost starts within ε of the real planet, with the same velocity. Watch the swarm hug the planet, then smear across the system — the moment it scatters is the moment the future became unknowable. Scatter (action bar below) re-gathers the swarm around the planet mid-flight.
+      </Note>
     </>
   );
 
-  // Play/Pause + Reset live once, in the always-on action strip (`actions`
-  // below) — never duplicated here. This panel keeps the Speed knob and the
-  // one-shot tour launch.
+  // Drive-tier "hands on the scene" verbs — projected into the action strip.
+  const handsNode = (
+    <>
+      <Button variant="toggle" active={placeMode} onClick={onTogglePlace}>
+        {placeMode ? 'Placing — click + drag on the scene' : 'Place planet by hand'}
+      </Button>
+      <Button icon="sparkles" onClick={() => api.current?.scatter()}>
+        Scatter ghosts here
+      </Button>
+      <Note>
+        Place pauses the sim and arms the scene: click where the planet should start, drag to set its velocity arrow, release to launch. Scatter re-gathers the ghost swarm around the planet’s current position mid-flight.
+      </Note>
+    </>
+  );
+
+  // Play/Pause + Restart live once, in the always-on action strip (`actions`
+  // below) — never duplicated here. This panel keeps the Speed knob, the
+  // one-shot tour launch, and the stored-settings reset.
   const simNode = (
     <>
       <Slider label="Speed" value={speed} min={0.1} max={4} step={0.1}
         onChange={setSpeed} format={v => `${v.toFixed(1)}×`} />
       {onTour && (
-        <button style={{ ...btnStyle, width: '100%', flex: 'none' }} onClick={onTour}>
-          ✦ Take the tour
-        </button>
+        <Button icon="sparkles" onClick={onTour}>
+          Take the tour
+        </Button>
       )}
-    </>
-  );
-
-  const settingsNode = (
-    <>
-      <button style={{ ...btnStyle, width: '100%', flex: 'none', marginTop: 8 }}
+      <Button variant="danger" icon="reset"
         onClick={() => { clearPersistedState('trinary'); window.location.hash = '#/trinary'; window.location.reload(); }}>
-        ↺ Reset settings to defaults
-      </button>
-      <div style={note}>
-        Your settings (system, masses, climate band, sky, trails…) are saved on this device and restored on reload. This clears them.
-      </div>
+        Reset settings to defaults
+      </Button>
+      <Note>
+        Your settings (system, masses, climate band, sky, trails…) are saved on this device and restored on reload. Reset clears them.
+      </Note>
     </>
   );
 
   const sections: SectionDef[] = [
-    { id: 'system', title: 'System', arch: 'subject', node: systemNode, estHeight: 430 },
-    { id: 'stars', title: 'Stars', arch: 'subject', node: starsNode, estHeight: 440 },
-    { id: 'launch', title: 'Planet launch', arch: 'domain', node: launchNode, estHeight: 480 },
-    { id: 'climate', title: 'Climate', arch: 'domain', node: climateNode, estHeight: 330 },
-    { id: 'sky', title: 'Sky', arch: 'view', node: skyNode, estHeight: 300 },
-    { id: 'frame', title: 'Reference frame', arch: 'view', node: frameNode, estHeight: 340 },
-    { id: 'trails', title: 'Trails', arch: 'marks', node: trailsNode, estHeight: 170 },
-    { id: 'chaos', title: 'Chaos demo', arch: 'lab', node: chaosNode, estHeight: 230 },
-    { id: 'sim', title: 'Sim', arch: 'playback', node: simNode, estHeight: 210 },
-    { id: 'settings', title: 'Settings', arch: 'quality', node: settingsNode, estHeight: 170 },
+    { id: 'system', title: 'System', arch: 'subject', node: systemNode, estHeight: 220 },
+    { id: 'stars', title: 'Stars', arch: 'subject', node: starsNode, estHeight: 460 },
+    { id: 'launch', title: 'Planet launch', railLabel: 'Launch', arch: 'domain', node: launchNode, estHeight: 560 },
+    { id: 'climate', title: 'Climate', arch: 'domain', node: climateNode, estHeight: 350 },
+    { id: 'sky', title: 'Sky', arch: 'view', node: skyNode, estHeight: 320 },
+    { id: 'frame', title: 'Viewpoint & trails', railLabel: 'View', arch: 'view', node: frameNode, estHeight: 460 },
+    { id: 'hands', title: 'Hands-on', railLabel: 'Hands', arch: 'drive', node: handsNode, estHeight: 240 },
+    { id: 'chaos', title: 'Ghost swarm', railLabel: 'Ghosts', arch: 'lab', node: swarmNode, estHeight: 280 },
+    { id: 'sim', title: 'Sim', arch: 'playback', node: simNode, estHeight: 300 },
   ];
 
   const views: ViewDef[] = [
@@ -1101,12 +1121,15 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
           <div ref={sceneElRef} style={{ position: 'absolute', inset: 0, background: 'var(--viz-bg)' }}>
             <Canvas3D onMount={onMount} />
 
-            {/* Live divergence readout. */}
+            {/* Live divergence readout. Top-RIGHT so the default layout's panel
+                column (which floats over the view's left edge) and the phone's
+                floating chrome bar never bury it. */}
             <div style={{
-              position: 'absolute', top: 10, left: 10, padding: '8px 12px',
+              position: 'absolute', top: isPhone ? 64 : 10, right: 10, padding: '8px 12px',
               background: 'var(--panel)', border: '1px solid var(--border)',
-              borderRadius: 8, color: 'var(--fg)', font: '12px/1.5 ui-monospace, monospace',
-              pointerEvents: 'none', backdropFilter: 'blur(4px)',
+              borderRadius: 8, color: 'var(--fg)', font: `${isPhone ? 11 : 12}px/1.5 ui-monospace, monospace`,
+              pointerEvents: 'none', backdropFilter: 'blur(4px)', textAlign: 'left',
+              maxWidth: 'calc(100% - 20px)',
             }}>
               <div>cloud spread&nbsp; <span ref={spreadElRef} style={{ color: 'var(--dim)' }}>0.00e+0</span></div>
               <div>Lyapunov λ&nbsp;&nbsp; <span ref={lyapElRef} style={{ color: 'var(--dim)' }}>…</span></div>
@@ -1125,11 +1148,9 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
                 backdropFilter: 'blur(6px)', maxWidth: 'min(90%, 460px)', zIndex: 5,
               }}>
                 <span>☄ Your planet fell into a star.</span>
-                <button
-                  style={{ ...btnStyle, flex: 'none', padding: '8px 12px', borderColor: 'var(--accent)', background: 'var(--accent-soft)' }}
-                  onClick={onFindStable}>
-                  ✓ Find a stable orbit
-                </button>
+                <Button variant="primary" style={{ width: 'auto', flex: 'none', padding: '8px 12px' }} onClick={onFindStable}>
+                  Find a stable orbit
+                </Button>
               </div>
             )}
 
@@ -1142,28 +1163,47 @@ export default function TrinaryStars({ onTour }: { onTour?: () => void }) {
     },
   ];
 
-  // Built-in layouts replace the old Settings "simple / advanced" toggle:
-  // Sandbox ≈ the old simple set; Advanced opens every knob.
+  // Task-named layouts (the StableMatching precedent): each names a thing to DO,
+  // not a knob count. The framework's auto "Everything" remains the full spread.
+  // Sandbox opens the Ghost swarm — the app's headline experiment — on day one.
   const layouts: LayoutDef[] = [
     {
-      id: 'sandbox', name: 'Sandbox', sub: 'System · Planet launch · Sim', icon: 'tune',
-      open: { system: { x: 84, y: 18 }, launch: { x: 84, y: 466 }, sim: { x: 366, y: 18 } },
+      id: 'sandbox', name: 'Sandbox', sub: 'Pick a system · launch · watch the swarm', icon: 'tune',
+      // No Sim panel here: its verbs (Play/Restart) live in the always-on strip,
+      // and a fourth panel would bury the analysis strip along the view's bottom.
+      open: {
+        system: { x: 84, y: 18 }, launch: { x: 84, y: 270 },
+        chaos: { x: 366, y: 64 },
+      },
     },
     {
-      id: 'advanced', name: 'Advanced', sub: 'Every knob', icon: 'grid',
+      id: 'chaos', name: 'Ghost swarm', sub: 'Sensitive dependence, tuned by hand', icon: 'flask',
       open: {
-        system: { x: 84, y: 18 }, launch: { x: 84, y: 466 },
-        stars: { x: 366, y: 18 }, climate: { x: 366, y: 476 },
-        sky: { x: 648, y: 18 }, frame: { x: 648, y: 336 },
-        sim: { x: 930, y: 18 },
+        chaos: { x: 84, y: 18 }, hands: { x: 84, y: 330 },
+        stars: { x: 366, y: 64 }, sim: { x: 648, y: 64 },
+      },
+    },
+    {
+      id: 'climate-sky', name: 'Climate & sky', sub: 'Habitable band · stand on the planet', icon: 'window',
+      open: {
+        climate: { x: 84, y: 18 }, sky: { x: 84, y: 392 }, sim: { x: 366, y: 64 },
+      },
+    },
+    {
+      id: 'frames', name: 'Rotating frames', sub: 'Co-orbits, Trojans, horseshoes', icon: 'orbit',
+      open: {
+        frame: { x: 84, y: 18 }, launch: { x: 366, y: 64 }, sim: { x: 648, y: 64 },
       },
     },
   ];
 
-  /* Always-on action strip — projection of the Sim panel's verbs. */
+  /* Always-on action strip — the Drive/Playback verbs (Play projects Sim;
+     Place/Scatter project the Hands-on panel). */
   const actions: ActionDef[] = [
     { id: 'play', icon: paused ? 'play' : 'pause', label: paused ? 'Play' : 'Pause', primary: true, active: !paused, sectionId: 'sim', onClick: () => setPaused(p => !p) },
-    { id: 'reset', icon: 'reset', label: 'Reset', sectionId: 'sim', onClick: () => api.current?.reset() },
+    { id: 'place', icon: 'move', label: placeMode ? 'Placing…' : 'Place', active: placeMode, sectionId: 'hands', onClick: onTogglePlace },
+    { id: 'scatter', icon: 'sparkles', label: 'Scatter', sectionId: 'hands', onClick: () => api.current?.scatter() },
+    { id: 'reset', icon: 'reset', label: 'Restart', sectionId: 'sim', onClick: () => api.current?.reset() },
   ];
 
   return (

--- a/src/animations/TrinaryStars/__tests__/frame.test.ts
+++ b/src/animations/TrinaryStars/__tests__/frame.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { frameAnchor, frameTransform } from '../frame';
+import type { Star } from '@/lib/nbody';
+
+function star(x: number, y: number, mass: number): Star {
+  return { x, y, vx: 0, vy: 0, ax: 0, ay: 0, mass };
+}
+
+const STARS = [star(2, 0, 1), star(-1, 1, 2), star(0, -3, 3)];
+
+describe('frameAnchor', () => {
+  it('star anchors return the star positions', () => {
+    expect(frameAnchor(STARS, 's0')).toEqual({ x: 2, y: 0 });
+    expect(frameAnchor(STARS, 's2')).toEqual({ x: 0, y: -3 });
+  });
+
+  it('pair anchors are mass-weighted centers', () => {
+    // c01: masses 1 & 2 → ((2·1 + -1·2)/3, (0·1 + 1·2)/3) = (0, 2/3)
+    const c = frameAnchor(STARS, 'c01');
+    expect(c.x).toBeCloseTo(0, 12);
+    expect(c.y).toBeCloseTo(2 / 3, 12);
+  });
+
+  it('the default anchor is the full barycenter', () => {
+    const b = frameAnchor(STARS, 'bary');
+    const M = 6;
+    expect(b.x).toBeCloseTo((2 * 1 - 1 * 2 + 0 * 3) / M, 12);
+    expect(b.y).toBeCloseTo((0 * 1 + 1 * 2 - 3 * 3) / M, 12);
+  });
+});
+
+describe('frameTransform', () => {
+  it('maps the center to the origin', () => {
+    const tf = frameTransform(STARS, 's1', 'none');
+    const o = tf(STARS[1].x, STARS[1].y);
+    expect(o.x).toBeCloseTo(0, 12);
+    expect(o.y).toBeCloseTo(0, 12);
+  });
+
+  it('with align, puts the align anchor on the +x axis', () => {
+    const tf = frameTransform(STARS, 's0', 's1');
+    const a = tf(STARS[1].x, STARS[1].y);
+    expect(a.y).toBeCloseTo(0, 12);
+    expect(a.x).toBeGreaterThan(0);
+    expect(a.x).toBeCloseTo(Math.hypot(STARS[1].x - STARS[0].x, STARS[1].y - STARS[0].y), 12);
+  });
+
+  it('is an isometry: distances between any two points are preserved', () => {
+    const tf = frameTransform(STARS, 'c12', 's0');
+    const pts: [number, number][] = [[0, 0], [1, 2], [-3, 4], [5, -1]];
+    for (let i = 0; i < pts.length; i++) {
+      for (let j = i + 1; j < pts.length; j++) {
+        const a = tf(...pts[i]), b = tf(...pts[j]);
+        const before = Math.hypot(pts[i][0] - pts[j][0], pts[i][1] - pts[j][1]);
+        const after = Math.hypot(a.x - b.x, a.y - b.y);
+        expect(after).toBeCloseTo(before, 12);
+      }
+    }
+  });
+
+  it('preserves orientation (no accidental mirror)', () => {
+    const tf = frameTransform(STARS, 'bary', 's2');
+    // Signed area of a CCW triangle must stay positive through the transform.
+    const tri: [number, number][] = [[0, 0], [1, 0], [0, 1]];
+    const [A, B, C] = tri.map(p => tf(...p));
+    const cross = (B.x - A.x) * (C.y - A.y) - (B.y - A.y) * (C.x - A.x);
+    expect(cross).toBeGreaterThan(0);
+  });
+
+  it("align='none' is a pure translation", () => {
+    const tf = frameTransform(STARS, 's2', 'none');
+    const p = tf(7, 11);
+    expect(p.x).toBeCloseTo(7 - STARS[2].x, 12);
+    expect(p.y).toBeCloseTo(11 - STARS[2].y, 12);
+  });
+});

--- a/src/animations/TrinaryStars/frame.ts
+++ b/src/animations/TrinaryStars/frame.ts
@@ -1,0 +1,38 @@
+/** Reference-frame math for the Observatory: pure view transforms over the
+ *  star positions (no physics). Extracted from TrinaryStars.tsx so the
+ *  rotating-frame geometry — where subtle sign errors would silently bend
+ *  every co-rotating orbit — is unit-testable. */
+
+import type { Star } from '@/lib/nbody';
+
+/** Anchor point (in sim coords) for a reference-frame selector: a star, a pair's
+ *  center of mass, or the system barycenter. */
+export function frameAnchor(stars: Star[], key: string): { x: number; y: number } {
+  const com = (idx: number[]) => {
+    let M = 0, x = 0, y = 0;
+    for (const i of idx) { const s = stars[i]; M += s.mass; x += s.mass * s.x; y += s.mass * s.y; }
+    return { x: x / M, y: y / M };
+  };
+  switch (key) {
+    case 's0': return { x: stars[0].x, y: stars[0].y };
+    case 's1': return { x: stars[1].x, y: stars[1].y };
+    case 's2': return { x: stars[2].x, y: stars[2].y };
+    case 'c01': return com([0, 1]);
+    case 'c02': return com([0, 2]);
+    case 'c12': return com([1, 2]);
+    default: return com([0, 1, 2]); // barycenter
+  }
+}
+
+/** A pure view transform: put `center` at the origin, and (unless align='none')
+ *  rotate so the direction to `align` lies on +x. Physics is unchanged. */
+export function frameTransform(stars: Star[], center: string, align: string): (x: number, y: number) => { x: number; y: number } {
+  const C = frameAnchor(stars, center);
+  let c = 1, s = 0;
+  if (align !== 'none') {
+    const A = frameAnchor(stars, align);
+    const ang = Math.atan2(A.y - C.y, A.x - C.x);
+    c = Math.cos(ang); s = Math.sin(ang);
+  }
+  return (x, y) => { const dx = x - C.x, dy = y - C.y; return { x: dx * c + dy * s, y: -dx * s + dy * c }; };
+}

--- a/src/animations/TrinaryStars/lab/BasinMap.tsx
+++ b/src/animations/TrinaryStars/lab/BasinMap.tsx
@@ -677,7 +677,7 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
             <Pills label="Reference frame" value={frame}
               options={[
                 { value: 'bary', label: 'Barycenter' },
-                { value: 's0', label: 'Star A' }, { value: 's1', label: 'Star B' }, { value: 's2', label: 'Star C' },
+                { value: 's0', label: 'Star 1' }, { value: 's1', label: 'Star 2' }, { value: 's2', label: 'Star 3' },
               ]}
               onChange={(v) => setFrame(v as FrameId)} />
           )}
@@ -777,7 +777,7 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
           </div>
           {mode === 'pos' && frame !== 'bary' && (
             <div style={{ font: '11px/1.5 system-ui', color: 'var(--dim)', marginTop: 6 }}>
-              Frame co-moving with <b>{frame === 's0' ? 'Star A' : frame === 's1' ? 'Star B' : 'Star C'}</b>: each pixel is a start offset from that star, launched with the star’s own velocity, so destinies are read relative to a moving star (⌖ marks it, pinned at the origin while the others orbit).
+              Frame co-moving with <b>{frame === 's0' ? 'Star 1' : frame === 's1' ? 'Star 2' : 'Star 3'}</b>: each pixel is a start offset from that star, launched with the star’s own velocity, so destinies are read relative to a moving star (⌖ marks it, pinned at the origin while the others orbit).
             </div>
           )}
         </div>

--- a/src/animations/TrinaryStars/lab/BasinMap.tsx
+++ b/src/animations/TrinaryStars/lab/BasinMap.tsx
@@ -138,6 +138,12 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
   // Resolution currently on the canvas — varies during a progressive render, so
   // hover/click/recolor index the grids by this, not the target `res` state.
   const paintedResRef = useRef(128);
+  // The domain/config the CURRENTLY PAINTED grids were computed with. The click
+  // handoff, hover readout and zoom selection must map pixels through THIS —
+  // not the live state — or moving any slider (sampling box, masses, launch
+  // rule, frame) after rendering silently remaps every pixel: the map would
+  // show world A's fate while a click launches world B.
+  const paintedCtxRef = useRef<{ domain: Domain; bc: BasinConfig; cfg: EnsembleConfig } | null>(null);
   const autoFitRef = useRef(autoFit); autoFitRef.current = autoFit;
   const statMetricRef = useRef(statMetric); statMetricRef.current = statMetric;
   // Identifies what the value grids currently hold, so an idle recolor only
@@ -182,13 +188,18 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
     mode, metric, lens, statRuns, statMetric, domain: effDomain, res, samples, posRule, posSpeedFrac, fixedAngle, fixedRadius, fixedRetro, frame,
   });
   const goObservatory = (i: number, j: number) => {
-    const d = effDomain, pr = paintedResRef.current;
+    // Map the clicked pixel through the PAINTED context (domain + launch rules
+    // + system config at render time) — the live sliders may have moved since,
+    // and the pixel's fate belongs to the world it was computed for.
+    const pc = paintedCtxRef.current;
+    const d = pc?.domain ?? effDomain, pr = paintedResRef.current;
+    const pcfg = pc?.cfg ?? cfg;
     const ax = d.a0 + (d.a1 - d.a0) * ((i + 0.5) / pr);
     const by = d.b1 - (d.b1 - d.b0) * ((j + 0.5) / pr);
-    const planet = basinPlanetAt(cfg, currentBc(), ax, by);
+    const planet = basinPlanetAt(pcfg, pc?.bc ?? currentBc(), ax, by);
     const q = new URLSearchParams({
-      p: cfg.presetId, tg: cfg.target,
-      m0: String(cfg.massMul[0]), m1: String(cfg.massMul[1]), m2: String(cfg.massMul[2]), ss: String(cfg.starSoft),
+      p: pcfg.presetId, tg: pcfg.target,
+      m0: String(pcfg.massMul[0]), m1: String(pcfg.massMul[1]), m2: String(pcfg.massMul[2]), ss: String(pcfg.starSoft),
       px: planet.x.toFixed(5), py: planet.y.toFixed(5), vx: planet.vx.toFixed(5), vy: planet.vy.toFixed(5),
     });
     // Open the run in a new tab so the Lab — and the map you just computed —
@@ -381,6 +392,7 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
       }
       const outGrid = new Uint8Array(N * N), tGrid = new Float32Array(N * N), statGrid = new Float32Array(N * N * 4);
       outGridRef.current = outGrid; tGridRef.current = tGrid; statGridRef.current = statGrid; paintedResRef.current = N;
+      paintedCtxRef.current = { domain: dom, bc, cfg: cfgNow };
       let painted = 0; const total = N * N;
 
       // Color from the themed ramps (ignoring the worker/GPU's own rgb), so every
@@ -584,9 +596,11 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
     const i = Math.min(pr - 1, Math.max(0, Math.floor(((e.clientX - r.left) / r.width) * pr)));
     const j = Math.min(pr - 1, Math.max(0, Math.floor(((e.clientY - r.top) / r.height) * pr)));
     if (tGridRef.current.length) {
-      const ax = effDomain.a0 + (effDomain.a1 - effDomain.a0) * ((i + 0.5) / pr);
-      const by = effDomain.b1 - (effDomain.b1 - effDomain.b0) * ((j + 0.5) / pr);
-      const [la, lb] = AXIS_LABELS[mode];
+      // Read through the painted domain — the live box may have moved since.
+      const pd = paintedCtxRef.current?.domain ?? effDomain;
+      const ax = pd.a0 + (pd.a1 - pd.a0) * ((i + 0.5) / pr);
+      const by = pd.b1 - (pd.b1 - pd.b0) * ((j + 0.5) / pr);
+      const [la, lb] = AXIS_LABELS[paintedCtxRef.current?.bc.mode ?? mode];
       const v = tGridRef.current[j * pr + i];
       const detail = lens === 'stat'
         ? `${STAT_LABEL[statMetric]} ${(v * 100).toFixed(0)}% (of ${statRuns} worlds)`
@@ -621,9 +635,12 @@ const BasinMap = forwardRef<BasinHandle, { cfg: EnsembleConfig; system?: BasinSy
     if (dx < 6 || dy < 6) return; // degenerate selection
     const nx0 = Math.min(d.x0, d.x1) / r.width, nx1 = Math.max(d.x0, d.x1) / r.width;
     const ny0 = Math.min(d.y0, d.y1) / r.height, ny1 = Math.max(d.y0, d.y1) / r.height;
+    // The user selected a rectangle OF THE PAINTED IMAGE — convert through the
+    // painted domain, then apply to the live box/domain.
+    const pd = paintedCtxRef.current?.domain ?? effDomain;
     const nd: Domain = {
-      a0: effDomain.a0 + (effDomain.a1 - effDomain.a0) * nx0, a1: effDomain.a0 + (effDomain.a1 - effDomain.a0) * nx1,
-      b0: effDomain.b1 - (effDomain.b1 - effDomain.b0) * ny1, b1: effDomain.b1 - (effDomain.b1 - effDomain.b0) * ny0,
+      a0: pd.a0 + (pd.a1 - pd.a0) * nx0, a1: pd.a0 + (pd.a1 - pd.a0) * nx1,
+      b0: pd.b1 - (pd.b1 - pd.b0) * ny1, b1: pd.b1 - (pd.b1 - pd.b0) * ny0,
     };
     if (mode === 'radspeed' && system?.onBox) system.onBox({ rMin: nd.a0, rMax: nd.a1, fMin: nd.b0, fMax: nd.b1 });
     else setDomain(nd);

--- a/src/animations/TrinaryStars/lab/TrinaryLab.tsx
+++ b/src/animations/TrinaryStars/lab/TrinaryLab.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import Workspace from '../../../chrome/workspace/Workspace';
 import type { ActionDef, LayoutDef, SectionDef, ViewDef, WorkspaceMode } from '../../../chrome/workspace/types';
-import { Slider, Pills } from '../../../components/ControlPanel';
+import { Slider, Pills, Button } from '../../../components/ControlPanel';
 import { SCENARIOS, getScenario, DEFAULT_CLASSIFY, type TargetId, type Outcome, type RunResult } from '@/lib/nbody';
 import { Aggregator, OUTCOMES, type AggSnapshot } from './ensemble';
 import { runOne, targetMassOf } from './runner';
@@ -209,6 +209,8 @@ export default function TrinaryLab() {
 
   const [running, setRunning] = useState(false);
   const [agg, setAgg] = useState<AggSnapshot | null>(null);
+  // Settings changed since this census ran — results kept on screen, labeled.
+  const [stale, setStale] = useState(false);
   const [rate, setRate] = useState(0);
   const [engine, setEngine] = useState<Engine>(() => {
     const e = U.get('e') as Engine | null;
@@ -353,6 +355,7 @@ export default function TrinaryLab() {
 
   const start = () => {
     ensureAgg();
+    setStale(false); // fresh results will stream in and replace the kept census
     tmRef.current = targetMassOf(cfgRef.current);
     uiClock.current = { t: performance.now(), n: aggRef.current!.count };
     runningRef.current = true; setRunning(true);
@@ -372,13 +375,22 @@ export default function TrinaryLab() {
     pause();
     poolRef.current?.dispose(); poolRef.current = null;
     aggRef.current = new Aggregator(cfgRef.current.tMax);
-    setRate(0); setAgg(null);
+    setRate(0); setAgg(null); setStale(false);
   };
 
   const engineRef = useRef(engine); engineRef.current = engine;
   useEffect(() => () => { cancelAnimationFrame(rafRef.current); poolRef.current?.dispose(); }, []);
-  // Changing the configuration or engine invalidates accumulated stats.
-  useEffect(() => { reset(); }, [cfg, engine]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Changing the configuration or engine invalidates the accumulator — but a
+  // 20,000-world census is minutes of compute, so KEEP the last results on
+  // screen, banner them as stale, and let the next Run start fresh. Only the
+  // explicit Reset (or a fresh run) discards what's shown.
+  useEffect(() => {
+    pause();
+    poolRef.current?.dispose(); poolRef.current = null;
+    aggRef.current = new Aggregator(cfgRef.current.tMax);
+    setRate(0);
+    if (agg && agg.n > 0) setStale(true);
+  }, [cfg, engine]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const onPickPreset = (id: string) => {
     setPresetId(id); setTarget(getScenario(id).launch.target);
@@ -423,6 +435,12 @@ export default function TrinaryLab() {
     background: 'var(--panel-2)', color: 'var(--fg)', cursor: 'pointer', fontSize: 14,
   };
   const note: React.CSSProperties = { font: '11px/1.5 system-ui', color: 'var(--dim)', marginTop: 4 };
+  // Token-colored dot matching each star's scene color (--data-1/4/6): the mass
+  // sliders point at stars by COLOR, not by a color name that drifts per skin.
+  const dotStyle = (token: string): React.CSSProperties => ({
+    display: 'inline-block', width: 8, height: 8, borderRadius: 8,
+    background: `var(--${token})`, marginRight: 6,
+  });
 
   const targetOptions: { value: TargetId; label: string }[] = [
     { value: 'bary', label: 'Barycenter' }, { value: 's0', label: 'Star 1' },
@@ -437,12 +455,12 @@ export default function TrinaryLab() {
       <Pills options={SCENARIOS.map(p => ({ value: p.id, label: p.name }))} value={presetId} onChange={onPickPreset} />
       <div style={{ font: '12px/1.5 system-ui', color: 'var(--cp-fg-dim, #93a2bd)', padding: '4px 2px' }}>{preset.blurb}</div>
       <Pills label="Orbit around" options={targetOptions} value={target} onChange={setTarget} />
-      <Slider label="Star 1 mass · gold" value={massMul[0]} min={0.1} max={4} step={0.05} onChange={(v) => setStarMass(0, v)} format={(v) => (baseMasses[0] * v).toFixed(2)} />
-      <Slider label="Star 2 mass · orange" value={massMul[1]} min={0.1} max={4} step={0.05} onChange={(v) => setStarMass(1, v)} format={(v) => (baseMasses[1] * v).toFixed(2)} />
-      <Slider label="Star 3 mass · blue" value={massMul[2]} min={0.1} max={4} step={0.05} onChange={(v) => setStarMass(2, v)} format={(v) => (baseMasses[2] * v).toFixed(2)} />
-      <Slider label="Softening" value={starSoft} min={0.005} max={0.3} step={0.005} onChange={setStarSoft} format={(v) => v.toFixed(3)} />
-      <button style={{ ...btn, padding: '5px 12px', fontSize: 12, marginTop: 4 }}
-        onClick={() => { setMassMul([1, 1, 1]); setStarSoft(preset.system.softening); }}>⟲ Reset stars</button>
+      <Slider label={<><i style={dotStyle('data-1')} />Star 1 mass</>} value={massMul[0]} min={0.1} max={4} step={0.05} onChange={(v) => setStarMass(0, v)} format={(v) => (baseMasses[0] * v).toFixed(2)} />
+      <Slider label={<><i style={dotStyle('data-4')} />Star 2 mass</>} value={massMul[1]} min={0.1} max={4} step={0.05} onChange={(v) => setStarMass(1, v)} format={(v) => (baseMasses[1] * v).toFixed(2)} />
+      <Slider label={<><i style={dotStyle('data-6')} />Star 3 mass</>} value={massMul[2]} min={0.1} max={4} step={0.05} onChange={(v) => setStarMass(2, v)} format={(v) => (baseMasses[2] * v).toFixed(2)} />
+      <Slider label="Close-pass smoothing" value={starSoft} min={0.005} max={0.3} step={0.005} onChange={setStarSoft} format={(v) => v.toFixed(3)} />
+      <Button variant="ghost" icon="reset" style={{ width: 'auto', padding: '5px 12px', fontSize: 12, marginTop: 4 }}
+        onClick={() => { setMassMul([1, 1, 1]); setStarSoft(preset.system.softening); }}>Reset stars</Button>
     </>
   );
 
@@ -464,7 +482,7 @@ export default function TrinaryLab() {
         </div>
       )}
       <div style={note}>
-        How long each world is integrated, and the insolation band counted as habitable — used by <b style={{ color: 'var(--fg)' }}>both</b> the Destiny Map and the Census. Changing any setting clears the tally.
+        How long each world is integrated, and the insolation band counted as habitable — used by <b style={{ color: 'var(--fg)' }}>both</b> the Destiny Map and the Census. Changing a setting pauses the census and keeps its results on screen (labeled as the previous run) until you run again.
       </div>
     </>
   );
@@ -482,8 +500,7 @@ export default function TrinaryLab() {
         <LaunchSpace rMin={rMin} rMax={rMax} fMin={fMin} fMax={fMax} allowRetro={allowRetro} />
       </div>
       <div style={note}>
-        Each dot is a candidate world: a launch radius and a speed (as a multiple of the local circular speed). The cyan box is what you’re sampling now — move the sliders to reshape it, or drag a box on the Destiny Map’s radius×speed plane. Below the amber line orbits tend to be bound; above the red √2 line they tend to escape.
-        <span style={{ color: 'var(--dim)' }}> Changing any setting clears the tally.</span>
+        Each dot is a candidate world: a launch radius and a speed (as a multiple of the local circular speed). The highlighted box is what you’re sampling now — move the sliders to reshape it, or drag a box on the Destiny Map’s radius×speed plane. Below the dashed circular-speed line orbits tend to be bound; above the dashed √2 escape line they tend to escape.
       </div>
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8, marginTop: 10 }}>
         <button style={btn} title="New random ensemble seed" onClick={() => setBaseSeed((Math.random() * 4294967296) >>> 0)}>🎲 Reseed</button>
@@ -499,10 +516,18 @@ export default function TrinaryLab() {
   // the sampling box stay in the Sampling panel.
   const transportNode = (
     <>
+      {stale && (
+        <div style={{
+          font: '11px/1.5 system-ui', color: 'var(--fg)', background: 'var(--accent-soft)',
+          border: '1px solid var(--border)', borderRadius: 7, padding: '6px 9px', marginBottom: 8,
+        }}>
+          Settings changed — showing the <b>previous</b> run’s results. Run census starts fresh.
+        </div>
+      )}
       <div style={{ display: 'flex', flexWrap: 'wrap', gap: 8 }}>
-        <button style={{ ...btn, background: running ? 'var(--accent-soft)' : 'var(--success-soft)' }}
-          onClick={running ? pause : start}>{running ? '❚❚ Pause' : (n > 0 && n < targetN ? '▶ Resume' : '▶ Run census')}</button>
-        <button style={btn} onClick={reset}>↺ Reset</button>
+        <Button variant="primary" style={{ flex: 1, width: 'auto' }}
+          onClick={running ? pause : start}>{running ? 'Pause' : (!stale && n > 0 && n < targetN ? 'Resume' : 'Run census')}</Button>
+        <Button variant="ghost" icon="reset" style={{ flex: 'none', width: 'auto' }} onClick={reset}>Reset</Button>
       </div>
       <div style={{ height: 8, borderRadius: 4, background: 'var(--track)', marginTop: 10, overflow: 'hidden' }}>
         <div style={{ height: '100%', width: `${Math.min(100, n / Math.max(1, targetN) * 100)}%`, background: 'var(--success)', transition: 'width 0.1s' }} />
@@ -675,7 +700,7 @@ export default function TrinaryLab() {
     {
       id: 'run',
       icon: running ? 'pause' : 'flask',
-      label: running ? 'Pause' : (n > 0 && n < targetN ? 'Resume' : 'Run census'),
+      label: running ? 'Pause' : (!stale && n > 0 && n < targetN ? 'Resume' : 'Run census'),
       primary: true, active: running, sectionId: 'transport',
       onClick: running ? pause : start,
     },

--- a/src/animations/TrinaryStars/lab/TrinaryLab.tsx
+++ b/src/animations/TrinaryStars/lab/TrinaryLab.tsx
@@ -570,7 +570,7 @@ export default function TrinaryLab() {
 
   const distNode = (
     <>
-      <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '2px 0' }}>habitable fraction of lifetime</div>
+      <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '2px 0' }}>habitable fraction of the time budget</div>
       <Histogram data={agg?.histHab ?? []} max={agg?.histMax.hab ?? 1} color={C.happy} domain={['0%', '100%']} />
       <div style={{ font: '11px ui-monospace, monospace', color: 'var(--dim)', margin: '8px 0 2px' }}>longest stable era</div>
       <Histogram data={agg?.histLong ?? []} max={agg?.histMax.long ?? 1} color={C.survived} domain={['0', tMax.toFixed(0)]} />

--- a/src/animations/TrinaryStars/lab/__tests__/lab.test.ts
+++ b/src/animations/TrinaryStars/lab/__tests__/lab.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from 'vitest';
+import { Aggregator, OUTCOMES, HIST_BINS } from '../ensemble';
+import { mulberry32, runSeed, sampleParams, type EnsembleConfig } from '../rng';
+import { runOne, runPlanet, runPlanetLyap, runBatchFate, runBatchLyap, targetMassOf } from '../runner';
+import { buildStars, getScenario, launchPlanet, DEFAULT_CLASSIFY, type RunResult, type Planet } from '@/lib/nbody';
+
+/** A small, fast ensemble config over the figure-eight. */
+function cfg(over: Partial<EnsembleConfig> = {}): EnsembleConfig {
+  return {
+    presetId: 'figure8', target: 'bary', massMul: [1, 1, 1], starSoft: 0.01,
+    classify: DEFAULT_CLASSIFY, tMax: 30,
+    rMin: 1.0, rMax: 4.0, fMin: 0.5, fMax: 1.2, allowRetro: true,
+    baseSeed: 123456789,
+    ...over,
+  };
+}
+
+function fakeResult(over: Partial<RunResult>): RunResult {
+  return {
+    tSim: 30, outcome: 'survived', habitableFraction: 0.5, bothFraction: 0.2,
+    longestHabitable: 10, minStarDist: 1, ejectedStar: -1, tEject: -1,
+    planetFate: 'bound', radius: 2, speed: 1, angleDeg: 0, retro: false, seed: 0,
+    ...over,
+  };
+}
+
+describe('rng / sampling', () => {
+  it('mulberry32 is deterministic and uniform-ish in [0,1)', () => {
+    const a = mulberry32(42), b = mulberry32(42);
+    const seqA = Array.from({ length: 100 }, () => a());
+    const seqB = Array.from({ length: 100 }, () => b());
+    expect(seqA).toEqual(seqB);
+    for (const v of seqA) { expect(v).toBeGreaterThanOrEqual(0); expect(v).toBeLessThan(1); }
+    const mean = seqA.reduce((s, v) => s + v, 0) / seqA.length;
+    expect(mean).toBeGreaterThan(0.35);
+    expect(mean).toBeLessThan(0.65);
+  });
+
+  it('sampleParams is reproducible from (baseSeed, index) and respects every range', () => {
+    const c = cfg();
+    const M = targetMassOf(c);
+    for (let i = 0; i < 200; i++) {
+      const p1 = sampleParams(c, i, M);
+      const p2 = sampleParams(c, i, M);
+      expect(p1).toEqual(p2); // the UI's shareable-world claim
+      expect(p1.radius).toBeGreaterThanOrEqual(c.rMin);
+      expect(p1.radius).toBeLessThanOrEqual(c.rMax);
+      const vcirc = Math.sqrt(M / Math.max(0.05, p1.radius));
+      const f = p1.speed / vcirc;
+      expect(f).toBeGreaterThanOrEqual(c.fMin - 1e-12);
+      expect(f).toBeLessThanOrEqual(c.fMax + 1e-12);
+      expect(p1.angleDeg).toBeGreaterThanOrEqual(0);
+      expect(p1.angleDeg).toBeLessThan(360);
+      expect(p1.seed).toBe(runSeed(c.baseSeed, i));
+    }
+  });
+
+  it('retro launches never occur when allowRetro is off, and do occur when on', () => {
+    const off = cfg({ allowRetro: false });
+    const on = cfg({ allowRetro: true });
+    const M = targetMassOf(off);
+    let retros = 0;
+    for (let i = 0; i < 100; i++) {
+      expect(sampleParams(off, i, M).retro).toBe(false);
+      if (sampleParams(on, i, M).retro) retros++;
+    }
+    expect(retros).toBeGreaterThan(20); // ~50% expected
+    expect(retros).toBeLessThan(80);
+  });
+});
+
+describe('Aggregator', () => {
+  it('matches brute-force mean and sample standard error', () => {
+    const agg = new Aggregator(100);
+    const xs = [0.1, 0.5, 0.9, 0.3, 0.7, 0.2, 0.8, 0.4];
+    for (const x of xs) agg.ingest(fakeResult({ habitableFraction: x }));
+    const s = agg.snapshot();
+    const mean = xs.reduce((a, b) => a + b, 0) / xs.length;
+    const varS = xs.reduce((a, b) => a + (b - mean) ** 2, 0) / (xs.length - 1);
+    const stderr = Math.sqrt(varS / xs.length);
+    expect(s.n).toBe(xs.length);
+    expect(s.habMean).toBeCloseTo(mean, 12);
+    expect(s.habStderr).toBeCloseTo(stderr, 12);
+  });
+
+  it('tallies outcomes, clamps histogram bins, and keeps a correct top-10 leaderboard', () => {
+    const agg = new Aggregator(100);
+    // Out-of-range values must clamp into the first/last bin, not vanish.
+    agg.ingest(fakeResult({ habitableFraction: 0, longestHabitable: 0 }));
+    agg.ingest(fakeResult({ habitableFraction: 1, longestHabitable: 250 })); // > tMax
+    for (let i = 0; i < 15; i++) agg.ingest(fakeResult({ longestHabitable: i, outcome: 'happy', tEject: 10 }));
+    const s = agg.snapshot();
+    expect(s.counts.happy).toBe(15);
+    expect(s.counts.survived).toBe(2);
+    expect(s.histHab.reduce((a, b) => a + b, 0)).toBe(17);
+    expect(s.histHab.length).toBe(HIST_BINS);
+    expect(s.histEject.reduce((a, b) => a + b, 0)).toBe(15); // only tEject >= 0
+    // Leaderboard: exactly 10 records, sorted descending, topped by the 250 run.
+    expect(s.records.length).toBe(10);
+    expect(s.longMax).toBe(250);
+    for (let i = 1; i < s.records.length; i++) {
+      expect(s.records[i].longestHabitable).toBeLessThanOrEqual(s.records[i - 1].longestHabitable);
+    }
+    expect(OUTCOMES).toContain('blowup');
+  });
+});
+
+describe('runner', () => {
+  it('runOne is deterministic: same config + params → identical RunResult', () => {
+    const c = cfg({ tMax: 20 });
+    const p = sampleParams(c, 7, targetMassOf(c));
+    const a = runOne(c, p);
+    const b = runOne(c, p);
+    expect(a).toEqual(b);
+  });
+
+  it('classifies a plunging launch as planet-destroyed', () => {
+    const c = cfg({ tMax: 20 });
+    const r = runOne(c, { radius: 1.2, speed: 0, angleDeg: 0, retro: false, seed: 1 });
+    expect(r.outcome).toBe('planet-destroyed');
+    expect(r.planetFate).toBe('destroyed');
+    expect(r.minStarDist).toBeLessThan(DEFAULT_CLASSIFY.rKill);
+    expect(r.tSim).toBeLessThan(20);
+  });
+
+  it('classifies the edge-tuned default as bound through a short budget', () => {
+    const c = cfg({ tMax: 30 });
+    const r = runOne(c, { radius: 3.2, speed: 0.95, angleDeg: 0, retro: false, seed: 1 });
+    expect(r.outcome).toBe('survived');
+    expect(r.habitableFraction).toBeGreaterThan(0.5);
+  });
+
+  it('runBatchFate is result-identical to running each planet alone (the bit-identical claim)', () => {
+    const c = cfg({ tMax: 25 });
+    const mkPlanets = (): Planet[] => {
+      const stars = buildStars(getScenario(c.presetId), c.massMul);
+      return [
+        { ...launchPlanet(stars, 'bary', 3.2, 0.95), alive: true },  // long-lived
+        { ...launchPlanet(stars, 'bary', 1.2, 0.0), alive: true },   // destroyed early
+        { ...launchPlanet(stars, 'bary', 2.5, 2.2), alive: true },   // flung out fast
+      ];
+    };
+    // Batch: one shared star integration.
+    const starsB = buildStars(getScenario(c.presetId), c.massMul);
+    const batch = runBatchFate(c, starsB, mkPlanets());
+    // Solo: fresh stars per planet.
+    const solos = mkPlanets().map(p => {
+      const stars = buildStars(getScenario(c.presetId), c.massMul);
+      return runPlanet(c, stars, { ...p });
+    });
+    expect(batch.length).toBe(solos.length);
+    // The runner's own claim is "bit-identical to running each planet alone" —
+    // hold it to exact equality, not a tolerance.
+    for (let k = 0; k < solos.length; k++) {
+      expect(batch[k]).toEqual(solos[k]);
+    }
+  });
+
+  it('runBatchLyap matches runPlanetLyap per planet', () => {
+    const c = cfg({ tMax: 15 });
+    const mk = (): Planet[] => {
+      const stars = buildStars(getScenario(c.presetId), c.massMul);
+      return [
+        { ...launchPlanet(stars, 'bary', 3.2, 0.95), alive: true },
+        { ...launchPlanet(stars, 'bary', 2.0, 1.0), alive: true },
+      ];
+    };
+    const batch = runBatchLyap(c, buildStars(getScenario(c.presetId), c.massMul), mk());
+    const solos = mk().map(p => runPlanetLyap(c, buildStars(getScenario(c.presetId), c.massMul), { ...p }));
+    for (let k = 0; k < solos.length; k++) {
+      expect(batch[k].outcome).toBe(solos[k].outcome);
+      expect(batch[k].lambda).toBe(solos[k].lambda); // bit-identical claim
+    }
+  });
+});

--- a/src/animations/TrinaryStars/lab/__tests__/lab.test.ts
+++ b/src/animations/TrinaryStars/lab/__tests__/lab.test.ts
@@ -123,6 +123,17 @@ describe('runner', () => {
     expect(r.tSim).toBeLessThan(20);
   });
 
+  it('an early-destroyed world reports a SMALL habitable fraction (of the budget, not its short life)', () => {
+    // The world dies within a few time units, habitable right up to the end.
+    // Per-lifetime it would read ~100% habitable and poison the census mean;
+    // per-budget it must read roughly tDeath/tMax.
+    const c = cfg({ tMax: 60 });
+    const r = runOne(c, { radius: 1.2, speed: 0, angleDeg: 0, retro: false, seed: 1 });
+    expect(r.outcome).toBe('planet-destroyed');
+    expect(r.habitableFraction).toBeLessThanOrEqual(r.tSim / 60 + 0.02);
+    expect(r.habitableFraction).toBeLessThan(0.2);
+  });
+
   it('classifies the edge-tuned default as bound through a short budget', () => {
     const c = cfg({ tMax: 30 });
     const r = runOne(c, { radius: 3.2, speed: 0.95, angleDeg: 0, retro: false, seed: 1 });

--- a/src/animations/TrinaryStars/lab/runner.ts
+++ b/src/animations/TrinaryStars/lab/runner.ts
@@ -77,12 +77,19 @@ function outcomeOf(s: ReturnType<Analyzer['snapshot']>, blowup: boolean): Outcom
     : 'survived';
 }
 
-function resultOf(s: ReturnType<Analyzer['snapshot']>, blowup: boolean, params: RunParams): RunResult {
+function resultOf(s: ReturnType<Analyzer['snapshot']>, blowup: boolean, params: RunParams, tMax: number): RunResult {
+  // Fractions are measured over the ensemble's TIME BUDGET, not the planet's
+  // survived lifetime. The analyzer's own fractions are per-lifetime — fine for
+  // a live view, but poison for averaging: a world destroyed at t≈2 that was
+  // habitable right up to the end would report ~100% habitable and a census of
+  // early-killed planets would read absurdly rosy. Over the budget, that world
+  // reports 2/tMax — dead time is not habitable time.
+  const scale = s.total / Math.max(tMax, 1e-9);
   return {
     tSim: s.t,
     outcome: outcomeOf(s, blowup),
-    habitableFraction: s.habitableFraction,
-    bothFraction: s.bothFraction,
+    habitableFraction: Math.min(1, s.habitableFraction * scale),
+    bothFraction: Math.min(1, s.bothFraction * scale),
     longestHabitable: s.longestHabitable,
     minStarDist: s.minStarDist,
     ejectedStar: s.ejectedStar,
@@ -100,7 +107,7 @@ export function runOne(cfg: EnsembleConfig, params: RunParams): RunResult {
   const stars = buildStars(getScenario(cfg.presetId), cfg.massMul);
   const planet = launchPlanet(stars, cfg.target, params.radius, params.speed, params.angleDeg * DEG, params.retro);
   const { s, blowup } = simulate(cfg, stars, planet);
-  return resultOf(s, blowup, params);
+  return resultOf(s, blowup, params, cfg.tMax);
 }
 
 /** Run a single explicit planet IC against a given star configuration — used by
@@ -108,7 +115,7 @@ export function runOne(cfg: EnsembleConfig, params: RunParams): RunResult {
  *  radius/speed/angle parameterization. */
 export function runPlanet(cfg: EnsembleConfig, stars: Star[], planet: Planet): RunResult {
   const { s, blowup } = simulate(cfg, stars, planet);
-  return resultOf(s, blowup, { radius: 0, speed: 0, angleDeg: 0, retro: false, seed: 0 });
+  return resultOf(s, blowup, { radius: 0, speed: 0, angleDeg: 0, retro: false, seed: 0 }, cfg.tMax);
 }
 
 /** Finite-time largest Lyapunov exponent for one explicit planet IC (Benettin
@@ -170,7 +177,7 @@ export function runBatchFate(cfg: EnsembleConfig, stars: Star[], planets: Planet
       }
     }
   }
-  return planets.map((_, k) => resultOf(an[k].snapshot(), blowup[k] === 1, BATCH_PARAMS));
+  return planets.map((_, k) => resultOf(an[k].snapshot(), blowup[k] === 1, BATCH_PARAMS, cfg.tMax));
 }
 
 /** Batched finite-time Lyapunov runner (chaos lens): the same idea with a

--- a/src/chrome/readouts.tsx
+++ b/src/chrome/readouts.tsx
@@ -79,10 +79,6 @@ export function StatGrid({ stats }: { stats: { k: string; v: string }[] }) {
   );
 }
 
-export function Kicker({ children }: { children: React.ReactNode }) {
-  return (
-    <div style={{ fontFamily: 'var(--font-mono)', fontSize: 10, color: 'var(--dim-2)', letterSpacing: '.1em', textTransform: 'uppercase', margin: '8px 0 5px' }}>
-      {children}
-    </div>
-  );
-}
+// Kicker moved into components/ControlPanel (the shared type scale's level 2);
+// re-exported here so existing Analyze-tier imports keep working.
+export { Kicker } from '../components/ControlPanel';

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -662,6 +662,22 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
   display: grid; place-items: center; border: 1px solid transparent; background: transparent;
   color: var(--dim); cursor: pointer; transition: all .14s var(--ease);
 }
+/* Rail labels (2026-07): a persistent per-panel title under each icon, so ten
+   panels don't collapse into three identical archetype-glyph pairs. The closed
+   icon vocabulary is untouched — the label adds identity, not meaning. Vertical
+   rail only; the horizontal (immersive top-bar) rail keeps icon-only density,
+   and the phone dock already labels its icons. */
+.am-ws-rail:not(.am-ws-rail-h) .am-ws-rail-btn.am-labeled {
+  width: 40px; height: 44px;
+  grid-template-rows: 1fr auto; place-items: center; row-gap: 0;
+  padding: 5px 1px 4px;
+}
+.am-ws-rail-lbl {
+  max-width: 38px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-family: var(--font-ui); font-size: 8px; font-weight: 600; letter-spacing: .01em;
+  line-height: 1.1; color: inherit; opacity: .92;
+}
+.am-ws-rail-h .am-ws-rail-lbl { display: none; }
 .am-ws-rail-btn:hover { background: var(--hover); color: var(--fg); }
 .am-ws-rail-btn.am-on { background: var(--accent-soft); color: var(--accent); border-color: var(--border); }
 .am-ws-rail-btn.am-on::before { content: ""; position: absolute; left: -6px; top: 50%; transform: translateY(-50%); width: 3px; height: 18px; border-radius: 2px; background: var(--accent); }
@@ -699,10 +715,21 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 }
 .am-ws-phead:active { cursor: grabbing; }
 .am-ws-phead.am-collapsed { border-bottom-color: transparent; }
-.am-ws-pico { width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; background: var(--panel-2); color: var(--accent); flex-shrink: 0; }
+/* Accent rebudget (2026-07): header archetype icons are wayfinding, not state —
+   they speak in the dim voice so primary verbs stay the loudest thing on screen. */
+.am-ws-pico { width: 22px; height: 22px; border-radius: 6px; display: grid; place-items: center; background: var(--panel-2); color: var(--dim); flex-shrink: 0; }
 .am-ws-panel-title { flex: 1; font-size: 12.5px; font-weight: 700; letter-spacing: -0.01em; }
 .am-ws-phead .am-btn-icon { width: 26px; height: 26px; }
-.am-ws-pbody { padding: 4px 13px 13px; max-height: 50vh; overflow-y: auto; }
+.am-ws-pbody {
+  padding: 4px 13px 13px; max-height: 50vh; overflow-y: auto;
+  /* An always-visible thin scrollbar when content overflows, so a clipped panel
+     signals "there's more" instead of cutting notes mid-sentence. */
+  scrollbar-width: thin;
+  scrollbar-color: var(--track) transparent;
+  scrollbar-gutter: stable;
+}
+.am-ws-pbody::-webkit-scrollbar { width: 5px; }
+.am-ws-pbody::-webkit-scrollbar-thumb { background: var(--track); border-radius: 999px; }
 /* in narrow floating panels, let segmented pills wrap instead of clipping */
 .am-ws-pbody .am-pills { flex-wrap: wrap; }
 .am-ws-pbody .am-pill { flex: 1 1 calc(50% - 4px); min-width: 0; }
@@ -711,7 +738,7 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-ws-view { position: absolute; display: flex; flex-direction: column; background: var(--panel-solid); border: 1px solid var(--border-strong); border-radius: 13px; overflow: hidden; box-shadow: var(--shadow); animation: am-pop .16s var(--ease); }
 .am-ws-vhead { display: flex; align-items: center; gap: 8px; padding: 8px 8px 8px 11px; cursor: grab; border-bottom: 1px solid var(--border); user-select: none; background: var(--panel); touch-action: none; }
 .am-ws-vhead:active { cursor: grabbing; }
-.am-ws-vico { color: var(--accent); display: flex; }
+.am-ws-vico { color: var(--dim); display: flex; }
 .am-ws-vtitle { flex: 1; font-size: 12.5px; font-weight: 700; letter-spacing: -0.01em; }
 .am-ws-vhead .am-btn-icon { width: 26px; height: 26px; }
 .am-ws-view-body { position: relative; flex: 1; min-height: 0; background: var(--viz-bg); }

--- a/src/chrome/workspace/Rail.tsx
+++ b/src/chrome/workspace/Rail.tsx
@@ -35,7 +35,7 @@ export function Rail({ sections, openIds, onToggle, orientation = 'vertical' }: 
           onClick={() => onToggle(s.id)}
         >
           <Icon name={arch.icon} size={16} />
-          {orientation === 'vertical' && <span className="am-ws-rail-lbl">{s.title}</span>}
+          {orientation === 'vertical' && <span className="am-ws-rail-lbl">{s.railLabel ?? s.title}</span>}
           <span className="am-ws-rail-tip">{s.title}<i>{arch.tier}</i></span>
         </button>
       </React.Fragment>

--- a/src/chrome/workspace/Rail.tsx
+++ b/src/chrome/workspace/Rail.tsx
@@ -29,12 +29,13 @@ export function Rail({ sections, openIds, onToggle, orientation = 'vertical' }: 
       <React.Fragment key={s.id}>
         {prev && prev.tier !== arch.tier && <div className="am-ws-rail-sep" />}
         <button
-          className={`am-ws-rail-btn ${active ? 'am-on' : ''}`}
+          className={`am-ws-rail-btn am-labeled ${active ? 'am-on' : ''}`}
           aria-label={`${s.title} (${arch.tier})`}
           aria-pressed={active}
           onClick={() => onToggle(s.id)}
         >
-          <Icon name={arch.icon} size={18} />
+          <Icon name={arch.icon} size={16} />
+          {orientation === 'vertical' && <span className="am-ws-rail-lbl">{s.title}</span>}
           <span className="am-ws-rail-tip">{s.title}<i>{arch.tier}</i></span>
         </button>
       </React.Fragment>

--- a/src/chrome/workspace/types.ts
+++ b/src/chrome/workspace/types.ts
@@ -7,6 +7,9 @@ export interface SectionDef {
   /** Stable id — keyed into layout persistence; keep it short and topical. */
   id: string;
   title: string;
+  /** Short label under the rail icon when `title` won't fit ~38px (rail labels,
+   *  DESIGN-SPEC §4.3). Defaults to `title`. */
+  railLabel?: string;
   /** Icon, tier and tooltip derive from ARCHETYPES[arch]. */
   arch: Archetype;
   /** Panel body — controls bound to real app state. */

--- a/src/components/ControlPanel.css
+++ b/src/components/ControlPanel.css
@@ -72,7 +72,10 @@
   color: var(--cp-fg);
 }
 .cp-row-value {
-  color: var(--cp-accent);
+  /* Accent rebudget (2026-07): readouts are passive state — they speak in the
+     foreground voice (mono already differentiates them). Accent is reserved for
+     things you touch or that are ON: thumbs, active pills, primary buttons. */
+  color: var(--cp-fg);
   font-family: var(--font-mono, ui-monospace, monospace);
   font-size: 11.5px;
   font-variant-numeric: tabular-nums;
@@ -234,6 +237,65 @@
 .cp-pills button.cp-active {
   background: var(--cp-accent);
   color: var(--accent-fg, #000);
+}
+
+/* ---------- Button (the closed emphasis vocabulary for in-panel verbs) ----------
+   primary | secondary | ghost | danger | toggle — DESIGN-SPEC §4. At most one
+   primary per panel; accent belongs to it (and to the action strip's primary). */
+.cp-btn {
+  display: flex; align-items: center; justify-content: center; gap: 7px;
+  width: 100%;
+  padding: 9px 13px;
+  border-radius: 7px;
+  border: 1px solid var(--cp-border);
+  background: var(--panel-2, rgba(255, 255, 255, 0.06));
+  color: var(--cp-fg);
+  font: inherit; font-family: var(--cp-font); font-size: 12.5px; font-weight: 600;
+  cursor: pointer;
+  transition: all .14s;
+  white-space: nowrap;
+}
+.cp-btn:disabled { color: var(--cp-fg-dim); cursor: default; opacity: .6; }
+.cp-btn:hover:not(:disabled) { background: var(--cp-hover); }
+.cp-btn-primary {
+  background: var(--cp-accent);
+  border-color: transparent;
+  color: var(--accent-fg, #000);
+}
+.cp-btn-primary:hover:not(:disabled) { background: var(--cp-accent); filter: brightness(1.07); }
+.cp-btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--cp-fg-dim);
+}
+.cp-btn-ghost:hover:not(:disabled) { color: var(--cp-fg); background: var(--cp-hover); }
+.cp-btn-danger {
+  background: var(--danger-soft, rgba(240, 116, 106, 0.12));
+  border-color: var(--danger, #f0746a);
+  color: var(--danger, #f0746a);
+}
+.cp-btn-danger:hover:not(:disabled) { background: var(--danger-soft, rgba(240, 116, 106, 0.2)); filter: brightness(1.1); }
+.cp-btn-toggle.cp-armed {
+  background: var(--accent-soft, rgba(255, 212, 0, 0.12));
+  border-color: var(--cp-accent);
+  color: var(--cp-accent);
+}
+
+/* ---------- Type scale levels 2 & 4 (panel title > Kicker > row label > Note) */
+.cp-kicker {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--dim-2, var(--cp-fg-dim));
+  letter-spacing: .1em;
+  text-transform: uppercase;
+  margin: 8px 0 0;
+}
+.cp-note {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--cp-fg-dim);
+  padding: 2px;
 }
 
 /* Function title block at top of Function section */

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -1,12 +1,59 @@
 import React, { useEffect, useState } from 'react';
 import './ControlPanel.css';
 import { COLORMAPS, FAMILIES, themeMapsFor, gradientCss, type ColorFamily } from '../lib/colormapRegistry';
+import { Icon, ICONS } from '../chrome/icons';
 
 /**
- * Form primitives — Section, Slider, Pills, Select, Checkbox — used inside
- * AppShell's Settings/Actions tabs. The old desktop-drawer/mobile-sheet
+ * Form primitives — Section, Slider, Pills, Select, Checkbox, Button, Kicker,
+ * Note — used inside workspace panels. The old desktop-drawer/mobile-sheet
  * wrapper that lived here previously is now replaced by the global AppShell.
  */
+
+/** The closed emphasis vocabulary for in-panel verbs (DESIGN-SPEC §4):
+ *  - primary   — THE panel's action; accent-filled. At most one per panel.
+ *  - secondary — a normal verb (the default).
+ *  - ghost     — quiet utility (resets, "more…").
+ *  - danger    — destructive (clears saved state, wipes results).
+ *  - toggle    — an armed/disarmed mode; pass `active` for the armed state.
+ */
+export type ButtonVariant = 'primary' | 'secondary' | 'ghost' | 'danger' | 'toggle';
+
+interface ButtonProps {
+  variant?: ButtonVariant;
+  /** Icon from the closed chrome set (chrome/icons.tsx) — no emoji glyphs. */
+  icon?: keyof typeof ICONS & string;
+  /** For variant="toggle": whether the mode is currently armed. */
+  active?: boolean;
+  disabled?: boolean;
+  title?: string;
+  onClick?: () => void;
+  style?: React.CSSProperties;
+  children: React.ReactNode;
+}
+
+/** The shared in-panel button. Full-width by default; put several in a flex row
+ *  and pass style={{flex:1}} for a split row. */
+export function Button({ variant = 'secondary', icon, active = false, disabled, title, onClick, style, children }: ButtonProps) {
+  const cls = `cp-btn cp-btn-${variant}${variant === 'toggle' && active ? ' cp-armed' : ''}`;
+  return (
+    <button type="button" className={cls} disabled={disabled} title={title} onClick={onClick} style={style}
+      aria-pressed={variant === 'toggle' ? active : undefined}>
+      {icon && <Icon name={icon} size={13} />}
+      <span>{children}</span>
+    </button>
+  );
+}
+
+/** Mono uppercase in-panel group label — level 2 of the four-level type scale
+ *  (panel title > Kicker > row label > Note). */
+export function Kicker({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return <div className="cp-kicker" style={style}>{children}</div>;
+}
+
+/** Quiet explanatory prose under a control group — level 4 of the type scale. */
+export function Note({ children, style }: { children: React.ReactNode; style?: React.CSSProperties }) {
+  return <div className="cp-note" style={style}>{children}</div>;
+}
 
 export interface SectionProps {
   title: string;

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -81,7 +81,8 @@ export function Section({ title, icon, defaultOpen = false, children }: SectionP
 }
 
 interface SliderProps {
-  label: string;
+  /** Usually a string; a ReactNode allows e.g. a token-colored swatch dot. */
+  label: React.ReactNode;
   value: number;
   min: number;
   max: number;

--- a/src/lib/nbody/__tests__/analysis.test.ts
+++ b/src/lib/nbody/__tests__/analysis.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildStars, getScenario, launchPlanet, step, recenter,
+  insolation, planetEnergy, minStarDist, climateOf,
+  detectEjection, planetEscaped,
+  cloudSpread, lyapunovRenorm,
+  Analyzer, DEFAULT_CLASSIFY, SCENARIOS,
+  type SimState, type Star, type Planet, type Bin,
+} from '../index';
+
+function star(x: number, y: number, vx: number, vy: number, mass: number): Star {
+  return { x, y, vx, vy, ax: 0, ay: 0, mass };
+}
+
+describe('scalar measurements', () => {
+  it('insolation is Σ L/(d²+soft²) and respects the luminosity exponent', () => {
+    const stars = [star(1, 0, 0, 0, 2), star(-1, 0, 0, 0, 1), star(0, 5, 0, 0, 1)];
+    const p: Planet = { x: 0, y: 0, vx: 0, vy: 0, ax: 0, ay: 0 };
+    const soft2 = 0;
+    // lumExp = 1: L = mass.
+    expect(insolation(p, stars, 1, soft2)).toBeCloseTo(2 / 1 + 1 / 1 + 1 / 25, 12);
+    // lumExp = 3: the mass-2 star shines 8×.
+    expect(insolation(p, stars, 3, soft2)).toBeCloseTo(8 / 1 + 1 / 1 + 1 / 25, 12);
+  });
+
+  it('planetEnergy is negative for a slow (bound) planet, positive for a fast one', () => {
+    const stars = buildStars(getScenario('figure8'), [1, 1, 1]);
+    const slow: Planet = { ...launchPlanet(stars, 'bary', 3, 0.5) };
+    const fast: Planet = { ...launchPlanet(stars, 'bary', 3, 5) };
+    expect(planetEnergy(slow, stars, 0)).toBeLessThan(0);
+    expect(planetEnergy(fast, stars, 0)).toBeGreaterThan(0);
+  });
+
+  it('minStarDist returns the distance to the nearest star', () => {
+    const stars = [star(3, 0, 0, 0, 1), star(0, 4, 0, 0, 1), star(-10, 0, 0, 0, 1)];
+    const p: Planet = { x: 0, y: 0, vx: 0, vy: 0, ax: 0, ay: 0 };
+    expect(minStarDist(p, stars)).toBeCloseTo(3, 12);
+  });
+
+  it('climateOf: strict band edges — exactly at a bound counts as habitable', () => {
+    expect(climateOf(0.5, 1, 2)).toBe('cold');
+    expect(climateOf(1, 1, 2)).toBe('habitable');   // S < Slo is cold; S === Slo is not
+    expect(climateOf(1.5, 1, 2)).toBe('habitable');
+    expect(climateOf(2, 1, 2)).toBe('habitable');   // S > Shi is hot; S === Shi is not
+    expect(climateOf(2.5, 1, 2)).toBe('hot');
+  });
+});
+
+describe('event detection', () => {
+  it('detectEjection flags a far, unbound star (and not a bound trio)', () => {
+    const bound = buildStars(getScenario('figure8'), [1, 1, 1]);
+    expect(detectEjection(bound, 12)).toBe(-1);
+    // A tight massive pair + one star far away moving out much faster than escape.
+    const trio = recenter([
+      star(0.3, 0, 0, 0.9, 1),
+      star(-0.3, 0, 0, -0.9, 1),
+      star(30, 0, 5, 0, 0.5),
+    ]);
+    expect(detectEjection(trio, 12)).toBe(2);
+  });
+
+  it('planetEscaped needs BOTH positive energy and distance beyond rEsc', () => {
+    const stars = buildStars(getScenario('figure8'), [1, 1, 1]);
+    const farSlow: Planet = { x: 20, y: 0, vx: 0, vy: 0, ax: 0, ay: 0 };       // far but falling back
+    const farFast: Planet = { x: 20, y: 0, vx: 3, vy: 0, ax: 0, ay: 0 };        // far and unbound
+    const nearFast: Planet = { x: 2, y: 0, vx: 5, vy: 0, ax: 0, ay: 0 };        // unbound but still inside
+    expect(planetEscaped(farSlow, stars, 12, 0)).toBe(false);
+    expect(planetEscaped(farFast, stars, 12, 0)).toBe(true);
+    expect(planetEscaped(nearFast, stars, 12, 0)).toBe(false);
+  });
+});
+
+describe('divergence diagnostics', () => {
+  it('cloudSpread measures only the first `count` planets (the visible swarm, not the shadow)', () => {
+    const ref: Planet = { x: 0, y: 0, vx: 0, vy: 0, ax: 0, ay: 0 };
+    const ghost: Planet = { ...ref, x: 0.3 };
+    const shadow: Planet = { ...ref, x: 99 }; // appended measurement probe
+    expect(cloudSpread([ref, ghost, shadow], 2)).toBeCloseTo(0.3, 12);
+    expect(cloudSpread([ref, ghost, shadow])).toBeCloseTo(99, 12);
+    expect(cloudSpread([ref], 1)).toBe(0);
+  });
+
+  it('lyapunovRenorm returns log(d/d0) and rescales the shadow to exactly d0 in phase space', () => {
+    const ref: Planet = { x: 1, y: 2, vx: 0.3, vy: -0.4, ax: 0, ay: 0 };
+    const shadow: Planet = { x: 1.3, y: 2.4, vx: 0.3, vy: -0.4, ax: 0, ay: 0 };
+    const d0 = 1e-7;
+    const d = Math.hypot(0.3, 0.4);
+    const out = lyapunovRenorm(ref, shadow, d0);
+    expect(out).toBeCloseTo(Math.log(d / d0), 10);
+    const after = Math.sqrt(
+      (shadow.x - ref.x) ** 2 + (shadow.y - ref.y) ** 2 +
+      (shadow.vx - ref.vx) ** 2 + (shadow.vy - ref.vy) ** 2,
+    );
+    expect(after).toBeCloseTo(d0, 12);
+  });
+});
+
+/** Drive a real run through the analyzer at the app's sampling cadence. */
+function analyze(scenarioId: string, radius: number, speed: number, T: number) {
+  const sc = getScenario(scenarioId);
+  const stars = buildStars(sc, [1, 1, 1]);
+  const planet: Planet = { ...launchPlanet(stars, sc.launch.target, radius, speed), alive: true };
+  const an = new Analyzer(DEFAULT_CLASSIFY, stars, planet);
+  const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+  let next = 0.05;
+  for (let i = 0; i < Math.round(T / sc.system.dt); i++) {
+    step(sim, sc.system.dt);
+    if (sim.t >= next) { an.push(sim.t, stars, planet); next = sim.t + 0.05; }
+  }
+  return an.snapshot();
+}
+
+describe('Analyzer timeline invariants', () => {
+  it('segments are contiguous, monotone, and span [0, now]; fractions are a partition', () => {
+    const s = analyze('figure8', 3.2, 0.95, 40);
+    expect(s.segments.length).toBeGreaterThan(0);
+    expect(s.segments[0].t0).toBe(0);
+    for (const seg of s.segments) expect(seg.t1).toBeGreaterThanOrEqual(seg.t0);
+    for (let i = 1; i < s.segments.length; i++) {
+      expect(s.segments[i].t0).toBeCloseTo(s.segments[i - 1].t1, 10);
+    }
+    expect(s.segments[s.segments.length - 1].t1).toBeCloseTo(s.t, 10);
+    // The four bin fractions partition elapsed time.
+    const sum = (Object.keys(s.binFractions) as Bin[]).reduce((a, b) => a + s.binFractions[b], 0);
+    expect(sum).toBeCloseTo(1, 6);
+    expect(s.habitableFraction).toBeGreaterThanOrEqual(0);
+    expect(s.habitableFraction).toBeLessThanOrEqual(1);
+    // longest habitable stretch can't exceed total habitable time... but it CAN
+    // equal it; and never exceeds the elapsed time.
+    expect(s.longestHabitable).toBeLessThanOrEqual(s.t + 1e-9);
+  });
+
+  it('each terminal event fires at most once', () => {
+    // A plunging launch: destroyed quickly.
+    const s = analyze('figure8', 1.2, 0, 30);
+    const destroyedEvents = s.events.filter(e => e.kind === 'planet-destroyed');
+    expect(destroyedEvents.length).toBe(1);
+    expect(s.planetFate).toBe('destroyed');
+    // The fate is terminal: minStarDist dipped below the kill radius.
+    expect(s.minStarDist).toBeLessThan(DEFAULT_CLASSIFY.rKill);
+  });
+
+  it('a calm habitable orbit is eventually classified Paradise (both axes good)', () => {
+    // A synthetic hierarchical system: one heavy star + two distant tiny ones,
+    // planet on a close circular orbit around the heavy star → steady light,
+    // steady energy ⇒ climate AND dynamics both good.
+    const stars = recenter([
+      star(0, 0, 0, 0, 1),
+      star(40, 0, 0, 0.15, 0.001),
+      star(-40, 0, 0, -0.15, 0.001),
+    ]);
+    const planet: Planet = { ...launchPlanet(stars, 's0', 1.0, Math.sqrt(1 / 1.0)), alive: true };
+    const an = new Analyzer(DEFAULT_CLASSIFY, stars, planet);
+    const dt = 0.002;
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: dt, G: 1, starSoft: 0.02, planetSoft: 0.05 };
+    let next = 0.05;
+    for (let i = 0; i < Math.round(20 / dt); i++) {
+      step(sim, dt);
+      if (sim.t >= next) { an.push(sim.t, stars, planet); next = sim.t + 0.05; }
+    }
+    const s = an.snapshot();
+    expect(s.planetFate).toBe('bound');
+    expect(s.climate).toBe('habitable');
+    expect(s.calm).toBe(true);
+    expect(s.bin).toBe('both');
+    // And the timeline should be dominated by the Paradise bin once the calm
+    // window fills (~2 time units of 20).
+    expect(s.binFractions.both).toBeGreaterThan(0.7);
+  });
+});
+
+describe('scenario registry', () => {
+  it('getScenario falls back to the default for unknown ids', () => {
+    expect(getScenario('nope-not-real').id).toBe(SCENARIOS[0].id);
+  });
+
+  it('buildStars with uneven mass multipliers still has zero net momentum', () => {
+    const stars = buildStars(getScenario('pythagorean'), [2.5, 0.5, 1.3]);
+    let px = 0, py = 0, M = 0, cx = 0, cy = 0;
+    for (const s of stars) { px += s.mass * s.vx; py += s.mass * s.vy; M += s.mass; cx += s.mass * s.x; cy += s.mass * s.y; }
+    expect(Math.hypot(px, py)).toBeLessThan(1e-12);
+    expect(Math.hypot(cx / M, cy / M)).toBeLessThan(1e-12);
+  });
+});

--- a/src/lib/nbody/__tests__/integrator.test.ts
+++ b/src/lib/nbody/__tests__/integrator.test.ts
@@ -82,6 +82,29 @@ describe('Analyzer classification', () => {
     expect(snap.events.some(e => e.kind === 'planet-destroyed')).toBe(true);
   });
 
+  it('retune re-labels the band mid-run without wiping accumulated time', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const planet = { ...launchPlanet(stars, 'bary', 3.2, 1.0), alive: true };
+    const analyzer = new Analyzer(DEFAULT_CLASSIFY, stars, planet);
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let sampleT = 0;
+    for (let i = 0; i < Math.round(20 / sc.system.dt); i++) {
+      step(sim, sc.system.dt);
+      if (sim.t >= sampleT) { analyzer.push(sim.t, stars, planet); sampleT = sim.t + 0.05; }
+    }
+    const before = analyzer.snapshot();
+    expect(before.total).toBeGreaterThan(10);
+    // Squeeze the habitable band to a sliver: the CURRENT climate must re-label
+    // (the planet's steady insolation now sits above the ceiling), while the
+    // accumulated timeline keeps its history instead of resetting to zero.
+    analyzer.retune({ ...DEFAULT_CLASSIFY, habLo: 0.001, habHi: 0.01 });
+    analyzer.push(sim.t + 0.05, stars, planet);
+    const after = analyzer.snapshot();
+    expect(after.total).toBeGreaterThanOrEqual(before.total);
+    expect(after.climate).toBe('hot');
+  });
+
   it('accumulates habitable time for a planet launched at the reference insolation', () => {
     const sc = getScenario('figure8');
     const stars = buildStars(sc, [1, 1, 1]);

--- a/src/lib/nbody/__tests__/integrator.test.ts
+++ b/src/lib/nbody/__tests__/integrator.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildStars, getScenario, launchPlanet, step, Analyzer, DEFAULT_CLASSIFY,
+  type SimState, type Star,
+} from '../index';
+
+/** Total mechanical energy of the (softened) three-star system — the quantity a
+ *  symplectic leapfrog is supposed to keep bounded. */
+function systemEnergy(stars: Star[], soft: number): number {
+  const s2 = soft * soft;
+  let ke = 0;
+  for (const s of stars) ke += 0.5 * s.mass * (s.vx * s.vx + s.vy * s.vy);
+  let pe = 0;
+  for (let i = 0; i < stars.length; i++) {
+    for (let j = i + 1; j < stars.length; j++) {
+      const dx = stars[j].x - stars[i].x, dy = stars[j].y - stars[i].y;
+      pe -= stars[i].mass * stars[j].mass / Math.sqrt(dx * dx + dy * dy + s2);
+    }
+  }
+  return ke + pe;
+}
+
+function totalMomentum(stars: Star[]): { px: number; py: number } {
+  let px = 0, py = 0;
+  for (const s of stars) { px += s.mass * s.vx; py += s.mass * s.vy; }
+  return { px, py };
+}
+
+describe('leapfrog integrator', () => {
+  it('keeps total energy bounded over a long figure-eight run (symplectic)', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const sim: SimState = { stars, planets: [], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    const E0 = systemEnergy(stars, sc.system.softening);
+    let maxDrift = 0;
+    const steps = Math.round(50 / sc.system.dt);
+    for (let i = 0; i < steps; i++) {
+      step(sim, sc.system.dt);
+      maxDrift = Math.max(maxDrift, Math.abs((systemEnergy(stars, sc.system.softening) - E0) / E0));
+    }
+    // A symplectic scheme oscillates energy but does not drift secularly; a few
+    // parts in 10³ over thousands of steps is the expected bound (not < eps).
+    expect(maxDrift).toBeLessThan(0.02);
+  });
+
+  it('conserves total momentum (recentered systems stay put)', () => {
+    const sc = getScenario('pythagorean');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const sim: SimState = { stars, planets: [], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    for (let i = 0; i < 5000; i++) step(sim, sc.system.dt);
+    const { px, py } = totalMomentum(stars);
+    expect(Math.hypot(px, py)).toBeLessThan(1e-9);
+  });
+
+  it('leaves a frozen (alive:false) planet untouched', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const frozen = { ...launchPlanet(stars, 'bary', 3.2, 1.0), alive: false as const };
+    const before = { x: frozen.x, y: frozen.y, vx: frozen.vx, vy: frozen.vy };
+    const sim: SimState = { stars, planets: [frozen], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    for (let i = 0; i < 500; i++) step(sim, sc.system.dt);
+    expect(frozen.x).toBe(before.x);
+    expect(frozen.vy).toBe(before.vy);
+  });
+});
+
+describe('Analyzer classification', () => {
+  it('reports the planet destroyed after it is driven into a star', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    // Launch straight at the central star with no tangential speed → it plunges in.
+    const planet = { ...launchPlanet(stars, 'bary', 1.2, 0), alive: true };
+    const analyzer = new Analyzer({ ...DEFAULT_CLASSIFY, rKill: 0.12 }, stars, planet);
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let sampleT = 0;
+    for (let i = 0; i < Math.round(30 / sc.system.dt); i++) {
+      step(sim, sc.system.dt);
+      if (sim.t >= sampleT) { analyzer.push(sim.t, stars, planet); sampleT = sim.t + 0.05; }
+    }
+    const snap = analyzer.snapshot();
+    expect(snap.planetFate).toBe('destroyed');
+    expect(snap.events.some(e => e.kind === 'planet-destroyed')).toBe(true);
+  });
+
+  it('accumulates habitable time for a planet launched at the reference insolation', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    // A safe wide circular orbit: insolation stays near S_ref ⇒ habitable band.
+    const planet = { ...launchPlanet(stars, 'bary', 3.2, 1.0), alive: true };
+    const analyzer = new Analyzer(DEFAULT_CLASSIFY, stars, planet);
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let sampleT = 0;
+    for (let i = 0; i < Math.round(60 / sc.system.dt); i++) {
+      step(sim, sc.system.dt);
+      if (sim.t >= sampleT) { analyzer.push(sim.t, stars, planet); sampleT = sim.t + 0.05; }
+    }
+    const snap = analyzer.snapshot();
+    expect(snap.planetFate).toBe('bound');
+    expect(snap.habitableFraction).toBeGreaterThan(0.5);
+  });
+});

--- a/src/lib/nbody/__tests__/integrator.test.ts
+++ b/src/lib/nbody/__tests__/integrator.test.ts
@@ -105,6 +105,26 @@ describe('Analyzer classification', () => {
     expect(after.climate).toBe('hot');
   });
 
+  it('retuning β re-measures S_ref so the launch point still reads exactly 1× launch light', () => {
+    // Unequal masses (Pythagorean, 3/4/5) make the β-dependence of insolation
+    // strong: with a stale S_ref, changing β re-reads the SAME state against the
+    // wrong reference and the HUD can flip hot/cold from the slider alone.
+    const sc = getScenario('pythagorean');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const planet = { ...launchPlanet(stars, 'bary', 5.0, 0.55), alive: true };
+    const analyzer = new Analyzer({ ...DEFAULT_CLASSIFY, lumExp: 1 }, stars, planet);
+    // Without stepping, the state at t>0 equals the launch state exactly.
+    analyzer.push(0.1, stars, planet);
+    expect(analyzer.snapshot().climate).toBe('habitable');
+    // Crank β 1 → 4. The same unchanged state must still read as 1× launch
+    // light (habitable), because S_ref is re-measured under the new law.
+    analyzer.retune({ ...DEFAULT_CLASSIFY, lumExp: 4 });
+    analyzer.push(0.2, stars, planet);
+    const snap = analyzer.snapshot();
+    expect(snap.climate).toBe('habitable');
+    expect(snap.S / snap.Sref).toBeCloseTo(1, 6);
+  });
+
   it('accumulates habitable time for a planet launched at the reference insolation', () => {
     const sc = getScenario('figure8');
     const stars = buildStars(sc, [1, 1, 1]);

--- a/src/lib/nbody/__tests__/reversibility.test.ts
+++ b/src/lib/nbody/__tests__/reversibility.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from 'vitest';
+import { buildStars, getScenario, launchPlanet, step, type SimState, type Planet } from '../index';
+
+/**
+ * The leapfrog (kick–drift–kick) scheme is exactly time-reversible: integrate
+ * forward, flip every velocity, integrate the same number of steps, and the
+ * system must retrace its path back to the start (with velocities negated).
+ * This is a sharp whole-integrator invariant — any asymmetry in the kick/drift
+ * ordering, a force evaluated at the wrong positions, or state leaking between
+ * steps breaks it immediately.
+ */
+describe('leapfrog time-reversibility', () => {
+  it('running forward then backward returns stars AND planet to their start', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const planet: Planet = { ...launchPlanet(stars, 'bary', 3.2, 0.95), alive: true };
+    const start = {
+      stars: stars.map(s => ({ x: s.x, y: s.y, vx: s.vx, vy: s.vy })),
+      planet: { x: planet.x, y: planet.y, vx: planet.vx, vy: planet.vy },
+    };
+    const sim: SimState = { stars, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    const N = 2000; // t ≈ 4.4 — inside the Lyapunov horizon so FP error stays tiny
+    for (let i = 0; i < N; i++) step(sim, sc.system.dt);
+    for (const s of stars) { s.vx = -s.vx; s.vy = -s.vy; }
+    planet.vx = -planet.vx; planet.vy = -planet.vy;
+    for (let i = 0; i < N; i++) step(sim, sc.system.dt);
+
+    for (let k = 0; k < 3; k++) {
+      expect(stars[k].x).toBeCloseTo(start.stars[k].x, 6);
+      expect(stars[k].y).toBeCloseTo(start.stars[k].y, 6);
+      expect(-stars[k].vx).toBeCloseTo(start.stars[k].vx, 6);
+      expect(-stars[k].vy).toBeCloseTo(start.stars[k].vy, 6);
+    }
+    expect(planet.x).toBeCloseTo(start.planet.x, 5);
+    expect(planet.y).toBeCloseTo(start.planet.y, 5);
+    expect(-planet.vx).toBeCloseTo(start.planet.vx, 5);
+    expect(-planet.vy).toBeCloseTo(start.planet.vy, 5);
+  });
+});

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   SCENARIOS, buildStars, launchPlanet, orbitFrame, recenter, getScenario,
-  circularSpeed, findStableLaunch,
+  circularSpeed, findStableLaunch, migrateLegacyLaunch,
   step, minStarDist, planetEnergy,
   type SimState, type Planet, type Star, type TargetId,
 } from '../index';
@@ -89,6 +89,30 @@ describe('scenario launch defaults', () => {
   });
 });
 
+describe('migrateLegacyLaunch', () => {
+  // Returning visitors persist launches from before the safe-default fixes;
+  // without migration their stored settings resurrect the planet-into-star
+  // opening no matter what the scenario defaults say.
+  it('maps each known-fatal legacy default to the current safe launch', () => {
+    for (const [presetId, r, v] of [
+      ['figure8', 1.8, 1.1], ['figure8', 3.2, 1.0],
+      ['moth', 2.2, 1.1], ['pythagorean', 4.0, 1.6],
+    ] as const) {
+      const m = migrateLegacyLaunch(presetId, r, v);
+      expect(m).not.toBeNull();
+      const { launch } = getScenario(presetId);
+      expect(m).toEqual({ radius: launch.radius, speed: launch.speed });
+    }
+  });
+
+  it('never touches hand-tuned or already-current values', () => {
+    expect(migrateLegacyLaunch('figure8', 2.71, 0.83)).toBeNull();      // user's own
+    const { launch } = getScenario('figure8');
+    expect(migrateLegacyLaunch('figure8', launch.radius, launch.speed)).toBeNull(); // current
+    expect(migrateLegacyLaunch('binary', 1.8, 1.1)).toBeNull();          // preset without legacy entries
+  });
+});
+
 describe('recenter', () => {
   it('zeroes net momentum and the center of mass', () => {
     const stars = recenter([
@@ -146,6 +170,16 @@ describe('findStableLaunch', () => {
     const steps = Math.round(120 / sc.system.dt);
     for (let i = 0; i < steps; i++) { step(sim, sc.system.dt); minDist = Math.min(minDist, minStarDist(planet, s)); }
     expect(minDist).toBeGreaterThan(0.3);
+  });
+
+  it('returns values on the UI controls’ 0.05 grid (representable + preserved by the sliders)', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const found = findStableLaunch(stars, 'bary', { starSoft: sc.system.softening, dt: sc.system.dt });
+    expect(found).not.toBeNull();
+    const onGrid = (x: number) => Math.abs(x / 0.05 - Math.round(x / 0.05)) < 1e-9;
+    expect(onGrid(found!.radius)).toBe(true);
+    expect(onGrid(found!.speed)).toBe(true);
   });
 
   it('never returns a radius beyond largestRadius (must stay in the UI control range)', () => {

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SCENARIOS, buildStars, launchPlanet, orbitFrame, recenter, getScenario,
+  step, minStarDist, planetEnergy,
+  type SimState, type Planet,
+} from '../index';
+
+/**
+ * The Observatory's first impression is a planet dropped into a star system.
+ * Historically several scenarios shipped launch defaults that dropped the planet
+ * *inside* the stars' path, so it fell into a star within a couple of time units
+ * ("explodes in the sun") — a broken opening. These tests pin each scenario's
+ * default launch to the same collision test the live app uses (rKill = 0.12),
+ * integrating with the real engine, so a bad default can't regress unnoticed.
+ */
+
+const R_KILL = 0.12; // matches the Observatory's default collision radius.
+
+/** Run a scenario's default launch through the real integrator for `T` sim-time,
+ *  reporting the planet's fate the way the live analyzer does. */
+function flyDefault(scenarioId: string, T: number) {
+  const sc = getScenario(scenarioId);
+  const stars = buildStars(sc, [1, 1, 1]);
+  const { target, radius, speed } = sc.launch;
+  const planet: Planet = { ...launchPlanet(stars, target, radius, speed), alive: true };
+  const sim: SimState = {
+    stars, planets: [planet], t: 0,
+    dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05,
+  };
+  const dt = sc.system.dt;
+  const steps = Math.round(T / dt);
+  let minDist = Infinity;
+  let fate: 'bound' | 'destroyed' | 'ejected' = 'bound';
+  for (let i = 0; i < steps; i++) {
+    step(sim, dt);
+    const d = minStarDist(planet, stars);
+    if (d < minDist) minDist = d;
+    if (d < R_KILL) { fate = 'destroyed'; break; }
+    const rBary = Math.hypot(planet.x, planet.y);
+    if (rBary > 16 && planetEnergy(planet, stars, sim.starSoft * sim.starSoft) > 0) {
+      fate = 'ejected'; break;
+    }
+  }
+  return { fate, minDist, tEnd: sim.t };
+}
+
+describe('scenario launch defaults', () => {
+  // The opening act: no scenario should incinerate its planet on the way in.
+  // 60 time units is far longer than any realistic first-look viewing window.
+  it.each(SCENARIOS.map(s => s.id))('%s default launch is not destroyed early', id => {
+    const { fate, minDist } = flyDefault(id, 60);
+    expect(fate).not.toBe('destroyed');
+    // A comfortable margin over the kill radius, not a knife-edge grazing pass.
+    expect(minDist).toBeGreaterThan(R_KILL * 1.5);
+  });
+
+  // Figure-Eight is the app's default scenario — the very first thing a visitor
+  // sees — so hold it to a stricter bar: bound (not merely un-destroyed) for a
+  // long run.
+  it('the default scenario (Figure-Eight) keeps the planet bound long-term', () => {
+    expect(SCENARIOS[0].id).toBe('figure8');
+    const { fate, tEnd } = flyDefault('figure8', 300);
+    expect(fate).toBe('bound');
+    expect(tEnd).toBeGreaterThanOrEqual(300);
+  });
+});
+
+describe('recenter', () => {
+  it('zeroes net momentum and the center of mass', () => {
+    const stars = recenter([
+      { x: 1, y: 2, vx: 0.3, vy: -0.1, ax: 0, ay: 0, mass: 2 },
+      { x: -1, y: 0, vx: -0.2, vy: 0.4, ax: 0, ay: 0, mass: 1 },
+      { x: 0, y: -1, vx: 0.1, vy: 0.5, ax: 0, ay: 0, mass: 3 },
+    ]);
+    let M = 0, cx = 0, cy = 0, px = 0, py = 0;
+    for (const s of stars) { M += s.mass; cx += s.mass * s.x; cy += s.mass * s.y; px += s.mass * s.vx; py += s.mass * s.vy; }
+    expect(cx / M).toBeCloseTo(0, 12);
+    expect(cy / M).toBeCloseTo(0, 12);
+    expect(px / M).toBeCloseTo(0, 12);
+    expect(py / M).toBeCloseTo(0, 12);
+  });
+});
+
+describe('launchPlanet geometry', () => {
+  it('places the planet at the requested radius, moving tangentially around the target', () => {
+    const stars = buildStars(getScenario('binary'), [1, 1, 1]);
+    const f = orbitFrame(stars, 'binary');
+    const radius = 1.6, speed = 1.1;
+    const p = launchPlanet(stars, 'binary', radius, speed);
+    // Offset from the target is `radius` along +x.
+    expect(Math.hypot(p.x - f.cx, p.y - f.cy)).toBeCloseTo(radius, 10);
+    // Velocity relative to the target has magnitude `speed` and is perpendicular
+    // to the radial offset (tangential launch).
+    const rvx = p.vx - f.cvx, rvy = p.vy - f.cvy;
+    expect(Math.hypot(rvx, rvy)).toBeCloseTo(speed, 10);
+    const dot = (p.x - f.cx) * rvx + (p.y - f.cy) * rvy;
+    expect(dot).toBeCloseTo(0, 10);
+  });
+});

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -124,4 +124,16 @@ describe('findStableLaunch', () => {
     for (let i = 0; i < steps; i++) { step(sim, sc.system.dt); minDist = Math.min(minDist, minStarDist(planet, s)); }
     expect(minDist).toBeGreaterThan(0.3);
   });
+
+  it('never returns a radius beyond largestRadius (must stay in the UI control range)', () => {
+    // The recovery UI caps Start radius at 8; a result past it would clamp on the
+    // next slider drag, back toward an unsafe orbit. The finder must respect the
+    // bound and return null (→ caller falls back to the safe scenario default)
+    // rather than an out-of-range orbit. Pythagorean around Star 3 is the case
+    // the reviewer flagged (unconstrained search wanted r≈11.5).
+    const sc = getScenario('pythagorean');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const found = findStableLaunch(stars, 's2', { starSoft: sc.system.softening, dt: sc.system.dt, largestRadius: 8 });
+    if (found) expect(found.radius).toBeLessThanOrEqual(8);
+  });
 });

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -1,8 +1,9 @@
 import { describe, it, expect } from 'vitest';
 import {
   SCENARIOS, buildStars, launchPlanet, orbitFrame, recenter, getScenario,
+  circularSpeed, findStableLaunch,
   step, minStarDist, planetEnergy,
-  type SimState, type Planet,
+  type SimState, type Planet, type Star, type TargetId,
 } from '../index';
 
 /**
@@ -95,5 +96,32 @@ describe('launchPlanet geometry', () => {
     expect(Math.hypot(rvx, rvy)).toBeCloseTo(speed, 10);
     const dot = (p.x - f.cx) * rvx + (p.y - f.cy) * rvy;
     expect(dot).toBeCloseTo(0, 10);
+  });
+
+  it('circularSpeed is √(M/r) about the target', () => {
+    const stars = buildStars(getScenario('figure8'), [1, 1, 1]);
+    const f = orbitFrame(stars, 'bary');
+    expect(circularSpeed(stars, 'bary', 3)).toBeCloseTo(Math.sqrt(f.mass / 3), 10);
+  });
+});
+
+describe('findStableLaunch', () => {
+  // The empirical safe-orbit finder (backs the "Find a stable orbit" button and
+  // the fell-into-a-star recovery hint). Its contract: whatever it returns must
+  // actually survive — with clearance, not a chaotic knife-edge.
+  it.each(SCENARIOS.map(s => s.id))('returns a genuinely surviving orbit for %s', id => {
+    const sc = getScenario(id);
+    const stars = buildStars(sc, [1, 1, 1]);
+    const target: TargetId = sc.launch.target;
+    const found = findStableLaunch(stars, target, { starSoft: sc.system.softening, dt: sc.system.dt });
+    expect(found).not.toBeNull();
+    // Re-fly the returned launch independently and confirm it stays clear.
+    const s: Star[] = buildStars(sc, [1, 1, 1]);
+    const planet: Planet = { ...launchPlanet(s, target, found!.radius, found!.speed), alive: true };
+    const sim: SimState = { stars: s, planets: [planet], t: 0, dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05 };
+    let minDist = Infinity;
+    const steps = Math.round(120 / sc.system.dt);
+    for (let i = 0; i < steps; i++) { step(sim, sc.system.dt); minDist = Math.min(minDist, minStarDist(planet, s)); }
+    expect(minDist).toBeGreaterThan(0.3);
   });
 });

--- a/src/lib/nbody/__tests__/scenarios.test.ts
+++ b/src/lib/nbody/__tests__/scenarios.test.ts
@@ -56,13 +56,36 @@ describe('scenario launch defaults', () => {
   });
 
   // Figure-Eight is the app's default scenario — the very first thing a visitor
-  // sees — so hold it to a stricter bar: bound (not merely un-destroyed) for a
-  // long run.
-  it('the default scenario (Figure-Eight) keeps the planet bound long-term', () => {
+  // sees — so hold it to a stricter, two-sided bar. The launch is tuned to the
+  // EDGE of stability: (a) the planet survives the whole realistic viewing
+  // window, and (b) the ghost swarm visibly branches early — the app's headline
+  // demo must not require minutes of watching.
+  it('the default scenario (Figure-Eight) survives the viewing window', () => {
     expect(SCENARIOS[0].id).toBe('figure8');
     const { fate, tEnd } = flyDefault('figure8', 300);
     expect(fate).toBe('bound');
     expect(tEnd).toBeGreaterThanOrEqual(300);
+  });
+
+  it('the default launch sits near the edge: a 1e-3 ghost diverges by t=150', () => {
+    const sc = getScenario('figure8');
+    const stars = buildStars(sc, [1, 1, 1]);
+    const { target, radius, speed } = sc.launch;
+    const ref: Planet = { ...launchPlanet(stars, target, radius, speed), alive: true };
+    // Same offset the Observatory's default ghost spread uses (ε = 10^-3).
+    const ghost: Planet = { ...ref, x: ref.x + 1e-3 };
+    const sim: SimState = {
+      stars, planets: [ref, ghost], t: 0,
+      dtBase: sc.system.dt, G: 1, starSoft: sc.system.softening, planetSoft: 0.05,
+    };
+    let divT: number | null = null;
+    const steps = Math.round(150 / sc.system.dt);
+    for (let i = 0; i < steps; i++) {
+      step(sim, sc.system.dt);
+      if (Math.hypot(ghost.x - ref.x, ghost.y - ref.y) > 0.5) { divT = sim.t; break; }
+    }
+    expect(divT).not.toBeNull();
+    expect(divT!).toBeLessThan(150);
   });
 });
 

--- a/src/lib/nbody/analysis/analyzer.ts
+++ b/src/lib/nbody/analysis/analyzer.ts
@@ -15,7 +15,9 @@ const ZERO_BINS = (): Record<Bin, number> => ({ both: 0, climate: 0, dynamics: 0
 
 export class Analyzer {
   private p: ClassifyParams;
-  readonly Sref: number;
+  /** Reference insolation at launch (public for the sky view; retuning β
+   *  re-measures it from the launch snapshot). */
+  Sref: number;
   private Slo: number;
   private Shi: number;
 
@@ -45,9 +47,20 @@ export class Analyzer {
   private lastBound = true;
   private lastCalm = false;
 
+  /** The launch configuration S_ref was measured from, kept so a β (lumExp)
+   *  retune can re-measure the reference under the new law — "×launch light"
+   *  must keep meaning the light at THIS launch, whatever β currently is. */
+  private launchSnapshot: { stars: Star[]; planet: Planet } | null;
+
   constructor(params: ClassifyParams, stars: Star[], planet: Planet, Sref?: number) {
     this.p = params;
     this.Sref = Sref ?? insolation(planet, stars, params.lumExp, params.insolSoft2);
+    // With an externally-supplied Sref we don't own the reference's meaning, so
+    // never recompute it (retune keeps it fixed in that case).
+    this.launchSnapshot = Sref !== undefined ? null : {
+      stars: stars.map(s => ({ ...s })),
+      planet: { ...planet },
+    };
     this.Slo = this.Sref * params.habLo;
     this.Shi = this.Sref * params.habHi;
     // Seed the first sample so segment/era tracking starts cleanly.
@@ -60,11 +73,17 @@ export class Analyzer {
   }
 
   /** Re-tune the classification knobs mid-run without restarting the timeline:
-   *  the habitable band is re-derived from the SAME launch reference S_ref, so
    *  moving a climate slider re-labels the future without wiping the past (or
-   *  resetting the physics). Accumulated bins/segments keep their old labels —
+   *  resetting the physics). If β (lumExp) changed, S_ref is re-measured from
+   *  the stored launch configuration under the new law — otherwise the launch
+   *  point would drift away from meaning exactly 1× launch light in
+   *  unequal-mass systems. Accumulated bins/segments keep their old labels —
    *  the honest reading: they were classified under the rules of their time. */
   retune(params: ClassifyParams) {
+    if (params.lumExp !== this.p.lumExp && this.launchSnapshot) {
+      const { stars, planet } = this.launchSnapshot;
+      this.Sref = insolation(planet, stars, params.lumExp, params.insolSoft2);
+    }
     this.p = params;
     this.Slo = this.Sref * params.habLo;
     this.Shi = this.Sref * params.habHi;

--- a/src/lib/nbody/analysis/analyzer.ts
+++ b/src/lib/nbody/analysis/analyzer.ts
@@ -59,6 +59,17 @@ export class Analyzer {
     this.ingest(t, stars, planet, true);
   }
 
+  /** Re-tune the classification knobs mid-run without restarting the timeline:
+   *  the habitable band is re-derived from the SAME launch reference S_ref, so
+   *  moving a climate slider re-labels the future without wiping the past (or
+   *  resetting the physics). Accumulated bins/segments keep their old labels —
+   *  the honest reading: they were classified under the rules of their time. */
+  retune(params: ClassifyParams) {
+    this.p = params;
+    this.Slo = this.Sref * params.habLo;
+    this.Shi = this.Sref * params.habHi;
+  }
+
   private ingest(t: number, stars: Star[], planet: Planet, accumulate: boolean) {
     const dt = Math.max(0, t - this.lastT);
     const { lumExp, insolSoft2, calmWindow, calmThresh, rKill, rEsc } = this.p;

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -94,7 +94,11 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0022,
       softening: 0.01,
     },
-    launch: { target: 'bary', radius: 1.8, speed: 1.1 },
+    // A wide circumbinary (P-type) orbit that clears the stars' figure-eight loop:
+    // survives indefinitely, yet the breathing inner triple still fans the ghost
+    // cloud out over time. A closer launch (the old r=1.8) fell into a star in ~2
+    // time units — chaos, but a dead planet before you'd seen anything.
+    launch: { target: 'bary', radius: 3.2, speed: 1.0 },
   },
   {
     id: 'moth',
@@ -105,7 +109,10 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0004,
       softening: 0.0025,
     },
-    launch: { target: 'bary', radius: 2.2, speed: 1.1 },
+    // The Moth choreography is larger and more delicate than the figure-eight, so
+    // the planet needs a wider berth (old r=2.2 fell in almost at once). A gently
+    // sub-circular circumbinary orbit rides the whole regular era.
+    launch: { target: 'bary', radius: 3.5, speed: 0.95 },
   },
   {
     id: 'pythagorean',
@@ -121,7 +128,12 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0016,
       softening: 0.04,
     },
-    launch: { target: 'bary', radius: 4.0, speed: 1.6 },
+    // Burrau's problem is violently destructive — the stars fall from rest and one
+    // is eventually ejected — so no close orbit survives. A wide, slow launch keeps
+    // the planet clear of the initial collapse: it witnesses the whole spectacle
+    // and is flung into the dark much later, rather than incinerated at once (old
+    // r=4/v=1.6 fell in by t≈7).
+    launch: { target: 'bary', radius: 5.0, speed: 0.55 },
   },
   {
     id: 'binary',

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -162,6 +162,31 @@ export function getScenario(id: string): Scenario {
   return SCENARIOS.find(s => s.id === id) ?? SCENARIOS[0];
 }
 
+/** Launch defaults shipped by EARLIER versions that are now known-bad: the
+ *  pre-2026-07 fatal launches (planet falls into a star within seconds) and the
+ *  too-stable interim figure-eight. Returning visitors have these persisted in
+ *  localStorage, so fixing the scenario defaults alone doesn't reach them —
+ *  their stored settings silently resurrect the old failure. */
+const LEGACY_LAUNCHES: Record<string, [radius: number, speed: number][]> = {
+  figure8: [[1.8, 1.1], [3.2, 1.0]],
+  moth: [[2.2, 1.1]],
+  pythagorean: [[4.0, 1.6]],
+};
+
+/** If a persisted (radius, speed) for `presetId` matches a legacy default
+ *  exactly, return the scenario's current launch to migrate to; else null.
+ *  Exact match only — a user's own hand-tuned values are never touched. */
+export function migrateLegacyLaunch(
+  presetId: string, radius: number, speed: number,
+): { radius: number; speed: number } | null {
+  const eq = (a: number, b: number) => Math.abs(a - b) < 1e-9;
+  const legacy = LEGACY_LAUNCHES[presetId] ?? [];
+  if (!legacy.some(([r, v]) => eq(radius, r) && eq(speed, v))) return null;
+  const { launch } = getScenario(presetId);
+  if (eq(radius, launch.radius) && eq(speed, launch.speed)) return null; // already current
+  return { radius: launch.radius, speed: launch.speed };
+}
+
 /** Build a scenario's stars with per-star mass multipliers applied, re-centered
  *  so net momentum stays zero. A uniform multiplier just rescales time; uneven
  *  ones detune the configuration (e.g. break the figure-eight) — useful for
@@ -251,13 +276,17 @@ export function findStableLaunch(
     starSoft, dt, rKill = 0.12, minClear = 0.5, probeTime = 140,
     smallestRadius = 1.0, largestRadius = 16, radiusStep = 0.25,
   } = opts;
-  const round2 = (x: number) => Math.round(x * 100) / 100;
+  // Snap to the UI controls' 0.05 step so a returned launch is exactly
+  // representable — the probe below then tests the *snapped* values, so what
+  // ships is what was verified (an off-grid speed would drift on the next drag).
+  const CONTROL_STEP = 0.05;
+  const snap = (x: number) => Math.round(x / CONTROL_STEP) * CONTROL_STEP;
   const ss2 = starSoft * starSoft;
   const steps = Math.round(probeTime / dt);
 
   for (let r = smallestRadius; r <= largestRadius + 1e-9; r += radiusStep) {
-    const radius = round2(r);
-    const speed = round2(circularSpeed(stars, target, radius));
+    const radius = snap(r);
+    const speed = snap(circularSpeed(stars, target, radius));
     // Fresh star copy per candidate (the stars evolve during the probe).
     const s: Star[] = stars.map(st => ({ ...st }));
     const planet = launchPlanet(s, target, radius, speed);

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -95,11 +95,13 @@ export const SCENARIOS: Scenario[] = [
       dt: 0.0022,
       softening: 0.01,
     },
-    // A wide circumbinary (P-type) orbit that clears the stars' figure-eight loop:
-    // survives indefinitely, yet the breathing inner triple still fans the ghost
-    // cloud out over time. A closer launch (the old r=1.8) fell into a star in ~2
-    // time units — chaos, but a dead planet before you'd seen anything.
-    launch: { target: 'bary', radius: 3.2, speed: 1.0 },
+    // A circumbinary (P-type) orbit tuned to the EDGE of stability: close enough
+    // that the ghost cloud visibly branches by t≈84 (vs t≈334 for the safer
+    // r=3.2/v=1.0), yet never destroyed from any launch angle — the reference
+    // planet dances through close passes (min star distance ≈0.96) and is finally
+    // ejected around t≈427, a long chaotic life ending as a frozen wanderer, not
+    // a fireball. (The old r=1.8/v=1.1 fell into a star in ~2 time units.)
+    launch: { target: 'bary', radius: 3.2, speed: 0.95 },
   },
   {
     id: 'moth',

--- a/src/lib/nbody/scenarios.ts
+++ b/src/lib/nbody/scenarios.ts
@@ -13,7 +13,8 @@
  * fresh array so the simulation can be re-seeded deterministically on reset.
  */
 
-import type { Planet, Star } from './integrator';
+import { step, type Planet, type SimState, type Star } from './integrator';
+import { planetEnergy } from './analysis/classify';
 
 /** What the planet is launched into orbit around:
  *  the system barycenter, one specific star, or the inner two-star binary. */
@@ -117,7 +118,7 @@ export const SCENARIOS: Scenario[] = [
   {
     id: 'pythagorean',
     name: 'Pythagorean',
-    blurb: "Burrau's problem: stars of mass 3, 4 and 5 fall together from rest, swing through violent close passes, and eject one of their own.",
+    blurb: "Burrau's problem: stars of mass 3, 4 and 5 fall together from rest, swing through violent close passes, and eject one of their own. Your planet is a witness, not a resident — it rides a wide orbit through the fireworks and is eventually flung into the dark.",
     system: {
       // Masses 3,4,5 at the vertices of a 3-4-5 right triangle, starting at rest.
       makeStars: () => recenter([
@@ -204,4 +205,71 @@ export function launchPlanet(
     vy: f.cvy + dir * speed * ca,
     ax: 0, ay: 0,
   };
+}
+
+/** The local circular-orbit speed √(M/r) around a target body at `radius`. */
+export function circularSpeed(stars: Star[], target: TargetId, radius: number): number {
+  const f = orbitFrame(stars, target);
+  return Math.sqrt(f.mass / Math.max(0.05, radius));
+}
+
+export interface StableLaunchOptions {
+  /** Softening length for star–star interactions (matches the live sim). */
+  starSoft: number;
+  /** Integrator step. */
+  dt: number;
+  /** Collision radius that counts as "destroyed". */
+  rKill?: number;
+  /** How far a planet must always stay from the nearest star to count as safe
+   *  (an absolute clearance — bigger ⇒ rounder, more robustly-bound orbits, and
+   *  crucially avoids chaotic knife-edge survivors). */
+  minClear?: number;
+  /** Sim-time to integrate each candidate. Long enough to reject slow decays. */
+  probeTime?: number;
+  smallestRadius?: number;
+  largestRadius?: number;
+  radiusStep?: number;
+}
+
+/**
+ * Empirically find a launch that survives — the only reliable "safe orbit" in a
+ * chaotic star field, where a derived radius fails (a star may be ejected to
+ * infinity; a hierarchical system's planet orbits a sub-system) and a single
+ * bare-survival probe lands on knife-edge orbits that a rounding-sized nudge
+ * destroys. Sweeps the launch radius outward, using the local circular speed at
+ * each, and returns the first whose planet stays bound **and** never comes within
+ * `minClear` of a star across `probeTime`. Values are rounded to the control
+ * steps the UI uses, so the returned orbit behaves exactly as previewed. Returns
+ * `null` if nothing in range qualifies. Pure — integrates a private copy.
+ */
+export function findStableLaunch(
+  stars: Star[], target: TargetId, opts: StableLaunchOptions,
+): { radius: number; speed: number } | null {
+  const {
+    starSoft, dt, rKill = 0.12, minClear = 0.5, probeTime = 140,
+    smallestRadius = 1.0, largestRadius = 16, radiusStep = 0.25,
+  } = opts;
+  const round2 = (x: number) => Math.round(x * 100) / 100;
+  const ss2 = starSoft * starSoft;
+  const steps = Math.round(probeTime / dt);
+
+  for (let r = smallestRadius; r <= largestRadius + 1e-9; r += radiusStep) {
+    const radius = round2(r);
+    const speed = round2(circularSpeed(stars, target, radius));
+    // Fresh star copy per candidate (the stars evolve during the probe).
+    const s: Star[] = stars.map(st => ({ ...st }));
+    const planet = launchPlanet(s, target, radius, speed);
+    const sim: SimState = { stars: s, planets: [planet], t: 0, dtBase: dt, G: 1, starSoft, planetSoft: 0.05 };
+    let ok = true;
+    for (let i = 0; i < steps; i++) {
+      step(sim, dt);
+      let dmin = Infinity;
+      for (const st of s) { const d = Math.hypot(st.x - planet.x, st.y - planet.y); if (d < dmin) dmin = d; }
+      if (dmin < Math.max(rKill, minClear)) { ok = false; break; }
+      // Unbound-and-far ⇒ this radius won't settle into an orbit.
+      if (Math.hypot(planet.x, planet.y) > largestRadius + 4 && planetEnergy(planet, s, ss2) > 0) { ok = false; break; }
+    }
+    if (ok) return { radius, speed };
+  }
+  return null;
 }


### PR DESCRIPTION
Consolidates PR #249 (its branch is fully contained in this one) plus the legibility redesign, the app test suite, and the bug fixes that followed. One PR, four arcs:

## 1. The opening no longer fails (was PR #249)

The app opened with the planet falling into a star within ~2 sim-seconds. Three of four scenarios shipped launch defaults inside the stars' path:

| Scenario | Old → New | Result |
|---|---|---|
| Figure-Eight (default) | r=1.8, v=1.1 → **r=3.2, v=0.95** | destroyed t≈2.4 → edge-of-stability (see below) |
| Moth | r=2.2, v=1.1 → **r=3.5, v=0.95** | destroyed t≈2.4 → bound past t=1200 |
| Pythagorean | r=4.0, v=1.6 → **r=5.0, v=0.55** | destroyed t≈7.5 → witnesses the collapse, ejected ~t=1124 |
| Binary + Star | unchanged | bound |

The default is deliberately tuned to the **edge of stability**: ghosts (ε=10⁻³) branch at t≈84 — 4× sooner than the safe interim tuning — while never being destroyed from any of 8 tested launch angles; the planet's eventual fate is a late ejection (~t≈427), a long chaotic life ending as a frozen wanderer, not a fireball. Plus: `findStableLaunch` (empirical safe-orbit finder, snapped to the UI's 0.05 control grid and bounded to the slider range), a one-click **Find a stable orbit** recovery when a planet dies, default speed 1→1.5×, `Observatory.tsx`→`AnalysisHUD.tsx`, and `migrateLegacyLaunch` so returning visitors' persisted pre-fix launches are migrated instead of silently resurrecting the failure.

## 2. Legibility redesign (from the 38-finding verified design review)

**Chrome (design-language, DESIGN-SPEC §4.1–4.3):** a shared `Button` primitive with a closed emphasis set (`primary | secondary | ghost | danger | toggle`; at most one primary per panel); an **accent rebudget** (readouts → `--fg`, header icons → `--dim`; accent only marks touch/on state, so the primary verb is the loudest element by construction); persistent **rail labels** under desktop panel icons (`SectionDef.railLabel`); `Kicker`/`Note` type-scale primitives; visible scrollbars on overflowing panel bodies.

**Trinary:** one panel owns the whole launch (exact x/y/vx/vy behind an "Exact launch state" fold with pinned/auto status); panels 10→9 (Trails folded into Viewpoint, Settings into Sim, new drive-tier **Hands-on** panel projecting **Pause · Place · Scatter · Restart** into the strip); task-named layouts (Sandbox opens the **Ghost swarm** — the headline experiment — plus Ghost swarm / Climate & sky / Rotating frames); honest renames ("Chaos demo"→"Ghost swarm", "Perturbation ε"→"Ghost spread ε", "Star size"→"Collision radius", Star A/B/C→1/2/3, …); color-drift copy fixes (the "pink ghosts" are gray now — star sliders carry token-colored swatch dots instead of stale color names); sky sliders auto-enable the sky view; placing a planet launches it (exits place mode, unpauses); HUD moved clear of panels and the phone chrome bar.

## 3. Application test suite (36 new tests; 303 total)

Analyzer timeline invariants (contiguous segments, partition-of-time fractions, fire-once events, a synthetic Paradise system), leapfrog **exact time-reversibility**, scalar/event/divergence contracts, the Lab's seeded-reproducibility claims, Aggregator vs brute force, the batch runners' "bit-identical to solo" claim held to exact equality, and the rotating-frame transform (extracted pure to `frame.ts`: isometry, no mirror, align-to-+x).

## 4. Bug fixes the suite and review surfaced

- **Census averaging**: `habitableFraction` was per-survived-lifetime, so early-destroyed worlds reported ~100% habitable and censuses read absurdly rosy. Fractions now measure the **time budget** (dead time is not habitable time); the Destiny map's statistical lens inherits the fix.
- **Fate-map click handoff**: the painted grid didn't remember the domain/config it was painted with — click, hover, and zoom mapped through *live* state, so moving any slider after rendering silently remapped every pixel. `render()` now snapshots the painted context and all three consumers read through it.
- **Non-destructive knobs**: climate sliders re-label the running world via `Analyzer.retune()` instead of hard-resetting the physics; retuning β re-measures S_ref from a stored launch snapshot so the launch point always means exactly 1× launch light (Codex review finding); the Lab keeps a finished census on screen with a "previous run" banner instead of silently wiping minutes of compute.

## Verification

`npm test` → 303 pass · build clean · lint 0 errors · headless screenshots across desktop layouts + phone · Puppeteer-driven end-to-end checks (destroy→recover flow; legacy-persistence migration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7qW9gEW5LQ5SCo5G9KEGg