### PR TITLE
Number Planes: the journal (entries in time), the seed conversations, three walks, and the dual room

### DIFF
--- a/docs/design/notebook-handoff/THE-UNFOLDING.md
+++ b/docs/design/notebook-handoff/THE-UNFOLDING.md
@@ -8,9 +8,9 @@ journal.html): per Dan, the journal is a *construction* — this chain is the
 style and the quarry, not a script ("we do not have to literally follow my
 precise chain of unfolding. the goal is clarity with fun and excitement of
 learning together"). Verbatim vs paraphrase is marked on every quote as the
-source reports marked it. Two shared chat conversations (chatgpt.com +
-claude.ai share links, 2026-07-17) are NOT yet in this record — unreachable
-from the sandbox; add them when saved into the repo. -->
+source reports marked it. The two chat conversations Dan pointed at
+(2026-07-17) are now saved verbatim in conversations/ and indexed below as
+Step 0. -->
 
 # The unfolding — how Number Planes actually happened
 
@@ -21,6 +21,41 @@ numbers." Are there other options?**
 
 Each step below: the question as it was asked, what got built in answer, the
 small answer it produced, and the question it opened.
+
+## Step 0 · the seed conversations (supplied 2026-07-17)
+
+**Question.** "Why do trig functions feel unnatural compared to polynomials,
+exponentials, etc.?" — the opening of the conversation Dan names as "the seed
+for this entire study" (`conversations/2026-07-complex-analysis-and-the-three-number-systems.md`).
+
+**Built.** No artifact — a conversation. It dissolves its own opening
+("naturalness" names a relation between a function and the operations licensed
+as primitive, not a property), walks Euler's actual route to e^(iθ), reads exp
+as Cartesian→polar, derives conformality as the Jacobian forced into the
+scaled-rotation form [a, −b; b, a] — and then asks the pivotal question:
+*"What are other 'natural' choices for ℝ²→ℝ² functions beyond Jacobian
+constraints?"*
+
+**Answer.** Demanding the derivative form a closed number system yields
+exactly three options by what K² equals: −1 (complex — rigid, the one field),
+0 (dual — shears, automatic differentiation), +1 (split — boosts, left/right
+movers). Unit sets: circle, parallel lines, hyperbola; the same discriminant
+that classifies conics and PDE types. The conversation closes by tracing its
+own reasoning into conic sections: "the complex function *is* the cone before
+cutting."
+
+**Opened.** The trichotomy, met in passing as a classification of Jacobians,
+became the residue that grew into the whole study — Dan's later phrasing
+("When I think of 'the number plane' I think of complex numbers… are there
+other options?") descends from it, and the archive picks up at Step 1. The
+follow-on conversation (`conversations/2026-07-dual-numbers-galilean-autodiff.md`)
+deepens the p = 0 world: dual numbers ↔ Galilean geometry (boost = shear; one
+direction invisible to the metric), complex-dual numbers as the tangent bundle
+of ℂ, the ε^n jet ladder, tropical algebra as a different "algebra of
+approximation," and forward/reverse autodiff — feeding the dual-world card,
+the autodiff seal, and the tropical postmark.
+
+<sub>Sources: docs/design/notebook-handoff/conversations/ (verbatim transcripts + README provenance note)</sub>
 
 ## Step 1 · 2026-06-20
 

--- a/docs/design/notebook-handoff/THE-UNFOLDING.md
+++ b/docs/design/notebook-handoff/THE-UNFOLDING.md
@@ -1,0 +1,361 @@
+<!-- THE-UNFOLDING.md — the recorded question-chain of the Number Planes project.
+
+Distilled 2026-07-16 (branch claude/number-plane-directional-pivot-za1hzy) from
+287 extracted moments across the committed session archive (progress/handoff/
+plan/expert reports + git history) by an 8-reader mining pass with a threading
+synthesis. This is SOURCE MATERIAL for the journal (public/number-planes/
+journal.html): per Dan, the journal is a *construction* — this chain is the
+style and the quarry, not a script ("we do not have to literally follow my
+precise chain of unfolding. the goal is clarity with fun and excitement of
+learning together"). Verbatim vs paraphrase is marked on every quote as the
+source reports marked it. Two shared chat conversations (chatgpt.com +
+claude.ai share links, 2026-07-17) are NOT yet in this record — unreachable
+from the sandbox; add them when saved into the repo. -->
+
+# The unfolding — how Number Planes actually happened
+
+The seed question, per Dan (not itself verbatim in the archive; its earliest
+recorded descendant opens step 1, and its staged final form is printed on the
+notebook cover): **"When I think of 'the number plane' I think of complex
+numbers." Are there other options?**
+
+Each step below: the question as it was asked, what got built in answer, the
+small answer it produced, and the question it opened.
+
+## Step 1 · 2026-06-20
+
+**Question.** New app or reuse? — how should an intro-to-complex-numbers experience be delivered: a guide page reusing existing viewers, a small new applet, or extending an existing app? (Behind it, Dan's seed: 'When I think of the number plane I think of complex numbers — are there other options?')
+
+**Built.** Scoping before building: an orientation survey of existing assets (Plane Transform's log-polar ×→shift bridge; a Complex Particles feature inventory of 7 sampling patterns etc.) and three candidate deliverable shapes drafted and flagged needs-dan. Dan then redirected from 'write a guide page' to 'enrich the app so it can host these ideas', with four concrete asks (port grid/circle domain features; drag two complex numbers on the Argand plane; add/multiply a curve by a constant; morph a chart of (x,y) into (u,v)) and a six-step pedagogical arc ending in the whole plane morphing.
+
+**Answer.** The pieces already exist, but 'there is no simple interactive here-are-two-complex-numbers, drag them, watch a+b and a·b widget' — that is the missing piece; and the standing !high 'which plane am I looking at' ambiguity is squarely in scope. Deliverable = app code, not prose.
+
+**Opened.** How does animation figure in the design — Dan asserted it as the medium itself, which demanded a review: is 'animate everything' honest?
+
+**Dan, as recorded:**
+
+- "animate however is a truth through everything. even addition multiplication will be animated -- this is animath." (verbatim, recorded 'Per Dan (verbatim)')
+- Four asks for Plane Transform: port grid/circle/domain features; add two complex numbers by dragging them on the Argand plane; add or multiply a curve by a complex number; build toward morphing a chart of (x,y) into (u,v). (paraphrase)
+
+<sub>Sources: docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-intro-to-complex-numbers.md — §Session purpose; decision 17:47; findings 17:47/17:55; decision 17:58; §Candidate shapes · docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-expert-synthesis.md — 'Plan under review' (lines 23-45)</sub>
+
+## Step 2 · 2026-06-20
+
+**Question.** Is every animated picture TRUE (pedagogy: does each motion trace a path the math distinguishes?) and does the system respond to a hand just messing with it (game design)? — the four-hat review Dan commissioned, adding a Game Designer to the standard three hats.
+
+**Built.** Four expert reports + a synthesis (expert-maintainer, expert-consultant, expert-pedagogy, expert-gamedesigner, expert-synthesis) — committed as design artifacts, no code. Key contents: the maintainer's 'morphT lerp is the load-bearing lie' scoping; the consultant's 'the climax is ~5 lines of shader plus a clock' and the affine-vs-polar interpolant contract; the pedagogy hat's spiral proof (a·bᵗ; the b=−1 chord walks through the origin — 'this one example alone justifies the spiral'); the game hat's BLOCKING draggable-handles requirement and snapping/juice program; a phased plan leading with the live-multiplication hero.
+
+**Answer.** The loudest cross-hat convergence: 'animate everything, but make every motion trace a path the mathematics distinguishes' — a·b spirals, a+b slides, and that contrast IS the core lesson. Chapters = mode pills, not routes; arithmetic = SVG/DOM, no WebGL.
+
+**Opened.** Dan questioned whether this must live in Plane Transform at all and proposed a third side-along app that could let Plane Transform be retired — the pivot from 'enrich' to 'build fresh'. He also corrected the review's overstatement: animation is 'one of the major modes of exploration', not 'everything must animate'.
+
+**Dan, as recorded:**
+
+- Run a four-hat review: 'the standard three + a Game Designer added at Dan's request'. (paraphrase of recorded setup)
+- Proposed a third side-along app that could let us retire Plane Transform after switching. (paraphrase, recorded as 'Pivot under consideration')
+- Animation is "one of the major modes of exploration" — not "everything must animate." (verbatim fragments of Dan's correction)
+
+<sub>Sources: docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-expert-maintainer.md, -expert-consultant.md, -expert-pedagogy.md, -expert-gamedesigner.md, -expert-synthesis.md · docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-intro-to-complex-numbers.md — milestone 18:30; decisions 18:45 and 19:00</sub>
+
+## Step 3 · 2026-06-20
+
+**Question.** Given the fork is locked (fresh successor app, Complex Particles untouched), what exactly gets built first? — the plan question, answered by plan-fresh-complex-app.md and Dan's one-word go-ahead.
+
+**Built.** The plan doc for the fresh app (working name Argand, route #/argand; alternatives considered: Complex Plane, Plane Play, Twist & Scale; chapters Number·Add·Multiply·Curve·Transform·Morph as pills; honest-paths callout: 'a straight chord for multiplication is actively false'). Then, on 'begin.': Phase 1 shipped — the Argand app (complexOps.ts mulPath spiral / addPath slide, SVG ArgandPlane with draggable a/b handles, commutativity double spiral, Multiply|Add pills, defaults a=1.6+0.6i, b=i as a quarter-turn); on 'continue.': Phase 2 — Number|Curve toggle + curves.ts preset shapes (the asymmetric flag making handedness legible); plus pinch/wheel zoom and pan at Dan's ask.
+
+**Answer.** The hero worked, but Dan reframed its value model: the static parametric ARC is the payload; a bare position-scrubber is low-value unless coupled to a live changing equation — 'watch the algebra move, not just a dot'.
+
+**Opened.** Dan's full-arc/reverse-path note — and the discovery that his 'reverse direction' meant something deeper than playing the arc backward.
+
+**Dan, as recorded:**
+
+- "begin." (verbatim)
+- "the slider is not particularly useful unless you are watching the equation changing. What is useful is showing the parametric arc. The actual scrubber does not help much." (verbatim)
+- "continue." (verbatim)
+- Asked for pinch-to-zoom and two-finger pan on the plane. (paraphrase)
+
+<sub>Sources: docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-plan-fresh-complex-app.md — §App identity, §Chapters (IMPORTANT callout), §Phased build; frontmatter 'next:' · docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-intro-to-complex-numbers.md — code 21:00, finding 21:20, code 21:25, code 21:35</sub>
+
+## Step 4 · 2026-06-20
+
+**Question.** What is the honest 'reverse path' for the multiply animation? Dan: the arcs when stopped should always show the full arc, and the return should be the operation in reverse — 'or leave the movement out of the story.'
+
+**Built.** First pass: the full path always drawn at rest + a ping-pong Play clock retracing the same arc backward (dividing). Dan then clarified that he meant the two FACTORIZATIONS, not the same arc reversed — which produced the unified closed multiply loop (cycleSweep: q → q·b → b → q·b → q): first quarter ramps b's exponent (point acts on shape), next ramps q's (the whole shape collapses onto the single point b at the midpoint), then back.
+
+**Answer.** Both halves pass through the same product, 'so commutativity is the MOTION' — and because the loop is closed, the existing ping-pong clock plays it seamlessly. The session's first reading of 'reverse direction' was a corrected misread — part of the record.
+
+**Opened.** Dan's biggest mid-session reframe: stop thinking in two numbers and ×/+ — 'open up the app' around one function.
+
+**Dan, as recorded:**
+
+- "the arcs when stopped should always show the full arc. And if possible do the reverse path on the return, as the multiplication was in reverse direction. That, or leave the movement out of the story." (verbatim)
+- "in one case we are multiplying the circle by the point, in the other we are multiplying the point by the circle." (verbatim)
+
+<sub>Sources: docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-intro-to-complex-numbers.md — code 21:45 'Full arc always shown at rest; ping-pong animation'; code 22:05 'Unified two-factor multiply sweep (the real "reverse direction")'</sub>
+
+## Step 5 · 2026-06-20
+
+**Question.** "open up the app" — what if the whole app is one function f(z) = α₁z + α₀ (the complex cousin of y = mx + b) instead of two numbers combined by ×/+? (Dan's directive; fragment verbatim)
+
+**Built.** The full reframe (net −200 lines): draggable slope α₁ and shift α₀, Point/Shape/Grid feeds, the two honest legs closed into a loop, fixed point z* = α₀/(1−α₁). Inside the reframe THE SYSTEM SLIDER p = j² IS BORN — a persistent Complex/Dual/Split pill running the same affine line through rotation/shear/boost with the x²−p·y²=1 unit curve + null cone: the first artifact generalizing 'the' number plane into a family. Then Iterate + 'View from z*' (from the interesting-cases discussion Dan liked), quadratics on Dan's 'add a_2' (Degree pill, pink α₂ handle, poly layer, term-sum decomposition), and a polish round (polar grid, on-screen equation, domain coloring, p-behavior fixes).
+
+**Answer.** The family was a slider before it was a theory. And the first hard math lesson of taking one line through three planes: continuous powers don't always exist off ℂ — in degenerate domains powRealG falls back, so the orbit diverged from its iterates (the 'paths don't connect' bug Dan caught, fixed by powReliable gating with straight segments where the power isn't honest).
+
+**Opened.** Gallery placement (Argand slotted just after Complex Particles; fullscreen HUD fixed) — and, latently, the fact that the p=j² system was the app's least-taught feature.
+
+**Dan, as recorded:**
+
+- "open up the app" (verbatim fragment — the directive to rebuild around the affine map)
+- "add a_2" (verbatim)
+- Four asks after playing: polar grid + grid size, domain coloring, fix the p-value behavior bugs, show the equation on screen. (paraphrase)
+
+<sub>Sources: docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-intro-to-complex-numbers.md — decision 00:30, code 01:30, code 02:30, code 03:30, milestone 04:34 · git:bb6cd78 — 'Start session: scope intro-to-complex-numbers explanatory page (#226)' (the Argand app lands)</sub>
+
+## Step 6 · 2026-06-22
+
+**Question.** Should Argand eventually supersede Plane Transform outright ('successor-in-progress'), and what becomes of the retired views? — the handoff's explicit catalog question, put to Dan.
+
+**Built.** The handoff + developer guide (docs/apps/argand.md): the app as shipped — three feeds, three number systems via p = j², iteration & fixed points, View from z*, quadratics, immersive plot + bottom HUD, color-coded lockable handles; EXPLAINER 'Possible sources' block (Argand/Wessel, Yaglom, Cayley–Klein, rapidity, dual numbers). Honest limits recorded: only the SIGN of p matters; dual/split quadratic fixed points are approximate (the system √ falls back in degenerate regions) — flagged as the item bumping follow-up value.
+
+**Answer.** Dan: keep the name and the position. Also locked in: Means is dead — Dan found it unhelpful, do NOT resurrect (Repeat's 'x as repeated addition' idea salvageable as a toggle).
+
+**Opened.** The !high next item: the p = j² trichotomy is fully wired but the app's LEAST TAUGHT feature — how to write the explainer + tools that lift the dual/split story to first-class?
+
+**Dan, as recorded:**
+
+- "keep the name and keep it where it is (successor-in-progress to Plane Transform)" (recorded as verbatim in the plan's frontmatter 'next:' field: 'Dan 2026-06-22: ...')
+- Means was unhelpful — don't resurrect. (paraphrase, handoff guidance)
+
+<sub>Sources: docs/sessions/handoff/complex-numbers-animath-intro-jperz6/2026-06-22-S01-argand-app.md — §Summary, §Context, §Open/not done, §Self-reflection items 3 & 7 · docs/sessions/progress/complex-numbers-animath-intro-jperz6/2026-06-20-S01-plan-fresh-complex-app.md — frontmatter 'next:' (line 11) · docs/apps/argand.md — frontmatter 'next:', §Status, §Active, §Invariants & gotchas, §History & sources</sub>
+
+## Step 7 · 2026-06-24
+
+**Question.** I want to discuss interactions between the complex-dual-split slider and the other complex function apps. I think the core idea is "unitary spaces" where the most "familiar" entry point is complex numbers but even those are treated as foreigners we need to understand.
+
+**Built.** Two review rounds. Round 1 (Dan's recorded ask: review Argand's visual design and UX with FIVE hats — graphic designer + video game designer added): grounded in headless screenshots; found the one real honesty bug — dual/split quadratic fixed points drawn as confident gold dots at fabricated locations ('the geometric equivalent of a fabricated citation') — and a unanimous keep-the-bones-and-subtract verdict ('a great toy wearing a VCR's control panel'). Round 2 (reconvened on the pivot quote above): the cross-app 'unitary spaces' analysis.
+
+**Answer.** The idea is real: normG = x²−p·y² is the genuine invariant, and 'treat ℂ as a foreigner' means precisely that ℂ is the p<0 member of a family. But: capability-gate the p-dial (only affine/polynomial/rational maps generalize honestly — a live slider next to sin z is 'garbage with a confident face'; the lock itself teaches); domain coloring silently lies off ℂ; the dial is a capstone, not a spine ('you cannot defamiliarize ℂ for a learner who has not yet familiarized it'); and 'unitary' is the WRONG NAME — it re-privileges ℂ under the banner of de-privileging it.
+
+**Opened.** What should the umbrella actually be called, what maps are in scope — and (round-1 leftover) is Argand a sandbox or guided, and does it supersede Plane Transform?
+
+**Dan, as recorded:**
+
+- "I want to discuss interactions between the complex-dual-split slider and the other complex function apps. I think the core idea is \"unitary spaces\" where the most \"familiar\" entry point is complex numbers but even those are treated as foreigners we need to understand." (verbatim, the recorded second request)
+- Review the Argand app — visual design and UX — with two added hats: graphic designer + video game designer. (recorded original request; close paraphrase)
+
+<sub>Sources: docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-expert-synthesis.md — 'Original request', R2.1 (~lines 337-371) · docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-expert-pedagogy.md — §2 (~lines 84-121), Augmentation §1 and §3 · docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-design-ux-review.md — 12:40, 12:52, 13:05, 14:10 entries</sub>
+
+## Step 8 · 2026-06-24
+
+**Question.** What is the umbrella name and scope — and are polar coordinates even meaningful in the other number planes (dual/split)? (Dan's naming decision + his recorded sub-question, paraphrase)
+
+**Built.** Dan rejected BOTH naming candidates — 'unitary' (re-privileges ℂ) and 'Cayley–Klein / j²-continuum' (correct but scary; two surnames read as gatekeeping) — and chose the umbrella 'NUMBER PLANES', tagline 'how do you do arithmetic on the plane?', leaves keeping the in-world verbs Spin · Shear · Boost, proper nouns only in the sources block. He scoped the program to lines → polynomials → (maybe) rational functions — exactly the honestly-generalizable set — and made 'explain the limits' a first-class requirement (the fabricated-fixed-point fix promoted to 'the worked example of a limit we explicitly teach'). The polar question got R2.6 + an attribution scout (Harkin & Harkin 2004 verified as the best citable survey of the p=j² dial; Dan's call on citations: hold, stage for the reframe).
+
+**Answer.** Polar is genuinely meaningful in all three planes (z = ρ·e^{jθ}, multiplication adds θ and scales ρ) but only ℂ has a global angle — θ is rapidity per sector (split) or slope (dual); never say 'angle' unqualified. And the unification: the polar grid IS the domain coloring — one (ρ,θ) law from N = x²−p·y², with undefined regions rendered as honest structure ('the angle ran out'). The breakdown is the lesson, not an error.
+
+**Opened.** Dan's 16:10 pivot to build: start a fresh math foundation designed to span the three classes, with tests — and make clear the app does NOT replace Plane Transform (the 'successor-in-progress' framing scrubbed in all 5 spots).
+
+**Dan, as recorded:**
+
+- "we would want to explain what the limits are for things like fixed points." (verbatim)
+- Chose 'Number Planes', tagline 'how do you do arithmetic on the plane?'; rejected 'unitary' and 'Cayley–Klein'. (paraphrase of the recorded 14:40 steer)
+- Are polar coordinates meaningful in the other number planes, and how should they be handled? (paraphrase of Dan's 15:00 sub-question)
+- 'Hold, stage for reframe' (recorded fragment — the citations wait for the reframe)
+
+<sub>Sources: docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-expert-synthesis.md — R2.5 (~lines 483-536), R2.6 (~lines 547-619) · docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-attribution-sources.md — §2.1, §3 · docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-design-ux-review.md — 14:40, 15:00, 15:20, 15:45, 16:10 entries</sub>
+
+## Step 9 · 2026-06-24
+
+**Question.** Can the teaching live INSIDE the app — a Step-0 tour that starts on the real line and grows the plane out of it? (paraphrase of Dan's evening direction — answered, over four hours of iteration, with a decisive NO)
+
+**Built.** The evening's builds: (kept) src/animations/Argand/numberPlanes.ts + 50-test suite — the math-first engine where the generic algebra over p=j² is primary and complex is just p<0, left deliberately dormant; controls cleanup (coefficients 'very messy' per Dan; 'System' panel renamed 'Number plane'). (Shelved) tour.ts — a 9-step walkthrough with a real-line Step 0 and the S⁰⊂S¹⊂S³ magnitude ladder; a line mode iterated to Dan's specs (no y-axis, ticks expanding into the plane, ±1 markers fading into the unit circle); and finally the fresh minimal LineTransform app (#/line-transform, ~160 lines: one number line, x·y·m·b, colored y=mx+b).
+
+**Answer.** DEAD END, explicitly: Dan — 'not a good way to learn' (first tour), 'not communicating… this should be a very simple thing that shows linear transformations on a real line' (line-in-plane-chrome), and finally 'this is not useful… I don't think we have the correct formulation… shelve all the number-line stuff, stay in the plane, drop the tour. Pull back to the changes before we went to the number line.' Argand reverted to bc404f7; tour.ts and LineTransform/ live only in git history. The handoff's lesson: the teaching belongs in a document, not bolted onto the plane viewer.
+
+**Opened.** The narrative-first pivot (21:30): craft the story as a document first. The live co-design that followed produced the story's core answers — Dan's crux 'Why not × element-wise too?' (answer: you CAN — element-wise multiplication IS the split plane in its null basis; the trichotomy is how much the axes entangle); bilinearity + unit collapse the whole choice to one number j²=p; the Hurwitz 1-2-4-8 ladder; eigen-'rails' (split 2, dual 1, complex 0 → must spiral); the dial is a circle (ℝP¹, dual at 0 AND ∞); |·|_p measures net area scaling. All banked into the plan doc for a choice-driven Number Planes page (the session's true deliverable: 'the thing to continue from is the plan doc, not the app').
+
+**Dan, as recorded:**
+
+- "not a good way to learn" (verbatim)
+- "not communicating… this should be a very simple thing that shows linear transformations on a real line." (verbatim)
+- "this is not useful… I don't think we have the correct formulation… shelve all the number-line stuff, stay in the plane, drop the tour. Pull back to the changes before we went to the number line." (verbatim)
+- 'very messy' (verbatim fragment, on the coefficients)
+- Why not × element-wise too? (paraphrase — the narrative crux)
+- "tell me more about complex multiplication," "tell me about quadratics," "show me in p-space," "what happens to the eigenvalues," … (verbatim — Dan's examples of reader choices, shaping the explorable-web navigation model)
+
+<sub>Sources: docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-design-ux-review.md — 16:35, 17:05, 17:45, 18:20, 18:50, 19:40, 20:30, 21:00, 21:30, 22:10 entries · docs/sessions/progress/argand-plane-review-51egvz/2026-06-24-S01-plan-number-planes-page.md — 'The premise & the spine', 'Navigation model', nodes 2/3/5/6, 'Decisions logged', 'Open questions (need Dan)' · docs/sessions/handoff/argand-plane-review-51egvz/2026-06-24-S01-design-ux-review.md — headline + 'The thing to continue from' · git:9af344b — 'Argand: five-hat review + plane-app polish + numberPlanes foundation (narrative rethink in progress) (#237)'</sub>
+
+## Step 10 · 2026-06-25
+
+**Question.** Dan: 'the Number Plane app which will be the rename for the Argand plane' — but the prior plan describes a separate HTML page, not a rename. Rename the app, build the page, or both? And singular or plural?
+
+**Built.** Scope pinned by Dan's circling quote to the HTML guide page, structured as circle-around-one-core (hub + ring of lenses, NOT a branching tree): public/number-planes.html built (713 lines — hub with the j²=p choice, a carried Spin/Shear/Boost choice in a sticky header rewriting the prose live, four written lenses + four teaser stubs, circle-back footers). Then, on Dan's new 'gallery but for the guides' direction, the themed guides layer: guide-theme.css mirroring all 8 app skins, guide-skin.js sharing the app's persisted skin key, guides.html gallery with a featured Number Planes card. PR flow per Dan: work migrated off the auto-named branch to number-plane-guide → PR #244; Codex review fixes including qualifying the affine fixed-point claim ('as long as 1−α is invertible').
+
+**Answer.** The structural insight that made the page possible: the core is ONE trichotomy — the count 2/1/0 (real roots of t²=p) IS the rails, the unit curve, the orbit shape, and the algebra; every lens is the same count re-met. And a proof of the drift risk within hours: theming v2 landed the SAME DAY, adding a mode axis the static mirror doesn't replicate.
+
+**Opened.** The gating fork (needs Dan): keep the guides as a themed static section, or promote them into the chrome as a real #/guides route (native skins, no drift)? Plus: finish the 4 stub lenses; build the #/embed/number-planes applet on the dormant numberPlanes.ts (the 'find the rails' morph named the centerpiece); naming still deferred.
+
+**Dan, as recorded:**
+
+- "the Number Plane app which will be the rename for the Argand plane" (verbatim fragment)
+- "I often feel like I have to circle around these ideas several times from different perspectives and I would like the page to have that same quality." (verbatim)
+- "let's not worry about naming for now" (verbatim)
+- "something like the gallery but for the guides … keep the same theming modes and styles and a coherent experience and a place to keep these types of pages." (verbatim)
+- "continue" (verbatim — after the fork question errored; combined with his standing 'everything is provisional')
+- Dan: open the PR, follow it, address the bot's review comments, move to a cleanly-named branch. / Dan: study the gallery next session; update the report + write a handoff. (recorded 'Dan:' shorthand — close paraphrase)
+- How do I test-drive these pages — does Cloudflare build a preview from a PR? (paraphrase)
+
+<sub>Sources: docs/sessions/progress/number-plane-guide/2026-06-25-S01-number-plane-rename.md — 17:20, 17:35, 18:05, 18:25, 19:10, 19:45, 20:15 entries · docs/sessions/handoff/number-plane-guide/2026-06-25-S01-number-plane-rename.md — §Open/not done, §Context, §Self-reflection 4 & 7 · git:69fdf57, git:dc09e48, git:733ac88, git:99994ca, git:b3b07d9</sub>
+
+## Step 11 · 2026-06-29
+
+**Question.** What should the reader encounter first ('first looks')? And Dan's challenge underneath it: is there really only one way to multiply the line — 'Complex numbers are defined by their addition and multiplication. But I can already think of other ways… like (a,b)·(c,d)=(a·c,b·d). But what are the constraints?'
+
+**Built.** A dense day of probes, several ending in recorded pullbacks. Math thread: sign rules are theorems (distributivity + unit force (−1)(−1)=1; on the line, 0 free parameters; tropical is the honest escape — drop subtraction); magnitude was never required for the trichotomy; the 3-D zoo is exactly five algebras, none a division algebra. Navigation: Dan reversed the explorable web to 'single thread + post-marks', then briefed page 1 — built as public/number-planes-line.html (PR #245, stacked on number-plane-guide) — then asked for slides + manipulable figures, producing the trail-deck viewer (guide-deck.js/css, guide-widgets.js). Voice: first draft rejected as a diary; locked as plain/declarative/example-first (touchstones McPhee, Korzybski — 'could it be different?' is the thesis — Bryson 'but braver'). Content: the 27-card Zettelkasten note system + card inspector + force-graph view (both at Dan's ask); a three-hats review REJECTED the object-type re-atomization ('atomize on reuse, not on type'; the real risk is integrity → check-cards.mjs shipped); then Dan pulled back from the whole taxonomy: regrouped under three core-concept hubs C1/C2/C3.
+
+**Answer.** On the line multiplication is forced; the plane is the first place the same demands leave exactly one knob loose (j²=p) — the guide's driving question becomes 'Why are complex numbers special — what are the knobs, could it be different?'. Process answer: the day's shape was probe → Dan's felt verdict → smaller truer unit ('the focus is on the idea. let's not be precious').
+
+**Opened.** Dan pinned the main story's Beat 4 as the next build: a new gallery app 'Number Plane' — one panel, three plots (p = −1, 0, +1), the SAME expression on each — possibly replacing Argand later.
+
+**Dan, as recorded:**
+
+- "we are going to try for a single thread and put the post-marks for other paths along the way. we will maybe figure out how to join them." (verbatim)
+- "build the first page around the Real number line, addition and multiplication with the open aside to tropical numbers (where lives a postmark) and finishes with our familiar field over the real numbers (only in passing, or in boxes that keep definitions)" (verbatim)
+- "maybe JS… a new kind of document viewer" / figures "have to be manipulable" (verbatim fragments)
+- "Complex numbers are defined by their addition and multiplication. But I can already think of other ways… like (a,b)·(c,d)=(a·c,b·d). But what are the constraints — and we start listing them out, then think of them on the number line." (verbatim)
+- "doing too much" (verbatim — trimming the L2 card)
+- "design a document html so we can look at the cards… see the connections, the type… examine the yaml." (verbatim)
+- "add a graph view? showing the different types of edges." (verbatim)
+- "proceed with the plan" (verbatim — executed as the three-hats-RECONCILED plan)
+- "we went too far… we were just trying to measure out the ideas into units. keep the text simple. the focus is on the idea. let's not be precious." (verbatim)
+- "yes please regroup into core units." (verbatim)
+
+<sub>Sources: docs/sessions/progress/number-plane-guide-first-page-zkpnzi/2026-06-29-S01-first-looks-first-page.md — 12:30, 12:55, 13:10, 13:25, 13:45, 14:10, 14:35, 15:30, 16:05, 16:30, 17:20, 17:45, 18:10 entries · docs/sessions/progress/number-plane-guide-first-page-zkpnzi/2026-06-29-S01-expert-synthesis.md, -expert-pedagogy.md, -expert-maintainer.md, -expert-consultant.md</sub>
+
+## Step 12 · 2026-06-29
+
+**Question.** Dan's Beat-4 pin (paraphrase): build the 'Number Plane' app — one panel, three plots, the same expression under each plane's multiplication, a single p dial. Then, after driving it: "I don't know what is getting squared" — and a cascade of what-do-I-see questions.
+
+**Built.** src/animations/NumberPlane/ at #/number-plane (SVG, no WebGL) — the FIRST CONSUMER of the dormant numberPlanes.ts engine: three plots at j² = −p, 0, +p; |z|=r level sets (circle · line pair · hyperbola), αz+β with shared draggable α/β, z²; one p dial; dashed null set. Round 2 from Dan's feature list: Point/Shape/Grid feeds with labeled image, Play morph, Iterate 1–14 (spiral · shear · saddle side by side — 'the money shot'), and the Align-frame-to-rails slider where the complex plot deliberately doesn't move — that failure IS the story (the plan's 'single most important interaction', realized). Round 3: shared zoom/pan, the honest z·αᵗ flow via engine powReal, quadratic pill, theme colormap. The evening discussions minted cards: the fan (rails = ideals; stir/creep/snap — verified live via the Rays feed Dan asked for), the cone (CN: the knife's tilt IS the dial, p = a²−1; no parabola), Cayley–Klein (CK), the p-trace (PT), sticky middles (NH), Sylvester inertia (IN) — 35 cards, checker green.
+
+**Answer.** Names settled with Dan: 'Number Planes' for the family, 'the p-plane' for a member (Harkin & Harkin's 'generalized complex numbers' kept as also-known-as); parameter space = 'the dial', compactified = 'the circle of planes' (moduli: 3 points, non-Hausdorff). Core constraint sharpened: only bilinearity + a unit are demanded — in 2D commutativity/associativity are free; the demands only become payable at dimension 4.
+
+**Opened.** 'The unfolding' — Dan named the working method ('this type of discussion is precisely the content of a notebook once we identify all the different connections and find a way to unfold them effectively') and the handoff assigned it: turn the 35-card pile + app into the living-notebook presentation. Flagged fork: are pages views over cards, or separate prose?
+
+**Dan, as recorded:**
+
+- "I don't know what is getting squared" (verbatim)
+- "add it so we can see it — yes, add the slider" (verbatim — the Rays feed)
+- "this type of discussion is precisely the content of a notebook once we identify all the different connections and find a way to unfold them effectively." (verbatim)
+- New app 'Number Plane' (may replace Argand later); the notebook could open on 'the three number planes'; the comparator invites a single p knob. (paraphrase, quoted fragments as recorded)
+
+<sub>Sources: docs/sessions/progress/number-plane-guide-first-page-zkpnzi/2026-06-29-S01-first-looks-first-page.md — 19:00, 19:50, 20:40, 21:40, 22:30 entries · docs/sessions/handoff/number-plane-guide-first-page-zkpnzi/2026-06-29-S01-first-looks-first-page.md — §Open/not done, §Context, Self-reflection #3 · git:0e6df33 — 'Number Planes guide: page 1 of the trail — the line (#245)' (carries NumberPlane.tsx, 788 lines)</sub>
+
+## Step 13 · 2026-07-03
+
+**Question.** How should the whole corpus be presented? Dan's brief (paraphrase): an interactive notebook — futuristic feeling, tactile, yet a PERSONAL notebook; curated and threaded but not forced; the right analogy is a GARDEN (we design the beds; many paths, natural to the layout; the visitor never walks into the plantings). He asked for a curatorial review of all 35 cards with backward projection to the pre-recorded germ line.
+
+**Built.** The garden plan (2026-07-03-S01-plan-garden-paths.md): backward projection naming the germ line ('arithmetic as geometry' as the founding instinct; Argand's System slider as 'the first dial' — 'the family was a slider before it was a theory') and the recorded reversal (June 24 web → June 29 single thread → the garden as synthesis). Verified against the card graph, which 'already knew a fourth bed exists' → C4 the Overlook. Layout: four beds (Line · Plaza · Three Parterres · Overlook), three paths — A 'Could it be different?' (the forcing walk), B 'What does each world feel like?' (the residents' walk — 'the Number Plane app is this path built as an instrument'), C 'It was one thing all along' (the overlook climb) — nine seams as junctions (Seam 1: the naive rival multiplication IS the split plane in disguise; CN the knife; CR the loop; IN the master seam), two trails, honest gates. Principles: depth = proximity; no page-jumps; the app is not a separate toolshed.
+
+**Answer.** The rhythm to preserve, distilled from the 06-29 record: 'a question → a reframe → an instrument to see it with' — the notebook's walk step. Meta-seam: the project's own history walks Path C ('the garden was designed by walking it').
+
+**Opened.** Making a real spread — which Dan's mockups, arriving overnight, would answer.
+
+**Dan, as recorded:**
+
+- Garden brief: we design the beds and layouts; many paths, natural to the layout; the visitor never walks into the plantings; curatorial review + backward projection requested. (paraphrase, recorded 20:15 decision)
+- "I circle these ideas from different perspectives" (verbatim fragment, quoted in the plan as 'The circling (Dan, June 24)' — the reason re-crossing the same clearing is a feature)
+
+<sub>Sources: docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-03-S01-plan-garden-paths.md — germ line (~50-71), 'The rhythm we are preserving', 'The plantings', Paths A/B/C, 'The seams', 'Garden principles' · docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-03-S01-living-notebook-presentation.md — §Session purpose, 19:53, 20:00, 20:15 entries</sub>
+
+## Step 14 · 2026-07-04
+
+**Question.** Dan, attaching two mockups: 'so you have an idea of the informational units and connectivity. paper should feel alive.' — how does a page feel alive AND personal without narration? And, mid-redesign, the question he directed the page itself to open on: 'Does the number plane have to be complex?'
+
+**Built.** A rapid probe→v2→script→v3 arc. Probe (notebook.html spread II 'the choice'): live level-set figure, sticky p dial, SPIN/SHEAR/BOOST comparator, and the MARGINALIA unit discovered in the mockups — the revealed note quoting the genuine 29-June no-parabola correction '— from the record' ('the personality lives in revision marks, not narration. Solves the diary problem'). Dan's v1 feedback → v2 the one-screen desk (viewport-fit, compartments, all 8 skins, the ×w matrix slot with live eigenvalues). Dan's pivotal review → 'staging is the missing layer' → the passage script 'The Choice' (4 stops: the question → renormalization 'only the sign survives' → the triad/three motions → the mirror trick z·z̄ = x²−p·y²; the key reorder: level sets AFTER ×w) → v3 the staged passage (18 moments, tap-per-line, settle-the-dots renormalization where the zero dot refuses, p-line ghost-morphing into the dial). Then the cover ('Building the Number Plane'), the living-page principle, the told FOIL — and at session end the external 'Notebook design system' handoff landed: plates + chapters, ONE p drives every plate, Chapter II as reference.
+
+**Answer.** 'Paper should feel alive' = state flows visibly across the page (the codex holds, the light responds). Staging beat space: the desk had compartments but no time mechanics. The dial's sticky stops at −1/0/+1 became EXPLAINED (renormalization residues), not merely felt. Method named per Dan: script the passages first; 'the garden arranges itself around walks that are already true.'
+
+**Opened.** The faithful Chapter II port — plus flagged tensions handed to Dan: scrollable page vs the no-scroll rule; fonts; where the walk sits relative to the plates room.
+
+**Dan, as recorded:**
+
+- "so you have an idea of the informational units and connectivity. paper should feel alive." (verbatim)
+- "yes I think that is a good idea" (verbatim — approving the probe); 'I am open to seeing what you come up with.' (recorded, on path choice)
+- "Does the number plane have to be complex?" (verbatim — the directed opening question, the staged descendant of the seed question)
+- "announcing is not our way" (verbatim fragment — the derivation unfolds, nothing is announced)
+- v1 feedback: page must fit the viewport — scrolling doesn't exist; 'nothing appears that cannot be hidden again'; compartments; more interactive, less illustrative; enable the themes. (paraphrase)
+- Approved the script with adjustments; C0 insight: the unit square shows spin/shear/boost because it shows the DECOMPOSITION — distributivity gives the full effect from the two basis moves. (paraphrase)
+
+<sub>Sources: docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-03-S01-living-notebook-presentation.md — 00:45, 01:10, 03:40, 05:20, 07:00, 09:30, 12:40 entries · docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-03-S01-plan-passage-script.md — NOTE block, Beat A0, STOP B/C/D</sub>
+
+## Step 15 · 2026-07-08
+
+**Question.** Dan's trigger for the six-lens review: does the ported chapter-2.html really 'work with any theme'? And, from Dan's parallel chat with Claude: what happens when j² is NOT purely real — j² = p + q·j — why is the failure localized to exactly one rectangle?
+
+**Built.** S01: the six-lens review of chapter-2.html (the plate-grid room) and notebook.html (the walk) — rigor re-derived every formula from ℝ[j]/(j²−p); pedagogy asked 'does the grid teach, or is it a control panel?'; editorial asked 'which one is the notebook?'. S02: the q-excursion plan + standalone prototype (q-dial, s-scrub re-grid, Δ badge, disguise presets incl. the golden rule j²=1+j with Fibonacci eigen-rails), machine-checked over 3000 trials, plus two proposed cards (LK 'The leak in Q3', RG 'The re-grid') and the recorded p_s trap kept as marginalia.
+
+**Answer.** Theming: TRUE (var()/color-mix recolors live across all 8 skins) with a WCAG-contrast caveat; the one-p contract honored faithfully. Math: 'a correct, honest transcription' with exactly one genuine defect (|p|≥15 labeled 'the dual plane, again' — two unreconciled compactifications) plus a CR sign slip. Product: 'passage teaches → grid confirms'; the walk→room door only opens one way; the reframe — 'the duplication is room-vs-room': three implementations of 'one p, three planes, live' in three identities ('three doors to one room, and no map on the wall'); the plate grid is the chapter template, don't clone the moment engine. Math of q: q rides Q3 and only Q3 — the one rectangle multiplying the generator by itself; the re-grid IS completing the square watched from rectangles; Δ = q²+4p is re-grid-proof → every rule j² = p + q·j re-grids to one of the three planes — the classification theorem, enacted. And the review's confessed blind spot: 'Nobody opened the page in a browser.'
+
+**Opened.** Dan-calls: does chapter-2 feed, replace, or coexist with the React #/number-plane app ('no lens was chartered to answer it')? Where does the q-excursion live, and does the one-p contract sandbox q? Plus the browser gap — which Dan closed five days later.
+
+**Dan, as recorded:**
+
+- 'works with any theme' (recorded fragment — Dan's trigger for the review)
+- "Revision marks, not narration" (recorded brief fragment — the register the editorial review tested both artifacts against)
+- What happens when j² = p + q·j — why is the failure localized to one rectangle, and what does the re-grid provably do and not do? (paraphrase; 'Provenance: Dan's conversation with Claude (chat, 2026-07-08), developed from Dan's four-rectangle construction')
+
+<sub>Sources: docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-08-S01-expert-rigor.md — headline, §2, §3, §5, §6, Verdict · docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-08-S01-expert-pedagogy.md — 'The central question', P1s, 'How the two artifacts should relate' · docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-08-S01-expert-editorial.md — 'The central question', 'Fidelity vs. the repo's own voice', garden-plan callout, 'Scope & the single highest-value next move' · docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-08-S01-expert-synthesis.md — §1, §3, §4 'Blind spots' · docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-08-S02-plan-q3-leak-regrid.md — provenance, 'The general rule and the leak', 'The re-grid', 'The residue', 'Honesty boundary', 'Open questions for Dan'</sub>
+
+## Step 16 · 2026-07-13
+
+**Question.** There are some definite problems. Do you have access to a browser? Can you look at the pages yourself and see what's wrong? Make it work and make it look great. And get the other notebooks into place so we can see the whole thing.
+
+**Built.** Headless Chromium over the served pages (desktop + phone, all 8 skins) found what six greps could not: the .fgl glosses were opacity:0 until hover — 'invisible forever on touch' — port-fidelity debt from day one; fixed with a deliberate divergence (glosses rest visible at 62%, flagged 'so a future session doesn't restore the regression'). Then the whole notebook: chapter-1.html 'the line' and chapter-3.html 'three worlds' as full ports on chapter-2's skeleton (executing the S01 'plate grid is the chapter template' decision), and index.html — the cover that binds it, its masthead printing the seed question at last: 'does the number plane have to be complex? — let's find out ✦', with three leaf side-doors (the walk in · the cards · the full app) and full cross-linking. The S02 leak/re-grid plan adjudicated 'adopt with corrections' (letters swapped; placement = a Chapter II annex; one-p contract → sandboxed q with an explicit adopt-p′ exit).
+
+**Answer.** The gap was behavioral (hover semantics, fonts, viewport), not structural — 'exactly the class of problem a diff can't see and only a browser can.' The notebook is now whole: cover + three chapters + side doors.
+
+**Opened.** Dan drives the four live pages next; then the leak/re-grid annex and retiring notebook.html into the chapters. Keyboard/ARIA pass parked per Dan.
+
+**Dan, as recorded:**
+
+- "There are some definite problems. Do you have access to a browser? Can you look at the pages yourself and see what's wrong? Make it work and make it look great. And get the other notebooks into place so we can see the whole thing." (verbatim)
+- 'The keyboard/ARIA pass stays parked per Dan' (recorded per-Dan decision, paraphrase)
+
+<sub>Sources: docs/sessions/progress/number-plane-notebook-kxvxzj/2026-07-13-S03-notebook-complete.md — §Session purpose, 'What the browser showed', 'The fixes', 'Divergence noted', 'The other notebooks (now in place)', 'Also this session', frontmatter 'next', Self-reflection</sub>
+
+## Step 17 · 2026-07-15
+
+**Question.** With the notebook whole and merged — is the chaptered notebook actually the right presentation of the material, or does the project's own working rhythm (dated discussions becoming cards becoming instruments) suggest a different form? (implicit; the record answers it with a pivot)
+
+**Built.** 2026-07-15: the Number Planes notebook LANDS on main — commit 531bbe5, PR #246: cover + Chapters I (The Line) · II (The Plane) · III (Three Worlds) as living-plate .dc.html designs with support.js (1,658 lines), the cards-reference deck, the walk-in, and a 306-line handoff README, carrying the whole Jul 3–13 session record. 2026-07-16: the journal probe lands — commit 5f978bc: public/number-planes/journal.html (511 lines), an entries-in-time presentation, the commit subject itself naming it 'the directional pivot'; paired progress report a63a808 ('notebook directional pivot session start') records the session.
+
+**Answer.** The record's final recorded move is another honest reframe, in the project's established pattern (probe → felt verdict → truer form): from a chaptered notebook to journal entries in time — a form that mirrors how the material was actually made.
+
+**Opened.** The journal direction itself — open at the record's end (2026-07-16), with the leak/re-grid annex, the retirement of notebook.html into the chapters, and the walk↔room/app-relationship Dan-calls still pending behind it.
+
+<sub>Sources: git:531bbe5 — 'Number Planes notebook — cover + chapters I·II·III (living plates), cards, walk-in (#246)' · git:5f978bc — 'Number Planes journal — entries-in-time probe (the directional pivot)' · git:a63a808 — same-day progress report, 'notebook directional pivot session start'</sub>
+
+## The dead ends (kept on purpose)
+
+- Guide-page-first deliverable (2026-06-20): Dan redirected from 'write a guide page' to app code the same afternoon.
+- 'Animation is the medium, everything animates' (2026-06-20): overstated reading of Dan's own line; corrected by Dan — animation is 'one of the major modes of exploration'; no autoplay by default.
+- Ping-pong 'same arc backward' (2026-06-20): the session's first reading of Dan's 'reverse direction' note; corrected by Dan to the two-factorizations loop (cycleSweep).
+- Means view (retired in the 00:30 affine reframe; Dan found it unhelpful — recorded 2026-06-22 as do-NOT-resurrect; Repeat retired too, its idea salvageable as a Point-feed toggle).
+- Horner-chain animation for quadratics (2026-06-20): superseded by the term-sum decomposition Dan chose.
+- 'Successor-in-progress to Plane Transform' framing: affirmed by Dan 2026-06-22 ('keep the name and keep it where it is'), then reversed 2026-06-24 — scrubbed in all 5 spots to 'stands on its own; complements, does not replace'.
+- 'Unitary spaces' as the umbrella name (Dan's own coinage, 2026-06-24): rejected — it names ℂ-only structure and re-privileges ℂ. 'Cayley–Klein / j²-continuum' also rejected (correct but scary; surnames read as gatekeeping). Winner: 'Number Planes'.
+- tour.ts 9-step in-app walkthrough + line mode + the standalone LineTransform app (#/line-transform) (2026-06-24 evening): built through three Dan rebukes ('not a good way to learn' → 'not communicating' → 'this is not useful… shelve all the number-line stuff'); Argand reverted to bc404f7; the artifacts live only in git history.
+- Explorable-web navigation (2026-06-24 plan): reversed 2026-06-29 by Dan to 'single thread + post-marks'; later synthesized 2026-07-03 as the garden (several designed paths, junctions, beds).
+- The static guides theming mirror (2026-06-25): accepted as reversible, and proven drift-prone within hours when theming v2 landed the same day; promotion-into-chrome remained the recommended (still-open) resolution.
+- Autobiographical diary voice (2026-06-29): first in-voice draft rejected by Dan; voice locked plain/example-first; the 'personal' quality finally solved 2026-07-04 by marginalia — 'revision marks, not narration'.
+- Object-type re-atomization of the cards (2026-06-29): rejected by the three-hats panel ('atomize on reuse, not on type'); then the whole taxonomy machinery pulled back by Dan ('we went too far… let's not be precious') in favor of C1/C2/C3 core-concept hubs.
+- The two-page book/codex mock and the static v2 desk (2026-07-04): dropped in Dan's rounds — no scroll, then 'staging is the missing layer'; the desk superseded by the staged passage.
+- Hover-only plate glosses (design fidelity, 2026-07-08/13): rendered the plates as voids, invisible forever on touch; deliberately diverged from on 2026-07-13 and flagged so no future session 'restores' the regression.
+- notebook.html as a standalone walk (2026-07-13): slated for retirement into the chapters (its animations to be harvested).
+- The chaptered notebook as final form (2026-07-16): the record ends on the 'directional pivot' to the entries-in-time journal probe.
+- Recorded math corrections kept as features, not erased: the 'paths don't connect' powRealG bug (2026-06-20), the fabricated dual/split fixed points (2026-06-24 → 'the worked example of a limit we explicitly teach'), the affine fixed-point overclaim in prose (2026-06-25, caught by a reviewer), the no-parabola correction (2026-06-29 → the notebook's first marginal note), and the p_s trap (2026-07-08 → proposed marginalia).
+
+## Provenance notes
+
+Chain assembled solely from the provided moments (progress/handoff/plan/expert reports + git commits); duplicates across readers merged (e.g. the four-hat review appears in both the progress report and the five expert files; the 2026-06-22 handoff and docs/apps/argand.md describe the same artifact; the 2026-06-24 evening appears in progress, plan, and handoff; the germ-line moments dated 06-20/06-24/06-29 inside the 07-03 garden plan are backward projections and were folded into their original steps rather than duplicated at 07-03). Ordering is strict by date; days with multiple distinct question→build→answer turns (06-20, 06-24, 06-29) are split into sequential steps per the record's own timestamps. Verbatim vs paraphrase is marked on every Dan quote exactly as the source reports marked it; 'Dan:' shorthand lines from the 06-25 report are labeled close-paraphrase per that report's own caveat. question_verbatim=true only where the step's question field is itself a recorded Dan quote (steps 7 and 15, i.e. the 06-24 unitary-spaces pivot and the 07-13 browser directive). The seed question ('are there other options?') is not itself in the archive verbatim; its earliest recorded descendant is the 06-20 scoping question and its staged final form is Dan's 07-04 'Does the number plane have to be complex?', printed on the notebook cover 07-13. One date discrepancy noted: the git commit for the NumberPlane app (0e6df33) is dated 2026-07-03 in the commit-moments but the app's build is recorded in the 2026-06-29 session reports — the step follows the session record (built 06-29, landed with PR #245's merge). The 07-15 notebook commit (531bbe5) and 07-16 journal pivot (5f978bc) are combined as the final step since the pivot is the record's closing move.

--- a/docs/design/notebook-handoff/WALKS.md
+++ b/docs/design/notebook-handoff/WALKS.md
@@ -109,14 +109,24 @@ entries 02/06 already contain most of its sculptures.
 
 ## Shared build inventory (ranked by how many walks starve without it)
 
-1. **The dual-world interior** (Galilean ruler + shear-composer) — Walks 1
-   and 3 both need it; the dual world currently has a placard but no
-   furniture. Quarry: the second seed conversation.
+1. **The dual-world interior** — ✅ BUILT v1 (2026-07-17):
+   `public/number-planes/dual.html` — the Galilean ruler (GR), the
+   parameter-composer (SH: angles/velocities/rapidities add), the wall from
+   both sides (DG), six seals, and the sticky **pocket dial** (knob + level
+   curve + the j² landing point — Dan's everywhere-reachable core cluster,
+   prototyped here; adopting it on every page is the follow-up that triggers
+   the shared notebook.css/js extraction).
 2. **The wiggle test** — Walk 2's centerpiece; the deepest missing sculpture
    (per-world rigidity made tangible).
-3. **The dual-number calculator** — cheap; the script exists verbatim.
+3. **The dual-number calculator** — ✅ BUILT v1, and it became more: the AD
+   hub on dual.html is the **three-estimators plate** — the j-slot of
+   f(a + b·j) IS the centered difference (p>0, rails at a±h), exact
+   forward-mode autodiff (p=0), and the complex-step derivative (p<0,
+   samples one floor up); both neighbors converge to the dual slot as p→0.
+   "Approached from either side as a common degeneracy" made literal.
 4. **The Jacobian microscope** — medium; also enriches Plane Transform.
-5. **Rapidity meter** — cheap; shared by Walks 1 and 3.
+5. **Rapidity meter** — folded into SH on dual.html (v1); a dedicated
+   velocity-saturation view remains open for Walk 3.
 
 **Authoring note:** every walk fits the journal's existing skeleton (entries
 + hand-gloss margins + pasted instruments + one p per page), so a leaflet

--- a/docs/design/notebook-handoff/WALKS.md
+++ b/docs/design/notebook-handoff/WALKS.md
@@ -1,0 +1,125 @@
+<!-- WALKS.md — three designed walks through the Number Planes grounds.
+
+Drafted 2026-07-17 (branch claude/number-plane-directional-pivot-za1hzy) at
+Dan's request: "generate three paths through this and suggest different ways
+of approaching the material." Frame: the sculpture-garden reading (Dan,
+2026-07-17 discussion) — the grounds (cards + instruments + adjacencies) are
+primary; every linear presentation is a LEAFLET, one of many. The journal
+(public/number-planes/journal.html) is leaflet #1: the founder's recorded
+walk. These three are complements, not replacements. Sources: the seed
+conversations (conversations/), THE-UNFOLDING.md, the cards, chapters I–III,
+the apps (Argand, NumberPlane, PlaneTransform, ComplexParticles), the
+2026-07-03 garden plan (whose paths A/B/C these refine). -->
+
+# Three walks through the grounds
+
+**The organizing axis.** Walks differ not mainly by order but by **what the
+visitor trusts at the gate** — questions, senses, theorems, or tools — and by
+**where the knob (j² = p) appears** on the route. The journal trusts
+*questions* and meets the knob mid-walk. The three walks below take the other
+three doors:
+
+| Leaflet | Trusts | The knob appears | Visitor |
+|---|---|---|---|
+| The journal (exists) | questions | in the middle (entry 04) | the curious generalist |
+| 1 · Residents' Walk | the senses | **last** — as the reveal | visual/kinesthetic; physics-inclined; bounces off axioms |
+| 2 · The Analysis Door | theorems | **as the door itself** | already knows complex analysis |
+| 3 · The Machines Walk | tools | **hidden in the hardware** | engineers, programmers, "why should I care" |
+
+Every walk crosses the **unprivileged door** to complex analysis at a
+different angle: Walk 2 steps through it knowingly; Walk 1 discovers it from
+inside; Walk 3 finds it printed on a circuit board.
+
+---
+
+## Walk 1 · The Residents' Walk — *"what does each world feel like?"*
+
+No axioms at the gate. The visitor is dropped into each world as an
+inhabitant and learns its physics by living there; the unifying theory is
+withheld until the overlook. (Refines garden-plan path B; the Number Plane
+app is this walk built as an instrument.)
+
+| # | Station | What happens | Serves it today | To build |
+|---|---|---|---|---|
+| 1 | Moving in (complex) | Multiply = turn + zoom; drag w, watch the grid carried; circles are the compass rose | Argand mul spiral; ch III ×w at p=−1; Complex Particles for the grand view | — |
+| 2 | The compass rose | The unit circle as the residents' protractor; e^iθ; periodicity = the circle closing | complex guides; Argand polar grid | — |
+| 3 | Next door (dual) | Multiplication **shears**. Absolute time along the real axis; the ruler is blind to the vertical (z·z̄ = x²); velocities add like slopes; every number carries its derivative in the ε-slot | DU world card; ch III at p=0 | **The dual interior**: a "Galilean ruler" plate (measure segments, watch vertical extent vanish) + a shear-composer (compose boosts = add velocities). Quarry: conversations/2026-07-dual-numbers-galilean-autodiff.md §§1–5 |
+| 4 | The third house (split) | Multiplication **boosts**. Two rails = the light cone; the interval x²−y² is what residents agree on; some points are mutually unreachable; the rails themselves are the zero divisors | ch III rails + eigen line; level curve at p=+1 | A rapidity meter (compose two boosts, watch rapidities add while velocities saturate) |
+| 5 | The overlook | The same αz+β in three windows; Iterate: spiral · shear · saddle side by side | **The Number Plane app is this station** | — |
+| 6 | The reveal | One hallway, one dial: the houses differ by j². Renormalize — only the sign ever mattered; there was never a fourth house | the j² slider; the renormalize plate (ch II) | — |
+
+**Exit:** deposits the visitor exactly where the journal's entry 04 begins —
+the knob, now *earned by travel* instead of derived. Cross-doors: station 3 →
+Machines Walk (autodiff); station 4 → Machines Walk (relativity); station 1 →
+Analysis Door (conformality).
+
+---
+
+## Walk 2 · The Analysis Door — *"out of the rigid room"*
+
+For the visitor who already lives in complex analysis. This walk is the seed
+conversation curated (conversations/2026-07-complex-analysis-…md; journal
+entry 00 expanded to full length). It uses the unprivileged door knowingly,
+in both directions.
+
+| # | Station | What happens | Serves it today | To build |
+|---|---|---|---|---|
+| 1 | The complaint | "Why do trig functions feel unnatural?" — dissolved: naturalness names a relation to the licensed primitives. Euler's actual route (de Moivre + the limit) | journal entry 00; seed conversation | — |
+| 2 | Conformality unpacked | The derivative is ONE complex number; the Jacobian forced to [a, −b; b, a]; ∂f/∂z̄ = 0 — "no conjugate anywhere in it" | Plane Transform (grid images) | **The Jacobian microscope**: zoom to any point of any map; a little circle stays a circle (holomorphic) or shears to an ellipse (not). The single deepest missing sculpture after the wiggle test |
+| 3 | The door question | "What else could the Jacobian be, if it must stay arithmetic?" → K² = −1, 0, +1. The hallway of three, met as a classification | the trichotomy plates | — |
+| 4 | Per-world function theory | **The wiggle test**: perturb a function on a small patch. Complex refuses (rigidity/identity theorem); split lets each rail wiggle free (left/right movers — floppiness); dual carries the wiggle into the ε-slot (jets, truncated Taylor) | — | **The wiggle-test plate** — Walk 2's centerpiece; nothing like it exists yet |
+| 5 | The determinant tells all | a²+b² / a² / a²−b² — definite · degenerate · indefinite = elliptic · parabolic · hyperbolic; the conics as unit sets AND as phase portraits of y″ = c·y | level curves (fig. 4 / PL) | a conic/phase-portrait overlay (cheap: same SVG, second trace) |
+| 6 | Back through the door | Complex analysis re-entered as *the p < 0 room*: the only field, the only rigid room — why the miracles (identity, Liouville, residues) live there and what dies elsewhere. FTA unseals | FD plate; FTA seal | — |
+
+**Side-chapel:** the q-leak annex (j² = p + q·j; the S02 plan) belongs off
+station 3 — what happens when the door's number goes off the real line.
+**Exit:** the visitor owns both placards on the door — "ℂ, the special case"
+and "ℂ, the entrance hall" — and knows neither is the fact.
+
+---
+
+## Walk 3 · The Machines Walk — *"it was in your pocket all along"*
+
+Entry through three working machines the visitor already relies on, opened
+hood-first. The seals, unsealed first; motivation runs backwards into theory.
+
+| # | Station | What happens | Serves it today | To build |
+|---|---|---|---|---|
+| 1 | Machine 1: backprop | Run f(5+ε) = 40 + 13ε live: the derivative computed *by arithmetic* — no limits, no h. ε² = 0 isn't a hack; it's a plane | autodiff seal | **The dual-number calculator plate**: pick/type f, drag a, watch value + derivative ride the two slots. Script = conversations/…autodiff §§ worked examples. Cheap |
+| 2 | Machine 2: the boost | Velocities refuse to add; rapidities add. The boost matrix is [a, pb; b, a] with p = +1; the interval survives | relativity seal; ch III matrix slot | rapidity meter (shared with Walk 1 station 4) |
+| 3 | Machine 3: phasors | AC circuits / graphics rotations: multiply = rotate, e^iθ runs the wall outlets | Argand; complex guides | — |
+| 4 | The workbench pattern | Three machines, one blueprint: [a, pb; b, a], differing by ONE number. The matrices seal opens | matrices seal | a three-machines side-by-side plate (assembly, not invention) |
+| 5 | The dial between machines | Turn p continuously; watch what survives and what breaks (and that only the sign matters) | Number Plane app; j² slider | — |
+| 6 | The warranty card | Why each machine *wants* its defect: autodiff wants nilpotents (truncation is the feature); relativity wants the null cone (the rails are physics); only one machine divides unconditionally (the field) | FD plate | — |
+
+**Exit:** at the theory's front gate, wanting the *why* — hands the visitor
+to the journal or the chapters. This walk is the only one that makes the
+zero divisors a selling point before a defect.
+
+---
+
+## A fifth sketch, kept in a drawer
+
+**The Quadratic Thread** (school door): the visitor already knows b² − 4ac.
+The discriminant IS the dial; root count = rail count = the sign; shortest
+path from a classroom to the whole grounds. Stations: the formula → the
+count 2/1/0 → where the missing roots live (one floor up) → t² = p → the
+three planes. Worth authoring when a younger audience matters; the journal's
+entries 02/06 already contain most of its sculptures.
+
+## Shared build inventory (ranked by how many walks starve without it)
+
+1. **The dual-world interior** (Galilean ruler + shear-composer) — Walks 1
+   and 3 both need it; the dual world currently has a placard but no
+   furniture. Quarry: the second seed conversation.
+2. **The wiggle test** — Walk 2's centerpiece; the deepest missing sculpture
+   (per-world rigidity made tangible).
+3. **The dual-number calculator** — cheap; the script exists verbatim.
+4. **The Jacobian microscope** — medium; also enriches Plane Transform.
+5. **Rapidity meter** — cheap; shared by Walks 1 and 3.
+
+**Authoring note:** every walk fits the journal's existing skeleton (entries
++ hand-gloss margins + pasted instruments + one p per page), so a leaflet
+costs prose + at most 1–2 new plates once its sculptures exist. Leaflets
+should cross-reference by *station*, not by page, so the grounds stay
+primary.

--- a/docs/design/notebook-handoff/conversations/2026-07-complex-analysis-and-the-three-number-systems.md
+++ b/docs/design/notebook-handoff/conversations/2026-07-complex-analysis-and-the-three-number-systems.md
@@ -1,0 +1,356 @@
+# A Conversation on Complex Analysis, Trig, and the Number Systems of the Plane
+
+*A conversation exploring why trig functions feel unnatural, Euler's formula, conformal maps, the Jacobian, Möbius transformations, the three 2D number systems, and their connection to conic sections.*
+
+---
+
+## Why do trig functions feel unnatural compared to polynomials, exponentials, etc.?
+
+The feeling reports something real, but it pays to locate where it lives. "Naturalness" doesn't reside in the functions; it names a relation between a function and whichever operations you've licensed as primitive. Swap the primitives and the ranking reshuffles. If your primitives amount to the field operations (+, ×, ÷) plus limits, polynomials and rational functions come out native and *everything* transcendental — exp included — looks imported. If your one primitive becomes "solve y′ = y," then exp turns native and trig still drags in an extra ingredient. And if you take the complex exponential as primitive, exp and trig collapse into a single object and the gap between them becomes an artifact of looking along the real axis. So the "etc." in your list already encodes a choice about what counts as cheap, and trig loses on that scoring — not through some intrinsic defect.
+
+Here's the structural version that does the most work. Strip the geometry away and the exponential amounts to *the* homomorphism carrying the additive reals onto the multiplicative positive reals: e^(a+b) = e^a · e^b — addition in, multiplication out, one clean rule. The pair (cos, sin) does the analogous job, but its target sits on the unit *circle* (rotations) rather than on a line (scalings): t ↦ (cos t, sin t) carries the additive reals onto the circle group. Nearly everything that feels foreign about trig falls out of that one swap of target — a line for a circle.
+
+The line stretches forever and has no holes; the circle closes up and wraps. So:
+
+- **Periodicity** comes from the circle closing: travel far enough and you return, hence cos(t) = cos(t + 2π). And merely to *state* the period you have to name π, a transcendental constant with no finite algebraic provenance — it gets imported from the circle itself. Exp never forces such a constant on you.
+
+- You get **two entangled functions** instead of one because you're now tracking a 2-D position (a point on the circle), not a 1-D magnitude. Under differentiation they rotate into each other — sin′ = cos, cos′ = −sin — cycling with period four. Neither closes under d/dx alone; only the pair does. That rotation-under-differentiation is precisely the factor of i you'll meet in a moment.
+
+- The **addition law** looks messy — sin(a+b) = sin a cos b + cos a sin b — for the same reason: it states the rule for *composing rotations*, which reads as one clean operation inside the group but splinters into cross-terms once written in (cos, sin) coordinates. Exp's addition law stays a one-liner because composing scalings is just multiplying.
+
+- The **inverses** misbehave because the circle has a hole. t ↦ (cos t, sin t) wraps the line around the circle infinitely often. Running that backwards — arcsin, arccos — means inverting a many-to-one wrap, so you inherit branch choices and the +2πn ambiguity. ln has none of this, because exp wraps nothing.
+
+Now the dissolution: over the complex numbers the foreignness largely evaporates, because e^(ix) = cos x + i·sin x. The trig functions *are* exponentials — exponentials evaluated along the imaginary axis. exp(real argument) grows; exp(imaginary argument) rotates; one function, different direction of travel in the plane.
+
+A large share of the residual "unnaturalness" is the curriculum's ordering fossilized into intuition. We didn't *derive* these functions from the exponential; we *inherited* them, geometry-first, from roughly two millennia of astronomy and triangle-solving — Hipparchus (~150 BCE), Ptolemy (~150 CE), Aryabhata (~499 CE). The exponential unification only arrived with Euler in the 1740s.
+
+---
+
+## Help me see why Euler's formula has to be that way.
+
+*(No response recorded — question was followed by the next prompt.)*
+
+---
+
+## How did he get there?
+
+Euler's actual route — laid out in the *Introductio in analysin infinitorum* (1748) — didn't begin with the series substitution textbooks now show. It began with de Moivre and a piece of controlled recklessness about infinities.
+
+He had, straight from the angle-addition formulas, de Moivre's relation:
+
+> (cos θ + i sin θ)^n = cos nθ + i sin nθ
+
+Fix a finite angle v and cut it into n equal pieces, θ = v/n:
+
+> cos v + i sin v = (cos(v/n) + i sin(v/n))^n
+
+Now let n grow without bound, so the slice v/n shrinks toward nothing. For an infinitesimal angle the small-angle facts become exact — cos(v/n) → 1 and sin(v/n) → v/n — so the bracket collapses to 1 + i·(v/n), leaving:
+
+> cos v + i sin v = lim_n (1 + iv/n)^n
+
+He had already *defined* the exponential by that very limit:
+
+> e^z = lim_n (1 + z/n)^n, hence e^(iv) = lim_n (1 + iv/n)^n
+
+The two right-hand sides coincide symbol for symbol. So e^(iv) = cos v + i sin v.
+
+**The one-line gloss on why it had to land there:** rotating the point (1, 0) by an infinitesimal angle dθ moves it by i·dθ — perpendicular, scaled by the angle — so multiplication-by-i functions as the generator of rotation. Compounding n such tiny rotations is literally (1 + i·dθ)^n, and "raise (1 + small/n) to the n" *is* the exponential. exp turns a generator into the flow it produces; the generator of rotation happens to be i; therefore the flow reads cos + i sin.
+
+A word on lineage: Roger Cotes had essentially the identity by 1714 (in logarithmic dress — iφ = ln(cos φ + i sin φ)), but it stayed buried because he died at 33. De Moivre (~1707–1722) supplied the power relation but never the compact exponential form; that compaction belongs to Euler.
+
+---
+
+## I can see how de Moivre's formula is useful. But this was because of an interest in complex numbers or angle identities? Was the same learning pain true here?
+
+Neither, really. De Moivre was chasing the **theory of equations**: factoring binomials like xⁿ − 1, locating roots of unity, and the old problem of cutting an arc into n equal parts. The angle identities were machinery he passed *through*; complex numbers were a computational convenience he used but wasn't curious about as objects.
+
+De Moivre's engine wasn't a list of trig identities — it was one algebraic trick. Set x = cos θ + i sin θ and notice:
+
+> x + 1/x = 2 cos θ,  x^n + 1/x^n = 2 cos nθ
+
+From that single substitution every multiple-angle relation falls out as a *consequence* of expanding a power, not as a fact to be drilled.
+
+Two different pains, worth indexing apart. De Moivre's labor (pain₁) was real but *generative*: heroic hand-computation with clumsy notation, results dribbling out across thirty-odd years. Your labor (pain₂) was *consuming his outputs without his engine*: handed the finished identities as a flat catalogue, motivated by triangle-solving, with the generative source amputated.
+
+The territory was never painful. The map you were issued in school just happened to be the one drawn before — or as though no one had ever found — the generative shortcut.
+
+---
+
+## Exp(z) takes exp(x + iy) to exp(x)*exp(iy), so horizontal lines map to rays from the origin and vertical lines wrap in circles of constant radius.
+
+Exactly right — and the asymmetry hiding in how you phrased it is worth keeping. Each horizontal line *lays down* its ray exactly once: e^x runs bijectively over (0, ∞), so the ray gets painted a single time, origin excluded. Each vertical line *winds* its circle infinitely often: e^(iy) comes back every time y advances by 2π. Two different behaviors:
+
+- Horizontals → rays **bijectively**
+- Verticals → circles **∞-to-1**
+
+Put the families together: exp carries the whole rectangular grid of the z-plane onto the whole polar grid of the w-plane — Cartesian coordinates becoming polar coordinates, with x reading off as ln r and y as the angle. And this isn't coincidence: horizontal and vertical lines cross at right angles; rays and circles also cross at right angles. Exp keeps those right angles because it stays **conformal everywhere** — (e^z)′ = e^z never vanishes.
+
+Two consequences:
+
+1. **The puncture:** e^x is never 0, so the origin is the one point no ray and no circle ever reaches. This is exactly why log has nothing to say at 0.
+
+2. **The strips:** because e^(z+2πi) = e^z, a single horizontal strip of height 2π already paints every ray and every circle once. Stack the next strip and it paints the same plane again, infinitely. So log isn't multivalued through some defect; it's multivalued because exp folded infinitely many height-2π strips down onto one punctured plane.
+
+---
+
+## You took the right angle part as an "of course." Also, this seems to beg questions — why is the circle and ray privileged? What about other topologies? Higher dimensional maps? Other differential equations?
+
+**The right angles:** Near any z₀ where f′(z₀) ≠ 0, the map looks like w ≈ f(z₀) + f′(z₀)·(z − z₀) — every little vector sticking out of z₀ gets *multiplied by the single fixed complex number* f′(z₀). Write that number as ρe^(iα); multiplying by it rotates every direction by the same α and scales every length by the same ρ. A transformation that rotates everything equally and scales everything equally is a similarity, and a similarity can't touch angles.
+
+A generic smooth map ℝ²→ℝ² has a Jacobian that's an arbitrary 2×2 matrix — four free numbers — free to stretch one axis more than the other and to shear, mangling angles. Complex-differentiability demands the Jacobian wear the special form [[a, −b],[b, a]] — a scaled rotation, two numbers. That is the Cauchy–Riemann equations seen geometrically. And in ℝⁿ for n ≥ 3 the conformal maps collapse to rigid Möbius transformations (Liouville's theorem) — going up, you *lose* this richness rather than extending it.
+
+**Why circle and ray:** The multiplicative group ℂ\{0} factors as ℝ₊ × S¹, modulus times phase. The ray is the orbit of the scaling part (non-compact — you can scale forever), the circle is the orbit of the rotation part (compact — rotations close up after 2π). The circle holds no deep privilege; it's merely *the* compact connected one-dimensional group, surfacing because ℂ*'s phase direction happens to be compact. Topologically ℂ* is a cylinder, and "circle and ray" are its compact cross-section and its non-compact axis.
+
+**Higher dimensions:** The quaternions ℍ give the next rung. The unit quaternions form S³, a three-sphere, and they double-cover the rotations of 3-space — Hurwitz (1898) showed the normed division algebras have dimension 1, 2, 4, 8 only (ℝ, ℂ, ℍ, 𝕆), then it stops. The umbrella is Lie theory, where exp: 𝔤 → G carries a flat vector space onto a curved group.
+
+**Other differential equations:** The functions live or die by their ODE, and a single sign sets the whole character:
+
+- y″ = −y gives cos/sin, the circle x²+y² = 1, the compact group SO(2)
+- y″ = +y gives cosh/sinh, the *hyperbola* x²−y² = 1, the non-compact SO(1,1) — the Lorentz boost of special relativity
+- y′ = (a cubic in y) gives **elliptic functions** — *doubly* periodic, living on a **torus**, ℂ/Λ
+
+The torus appears the instant you ask for the next differential equation. Your four questions sit closer to one question than they look: the circle was the genus-zero, single-period, compact-rank-one corner of a much larger room, and exp is just the door you happened to walk in through.
+
+---
+
+## You did that too compactedly. C-star, the Jacobian, why that is the definition of differentiable — fill in the picture.
+
+**ℂ\*:** The nonzero complex numbers under *multiplication* form a group. Write each nonzero z in polar form, z = r·e^(iθ). Multiplication splits cleanly: |zw| = |z||w| while arg(zw) = arg z + arg w — moduli multiply, arguments add. So ℂ* factors as ℝ₊ × S¹ — an infinite cylinder. Exp rolls the flat plane onto it, wrapping the imaginary axis around the circle with period 2πi.
+
+**The Jacobian:** Take f: ℂ → ℂ, written in real terms as f = u(x,y) + i·v(x,y). As a plain map of the plane ℝ²→ℝ², "differentiable" means it owns a Jacobian
+
+> J = [ u_x  u_y ; v_x  v_y ]
+
+four independent numbers. Complex differentiability demands that
+
+> f′(z) = lim_{h→0} [f(z+h) − f(z)] / h
+
+exist with the same value no matter which direction h arrives from. On the real line h sidles up from two sides; in the plane it can come along infinitely many directions, even spiraling in.
+
+If the quotient settles on one value c = f′(z), then to first order f(z+h) ≈ f(z) + c·h — the linear part of f *is* multiplication by the one fixed complex number c. Ask what "multiply by c = a + bi" looks like as a real 2×2 matrix:
+
+> (a + bi)(dx + i·dy) = (a·dx − b·dy) + i(b·dx + a·dy)
+
+yielding the matrix [ a, −b; b, a ]. Match against the general Jacobian and you're forced into:
+
+> u_x = v_y  and  u_y = −v_x — **the Cauchy–Riemann equations**
+
+**Your conjugation hunch:** Change coordinates to (z, z̄), treating z = x+iy and z̄ = x−iy as independent inputs. Any smooth f splits:
+
+> df = (∂f/∂z) dz + (∂f/∂z̄) dz̄
+
+The whole condition compresses to:
+
+> f holomorphic ⟺ ∂f/∂z̄ = 0
+
+Holomorphic means *no z̄ anywhere in it.* The prototype of the forbidden ingredient is conjugation itself. For f(z) = z̄:
+
+> [f(z+h) − f(z)] / h = h̄ / h
+
+h̄/h keeps modulus 1 but carries argument −2·arg(h) — coming in along the reals it equals 1, along the imaginaries −1, along the diagonal −i. No common limit. Conjugation is exactly the ingredient whose presence breaks complex-differentiability. **Holomorphic = honestly a function of z, with no secret dependence on z̄.**
+
+---
+
+## What if you just allow conjugation in addition to the other conformal maps — what is the closure?
+
+Closure under *composition*: a holomorphic f is a function of z alone; conjugation flips you between "function of z" and "function of z̄." Every composite lands in exactly one of two bins:
+
+> holomorphic ⊔ antiholomorphic
+
+a system carrying a ℤ/2 grading. The grading *is* orientation: holomorphic maps preserve angles and handedness, antiholomorphic ones preserve angles but flip handedness. Composition can flip parity but can never *mix.* Adjoining conjugation simply adjoins the mirror of everything you already had.
+
+In Jacobian language: the holomorphic maps have Jacobian in ℝ₊·SO(2) — the [a, −b; b, a] matrices, determinant a²+b² > 0. Conjugation contributes a scaled *reflection*, determinant −(a²+b²) < 0. Close those under composition and the derivatives fill out ℝ₊·O(2), the full linear conformal group — every plane similarity, rotations and reflections alike.
+
+At the level of bijections of the sphere: the conformal automorphisms of the Riemann sphere are exactly the Möbius transformations z ↦ (az+b)/(cz+d), the group PSL(2,ℂ). Throw in conjugation and the composition-closure becomes PSL(2,ℂ) ⋊ ℤ/2 — each map a product of inversions in circles, with the parity of inversions reading off the orientation. This extended group coincides with the isometry group of hyperbolic 3-space.
+
+---
+
+## Möbius transformations are orientation preserving?
+
+Yes — every one of them, globally on the Riemann sphere. The reason: z ↦ (az+b)/(cz+d) is a rational function of z with no z̄ anywhere, so it's holomorphic, and for any holomorphic map the real Jacobian determinant equals |f′(z)|² — a modulus squared, hence never negative. Since f′(z) = (ad−bc)/(cz+d)² never vanishes, the determinant stays strictly positive.
+
+What's probably nagging: every Möbius map is a product of inversions in circles, and inversions reverse orientation. Both true; the escape is *parity.* Each inversion flips orientation, so an *even* number of them flips it back: the Möbius transformations are precisely the even products (orientation-preserving), the anti-Möbius maps the odd ones (orientation-reversing).
+
+There's also a terminology trap. Geometric inversion in the unit circle is z ↦ 1/z̄ — it carries a z̄, so it's antiholomorphic and orientation-*reversing*, and it isn't a Möbius transformation. The Möbius z ↦ 1/z (no bar) is holomorphic and orientation-preserving — it factors as circle-inversion followed by reflection across the real axis, two flips that cancel.
+
+---
+
+## What are other "natural" choices for ℝ² → ℝ² functions beyond Jacobian constraints?
+
+"Natural" needs an operational definition. A pointwise Jacobian constraint amounts to choosing a set S ⊆ M₂(ℝ) of permitted matrices and demanding J(p) ∈ S at every point. Here are three honest meanings of "natural," in rising order of how much they ask.
+
+### Natural₁: Matrices you can do arithmetic with
+
+At each point a map does some linear thing to a tiny neighborhood. Demanding that the derivative form a closed number system — of the shape "real part plus something times a special element K" — yields exactly three options, governed by what K² equals.
+
+**K² = −1: Complex numbers.** The special element is a quarter-turn; squaring it lands you at −1 because two quarter-turns reverse you. The "unit circle" is the actual circle, its rotations are ordinary rotations, and this is the one case that forms a genuine *field* — every nonzero element has a reciprocal. That total absence of degenerate elements underwrites all the miracles (a function constrained this way is rigid: pin it on a tiny patch and it's forced everywhere).
+
+**K² = +1: Split-complex numbers (j² = +1).** The special element is a *flip* across a diagonal — flip twice and you're back. Its "circle" is a hyperbola, its "rotations" are Lorentz boosts, and its analogues of sine and cosine are cosh and sinh — precisely the y″ = +y world. But it has a fatal softness: certain nonzero elements multiply to zero along two special diagonal lines, and where that happens rigidity collapses. A function constrained this way splits into two completely independent one-variable functions — one riding each diagonal — which you can wiggle separately without consequence. (Physicists meet exactly this as "left-movers and right-movers" on a string.)
+
+**K² = 0: Dual numbers (ε² = 0).** A nonzero thing that squares to zero. Its "rotations" are *shears* — slide each row sideways in proportion to its height — the way velocities add in pre-relativity physics (Galileo's universe). And a number a + εb automatically drags its own derivative along in the ε-slot, so computing with these numbers computes derivatives *for free.* This is **automatic differentiation** — the thing every machine-learning framework runs on to get gradients.
+
+**The unifying punchline:** The determinant of each number-system's matrix comes out a² + b², a² − b², or a² — definite, indefinite, degenerate — the same three-way split that classifies every equation of this type into **elliptic, hyperbolic, parabolic.** Complex-analytic sits in the elliptic seat, the only one that's rigid, the only field.
+
+### Natural₂: Matrices that preserve some quantity
+
+- *Keep angles* (allow growth and rotation, forbid shear) → complex-analytic
+- *Keep area* (forbid net growth) → maps governing frictionless mechanics, Hamiltonian phase flows
+- *Keep the "no swirl" property* (force the matrix symmetric) → maps that are the gradient of some landscape, the mathematics of **optimal transport**
+- *No swirl and no compression at once* → these matrices are exactly the antiholomorphic Jacobians — "the mirror world" and "smooth incompressible swirl-free fluid flow" are the same constraint, which is why complex analysis solves 2D fluid flow and electrostatics
+- *Keep a chosen direction's family of lines intact* (triangular matrices) → **normalizing flows** in machine learning, chosen because triangular makes the determinant cheap to compute
+- *Keep angles AND lengths, no growth* → the theory freezes into only rigid motions. The lesson: it was the freedom to *grow* that kept angle-preservation alive as a rich theory
+
+**Is this list endless?** No — there's a census. Early-1900s work (Élie Cartan, completed in the 1960s) classified all the natural infinite families on the plane. The complete list: all smooth maps; area-preserving maps; angle-preserving (complex-analytic) maps; and their mirror. Full stop. Everything else preserves a family of lines — and "preserves a family of lines" is precisely why those theories went floppy and decomposed into one-variable pieces.
+
+### Natural₃: Don't forbid distortion, just cap it
+
+The strict theories are knife-edges — *exactly* angle-preserving. Loosen to *nearly:* let infinitesimal circles become ellipses, but with bounded eccentricity. This is **quasiconformality** — the full space of controlled deformations of the rigid theory. A remarkable result (Measurable Riemann Mapping Theorem, Ahlfors–Bers 1960) says *any* prescribed field of ellipse-shapes (so long as none flatten completely) can be realized by a real map.
+
+---
+
+## Why are we not talking about functions where the constraints are on the second derivatives?
+
+The honest answer: we'd quietly committed to a *classification* question, and classification only crystallizes at first order.
+
+**First, why classification needs first order.** The chain rule says the Jacobian of f∘g is the product of the two Jacobians, and matrices multiplying is exactly what let us speak of clubs "closed under composition" and classify them. Second derivatives extend no such courtesy — the chain rule for them tangles the orders together. Constrain the second derivative and the question stops being "list the closed clubs" (algebra) and turns into "solve the equation" (analysis).
+
+**Second, in the plane the marquee second-order theory is secretly the shadow of the first-order one.** The conjugation-detecting operator (∂/∂z̄), composed with its mirror twin, rebuilds the Laplacian (∂²/∂x² + ∂²/∂y²) exactly — the first-order condition is a *square root* of the second-order one. By paying the cheap first-order price we'd already bagged the headline second-order theory for free.
+
+**Make the second derivative primary and you walk into most of geometry and physics:**
+
+- *The same three words in their native home.* The natural linear second-order constraints sort by a single sign into elliptic (Laplace), hyperbolic (wave equation), parabolic (heat equation). Those names were *coined* for these second-order operators; when I pinned them on the three algebras earlier, I was borrowing downward.
+
+- *The same determinant, one floor up.* Take the determinant of the *second*-derivative matrix and you land on the Monge–Ampère equation, which governs surfaces of prescribed curvature and optimal transport. The first-order "gradient map" description was the shadow; the second-order one is the substance.
+
+- *Curvature and physics are irreducibly second-order.* Curvature simply *is* a second derivative. And the rule that selects the "best" shape — least-area soap film, least-action path, field at equilibrium — is, whenever the cost depends on slopes, a second-order equation. That's why nearly every law of physics is second order.
+
+The connection between floors: the rigid first-order theories sit *underneath* the second-order ones as their square roots and building blocks — complex-analytic under harmonic, and every least-area soap film can be *written down* from a pair of complex-analytic functions.
+
+---
+
+## Explain sin(ix) — difference of exponentials?
+
+Yes. Take sin(z) = (e^(iz) − e^(−iz))/(2i) and feed it z = ix:
+
+> e^(i·ix) = e^(−x)  and  e^(−i·ix) = e^(x)
+
+So:
+
+> sin(ix) = (e^(−x) − e^(x))/(2i) = −(e^x − e^(−x))/(2i) = i·sinh(x)
+
+The even twin: cos(ix) = (e^(−x) + e^(x))/2 = cosh(x) — no leftover i, because cos is even and swallows the input rotation whole.
+
+**Why:** Feed sine an *imaginary* argument and circular sine turns into hyperbolic sinh. Watch the two i's do the work: rotate the *input* by 90° (the i inside) and the *output* then lands rotated 90° as well (the i out front). Cos, being even, swallows the input rotation whole and returns on the real axis as cosh; sin, being odd, keeps one i and returns on the imaginary axis.
+
+**The payoff:** Real sine's famous boundedness — never escaping [−1, 1] — is an artifact of looking only along the real axis. Step off it in the perpendicular direction and the very same function grows like sinh, without bound. So complex sine is *unbounded.* The circle and the hyperbola were never two functions; they're two cross-sections of one complex object.
+
+---
+
+## Why does "mapping the complex plane" and "mapping to the unit circle" connect?
+
+A complex number z has been doing two different jobs this whole time. Pull them apart:
+
+A complex number is, in one role, a *place* — a point on the page, x across and y up. You combine places by **adding**, which slides the page around. That's "mapping the complex plane": a flat sheet of addresses.
+
+But a complex number is also an *action* — multiply by it and the whole plane *rotates and zooms.* Among all those actions, the ones that rotate *without* zooming — the pure turns — are exactly the complex numbers of size one. **The unit circle is the rotations of the plane.** Measuring "how much has this been turned" *is* mapping it onto the circle.
+
+What links the two faces is exp, with e^(a+b) = e^a·e^b. It takes the *additive* plane (addresses) and turns it into the *multiplicative* group (actions). Feed it the imaginary direction — addresses straight up the y-axis — and it produces pure rotations: e^(iθ) lands on the unit circle. Feed it the real direction and it produces pure zooms: e^x runs out along the ray.
+
+The two perpendicular axes of the page map onto the two factors of the action-group:
+
+- Real axis → ray (zooming) → cosh, sinh  
+- Imaginary axis → circle (turning) → cos, sin
+
+That last line is the whole reason sin(ix) = i·sinh(x): swapping which axis you feed swaps circle for ray, circular functions for hyperbolic.
+
+And here's where it closes the loop with the Jacobian: every analytic map, up close at any point, does exactly one thing — multiply by its derivative, which in size-and-angle form is ρ·e^(iθ): a zoom ρ times a turn e^(iθ), a point of the unit circle. **Conformality was the unit circle all along** — the local action is an honest rotation, the same turn in every direction.
+
+---
+
+## Why do we treat sin and cos as two different functions when they are "offsets" of each other?
+
+Because "two functions or one?" is the wrong split. They're the two *coordinates* of a single thing — a point going around a circle — and the offset is exactly the fingerprint proving they come from the *same* rotation, not evidence that one is redundant.
+
+Cos and sin do share a *shape*: each is the shadow that uniform circular motion casts on an axis. But same shape is not same information. Cos is the shadow on the x-axis, sin the shadow on the y-axis, and you can't recover a point's location in the plane from one shadow — you need both. The rotation lives in two dimensions; one real number can't track it.
+
+The π/2 offset, far from making them redundant, is precisely what *locks* them as coordinates of one rotation — for two reasons:
+
+1. **Differentiation cycles between them:** sin′ = cos, cos′ = −sin. Differentiating *is* shifting phase by a quarter turn. So "cos is sin offset by π/2" and "cos is the derivative of sin" are the *same sentence.* Neither function is closed under d/dx alone; only the pair is.
+
+2. **They answer two genuinely different initial conditions.** At the start, cos begins at full height with zero speed (a pendulum pulled aside and released); sin begins at zero with full speed (a pendulum struck from rest). A second-order system has exactly two independent pieces of starting data, and cos and sin are the canonical responses to each.
+
+You *can* fuse them — into e^(iθ), one function. But e^(iθ) is valued in 2D, so the pair just becomes the two real parts of one complex number. The solution space is two-dimensional, full stop. Cos and sin are the cleanest, perpendicular pair to carry those two dimensions, and the offset is the statement that they ride in quadrature: two perpendicular shadows of one turning point.
+
+---
+
+## So if multiplying by i is a quarter-turn rotation, is sin(iz) = cos(z)?
+
+No — sin(iz) = i·sinh(z), the same result we got for real x.
+
+Two different "quarter turns" can act on the *argument*, and they aren't the same move:
+
+- **Add π/2 to the argument** (z → z + π/2): a **slide** of the input along the axis. This is the one that turns sin into cos — sin(z + π/2) = cos(z).
+
+- **Multiply the argument by i** (z → iz): a **spin** of the input point 90° about the origin, swinging z off the real axis onto the imaginary one. Swinging the input into the imaginary direction is what trades a circular function for a hyperbolic one.
+
+Sliding by π/2 and spinning by i are different things to do to the input, so they give different outputs.
+
+**But your instinct wasn't empty.** Multiplying by i *does* produce the cos↔sin shift, when it rotates the **output** instead of the input. Multiply the rotating value e^(iθ) by i: i·e^(iθ) = e^(i(θ+π/2)) — phase advanced a quarter turn, cos and sin swapped. For the exponential, "add π/2 to the argument" and "multiply the value by i" are the *same* move, which is exactly why the offset and the i-quarter-turn felt linked.
+
+So it's two roles of i, sharpened: **i on the value advances the phase (cos ↔ sin); i on the argument spins the input (circular ↔ hyperbolic).** You reached for the first and wrote down the second.
+
+---
+
+## Trace out the reasoning of this conversation and connect it to conic sections.
+
+### What we built
+
+We started from an observation — trig feels "unnatural" next to exp, polynomials, inverses — and the first move was dissolving the question itself. "Natural" doesn't name a property sitting inside a function; it names a *relation* between a function and whichever operations you've taken as primitive. Shift the primitives and the ranking reshuffles.
+
+That collapse is Euler: e^(iθ) = cos θ + i sin θ, arriving from de Moivre's limit argument. The i sitting in the exponent and the i that means "quarter-turn rotation" aren't two different things wearing the same symbol; they name the same operation reached by two routes.
+
+From exp(z) = exp(x)·exp(iy) the plane's two directions separate cleanly. The real direction produces scaling — non-compact, never returning. The imaginary direction produces rotation — compact, returning every 2π. The 2πi periodicity isn't a property exp happens to have — it expresses that the rotation group of the plane closes up.
+
+The right-angle preservation at every point came from unpacking the derivative: demanding a direction-independent limit forces the Jacobian into the form [a, −b; b, a] — a scaled rotation. Equivalently: ∂f/∂z̄ = 0 — no conjugate anywhere in the formula.
+
+Adding conjugation produced a ℤ/2 extension: holomorphic (orientation-preserving) and antiholomorphic (orientation-reversing), the Jacobian determinant positive or negative accordingly.
+
+The Jacobian-constraint question yielded a clean trichotomy governed entirely by K²: −1 (complex numbers), 0 (dual numbers), +1 (split-complex numbers). These correlated with PDE type: elliptic, parabolic, hyperbolic. And from ODE: y″ = −y produces circular sin/cos; y″ = +y produces hyperbolic sinh/cosh; y″ = 0 produces linear drift and automatic differentiation.
+
+Sin and cos: not redundant offsets but two independent coordinates of one 2-dimensional rotation. The solution space of y″ = −y has dimension 2; cos and sin are the canonical responses to each initial condition, offset by π/2 because they ride in quadrature.
+
+Sin(ix) = i·sinh(x) expressed the whole unification concretely: multiplying the argument by i spins the input onto the imaginary axis, converting circular functions to hyperbolic ones. Not the same move as adding π/2, which stays in the circular world.
+
+### Where conics enter
+
+The level set "norm = 1" in each algebra:
+
+| Algebra | K² | Unit set |
+|---|---|---|
+| Complex numbers | −1 | **Circle**: a² + b² = 1 |
+| Split-complex | +1 | **Hyperbola**: a² − b² = 1 |
+| Dual numbers | 0 | **Two parallel lines**: a² = 1 (the parabola's degenerate limit) |
+
+These aren't decorative coincidences. The norm in each algebra is a quadratic form in (a, b), and a quadratic form in two variables classifies by its discriminant — negative (definite), positive (indefinite), zero (degenerate) — into exactly those three types. "Discriminant" here is the same discriminant that distinguishes conic sections when you cut a cone with a plane.
+
+The phase portrait of y″ = c·y makes this literally visible. In state space (y, y′):
+
+- c = −1: the trajectory (cos t, −sin t) traces a **circle**
+- c = +1: the trajectory (cosh t, sinh t) traces a **hyperbola**
+- c = 0: the trajectory (1, t) traces a **line** — the parabola's degenerate limit
+
+The conic sections function here not merely as the "unit circles" of the three algebras, but as the *phase-space trajectories* of the canonical motions in each geometry.
+
+**The "why circles and rays" question** — which earlier we answered multiplicatively from ℂ* = ℝ₊ × S¹ — now receives a second answer from the conic side. A circle is the compact conic: it closes up, which forces periodicity in exp(iθ). A ray lives in the degenerate-conic territory, and the non-compactness means no wrapping, no period. Circle and ray are distinguished by one operational fact: does the trajectory close? That's the compactness question, and compactness is conic-type in geometric language.
+
+### The deepest layer
+
+Over ℂ, no non-degenerate conic is different from any other. A projective transformation can convert any of them into any other, because they all pass through the same two "circular points at infinity" in the complex projective plane.
+
+And sin(ix) = i·sinh(x) is exactly that transformation in function-theoretic language. The circular functions and hyperbolic functions aren't two objects — they're one complex function observed along two perpendicular lines through the domain. The circle-trajectory and hyperbola-trajectory in state space are cross-sections of one complex curve. **The real-axis cut gives the circle; the imaginary-axis cut gives the hyperbola; the complex function *is* the cone before cutting.**
+
+The three algebras, the three PDE types, and the three conic sections all index the same underlying trichotomy — the three-way split that elliptic/hyperbolic/parabolic names, wherever you happen to meet it. That split appears so persistently not because mathematicians keep rediscovering the same curiosity, but because it reflects a feature of how quadratic structure on a 2-dimensional space can behave. Whether you approach it through number systems, Jacobian constraints, the geometry of cones and planes, phase portraits, or the signature of a quadratic form — the map changes, the territory doesn't.
+
+---
+
+*Conversation conducted July 2026.*

--- a/docs/design/notebook-handoff/conversations/2026-07-dual-numbers-galilean-autodiff.md
+++ b/docs/design/notebook-handoff/conversations/2026-07-dual-numbers-galilean-autodiff.md
@@ -1,0 +1,2244 @@
+# Dual Numbers, Galilean Spaces, Tropical Algebra, and Automatic Differentiation
+
+**Conversation transcript**  
+**Exported:** July 17, 2026
+
+---
+
+## User
+
+Tell me about dual numbers and Gallalean spaces.
+
+---
+
+## Assistant
+
+I’ll treat “Gallalean” as “Galilean,” unless you intended a specific spelling from a source. I’ll connect the algebra of dual numbers to the geometry of Galilean/degenerate metric spaces.
+
+---
+
+## Assistant
+
+Dual numbers and Galilean spaces fit together because both replace ordinary Euclidean/Lorentzian geometry with a **degenerate** structure. Something has become “invisible” to the quadratic metric.
+
+## 1. Dual numbers
+
+The **dual numbers** are numbers of the form
+
+$$
+a + b\varepsilon
+$$
+
+where $a,b\in\mathbb R$, and
+
+$$
+\varepsilon^2 = 0,\qquad \varepsilon\neq 0.
+$$
+
+So $\varepsilon$ acts like a nonzero infinitesimal whose square vanishes.
+
+Addition works componentwise:
+
+$$
+(a+b\varepsilon)+(c+d\varepsilon)=(a+c)+(b+d)\varepsilon.
+$$
+
+Multiplication gives:
+
+$$
+(a+b\varepsilon)(c+d\varepsilon)
+=ac+(ad+bc)\varepsilon+bd\varepsilon^2
+=ac+(ad+bc)\varepsilon.
+$$
+
+The key feature: when you plug a dual number into a smooth function,
+
+$$
+f(a+b\varepsilon)=f(a)+b f'(a)\varepsilon.
+$$
+
+That happens because the Taylor series stops after the linear term: all $\varepsilon^2,\varepsilon^3,\ldots$ vanish. This makes dual numbers a natural algebraic model for **first-order infinitesimal displacement**. They encode both a value and a tangent direction.
+
+So:
+
+$$
+a+b\varepsilon
+$$
+
+means something like:
+
+> position $a$, with infinitesimal tangent component $b$.
+
+This explains their use in automatic differentiation, kinematics, screw theory, and projective geometry over dual-number rings. Dual quaternions, for example, encode rigid-body motions using dual numbers; this shows up in kinematic geometry and linkage theory. ([arxiv.org](https://arxiv.org/abs/2006.14259?utm_source=chatgpt.com))
+
+## 2. Galilean geometry / Galilean spacetime
+
+A **Galilean space** models classical Newtonian spacetime rather than relativistic spacetime.
+
+In special relativity, spacetime has a nondegenerate metric:
+
+$$
+ds^2 = -c^2dt^2 + dx^2+dy^2+dz^2.
+$$
+
+Time and space mix under Lorentz transformations.
+
+In Galilean spacetime, time stays absolute. A Galilean boost looks like:
+
+$$
+t' = t,\qquad x' = x - vt.
+$$
+
+So different inertial observers disagree about velocity, but they agree about time intervals. The geometric structure therefore separates into:
+
+$$
+\text{absolute time} \quad + \quad \text{Euclidean space on each time-slice}.
+$$
+
+The “metric” becomes degenerate: there is no single ordinary nondegenerate spacetime metric measuring both time and space the way a Lorentzian metric does. Modern treatments often describe Galilean/Newton-Cartan spacetime using degenerate metric structures, with a one-form for time and a spatial metric on the directions transverse to time. Recent geometric-algebra treatments also describe Galilean spacetime via a four-dimensional vector space with a degenerate metric. ([arxiv.org](https://arxiv.org/abs/2401.04205?utm_source=chatgpt.com))
+
+## 3. The simplest 2D Galilean plane
+
+A useful toy model has coordinates $(x,y)$, but distance only sees the $x$-direction first.
+
+One version of Galilean plane geometry treats the “absolute” coordinate like $x$, and the other coordinate like a fiber direction. The metric behaves roughly like:
+
+$$
+ds^2 = dx^2
+$$
+
+rather than
+
+$$
+ds^2 = dx^2 + dy^2.
+$$
+
+So vertical displacement has zero length:
+
+$$
+(0,\Delta y)
+$$
+
+has squared length $0$. But it is not the zero vector. That is the same flavor as dual numbers: $\varepsilon\neq 0$, but $\varepsilon^2=0$.
+
+This is the core analogy:
+
+| Object | Ordinary geometry | Degenerate/Galilean version |
+|---|---:|---:|
+| Number | $a+bi,\ i^2=-1$ | $a+b\varepsilon,\ \varepsilon^2=0$ |
+| Metric | $dx^2+dy^2$ | $dx^2$ |
+| Invisible direction | none | vertical/fiber direction |
+| Infinitesimal behavior | higher powers survive | first-order only |
+
+## 4. Why dual numbers naturally describe Galilean geometry
+
+Think of a point in the dual-number line:
+
+$$
+z = x + y\varepsilon.
+$$
+
+Its “norm” behaves like:
+
+$$
+z\bar z = (x+y\varepsilon)(x-y\varepsilon)=x^2,
+$$
+
+because the $\varepsilon$-part cancels and $\varepsilon^2=0$.
+
+So the dual component $y\varepsilon$ contributes to position, slope, tangent data, or shear-like structure, but not to ordinary squared distance.
+
+That makes the dual-number plane a natural coordinate model for a Galilean plane:
+
+$$
+(x,y) \leftrightarrow x+y\varepsilon.
+$$
+
+The real part $x$ gives the measurable Galilean distance.  
+The dual part $y$ gives a secondary, infinitesimal, fiber, velocity, or tangent-like coordinate.
+
+## 5. Galilean boosts as shear transformations
+
+A Galilean boost in one spatial dimension:
+
+$$
+x' = x - vt,\qquad t'=t
+$$
+
+is a shear. It preserves time but shifts position by something proportional to time.
+
+In matrix form:
+
+$$
+\begin{pmatrix}
+t'\\
+x'
+\end{pmatrix}
+=
+\begin{pmatrix}
+1 & 0\\
+-v & 1
+\end{pmatrix}
+\begin{pmatrix}
+t\\
+x
+\end{pmatrix}.
+$$
+
+This shear-like behavior matches the algebraic feel of dual numbers. Multiplication by a unit dual number,
+
+$$
+1+v\varepsilon,
+$$
+
+also produces a first-order shear-like transformation:
+
+$$
+(1+v\varepsilon)(a+b\varepsilon)
+= a + (b+va)\varepsilon.
+$$
+
+The real part stays fixed; the dual part changes by an amount proportional to the real part. That resembles a Galilean boost: one coordinate remains absolute, while the other gets shifted linearly.
+
+## 6. The conceptual punchline
+
+Dual numbers are to Galilean geometry somewhat like complex numbers are to Euclidean geometry.
+
+Complex numbers satisfy:
+
+$$
+i^2=-1
+$$
+
+and naturally encode rotations and Euclidean geometry.
+
+Dual numbers satisfy:
+
+$$
+\varepsilon^2=0
+$$
+
+and naturally encode tangents, shears, infinitesimals, and degenerate/Galilean geometry.
+
+A compact slogan:
+
+> **Complex numbers encode rotation. Dual numbers encode first-order displacement. Galilean geometry is what happens when one direction counts only to first order.**
+
+Or even more bluntly:
+
+> A Galilean space is a geometry where one coordinate has metric reality, and another coordinate has infinitesimal/tangent/fiber reality.
+
+That is why dual numbers feel like the right algebra for Galilean spaces.
+
+---
+
+## User
+
+Is there a "complex number" with dual number coefficients?
+
+---
+
+## Assistant
+
+Yes. Usually called the **complex dual numbers** or **dual-complex numbers**.
+
+They look like
+
+$$
+z = (a+b\varepsilon) + i(c+d\varepsilon)
+$$
+
+where
+
+$$
+i^2=-1,\qquad \varepsilon^2=0,\qquad i\varepsilon=\varepsilon i.
+$$
+
+You can regroup this as
+
+$$
+z = (a+ic) + (b+id)\varepsilon.
+$$
+
+So it is equivalently:
+
+$$
+\mathbb C[\varepsilon]/(\varepsilon^2)
+$$
+
+meaning: **dual numbers with complex coefficients**.
+
+An element has the form
+
+$$
+z = z_0 + z_1\varepsilon
+$$
+
+with $z_0,z_1\in\mathbb C$.
+
+Multiplication:
+
+$$
+(z_0+z_1\varepsilon)(w_0+w_1\varepsilon)
+=
+z_0w_0+(z_0w_1+z_1w_0)\varepsilon.
+$$
+
+And functions behave beautifully:
+
+$$
+f(z_0+z_1\varepsilon)=f(z_0)+z_1 f'(z_0)\varepsilon
+$$
+
+for holomorphic $f$, assuming $f$ is defined near $z_0$.
+
+So the interpretation:
+
+$$
+z_0+z_1\varepsilon
+$$
+
+means:
+
+> a complex point $z_0$, together with a complex tangent vector $z_1$.
+
+Geometrically, this is the algebra of **first-order infinitesimal neighborhoods in the complex plane**. It is not a field, because $\varepsilon\neq 0$ but $\varepsilon^2=0$, so $\varepsilon$ has no inverse.
+
+There is also a nearby object:
+
+$$
+\mathbb D[i] \cong \mathbb C[\varepsilon]/(\varepsilon^2),
+$$
+
+where $\mathbb D$ denotes the real dual numbers. Same thing, as long as $i$ and $\varepsilon$ commute.
+
+So yes: a “complex number with dual-number coefficients” exists naturally, and the clean notation is
+
+$$
+(a+b\varepsilon)+i(c+d\varepsilon)
+$$
+
+or, better,
+
+$$
+z_0+z_1\varepsilon,\qquad z_0,z_1\in\mathbb C.
+$$
+
+---
+
+## User
+
+And what does that mean, practically speaking? What does exp(z0+z1*eps)? What do I get for the extra two dimensions?
+
+---
+
+## Assistant
+
+Yes. Practically, a complex dual number
+
+$$
+z=z_0+z_1\varepsilon,\qquad z_0,z_1\in\mathbb C,\quad \varepsilon^2=0
+$$
+
+represents:
+
+> a point $z_0$ in the complex plane, plus a tangent vector $z_1$ attached to that point.
+
+So it has four real coordinates:
+
+$$
+z_0 = x+iy,\qquad z_1 = u+iv.
+$$
+
+You can think of it as:
+
+$$
+(x,y)\quad\text{position}
+$$
+
+plus
+
+$$
+(u,v)\quad\text{infinitesimal displacement / velocity / tangent direction}.
+$$
+
+## Exponential
+
+For any analytic function,
+
+$$
+f(z_0+z_1\varepsilon)=f(z_0)+z_1 f'(z_0)\varepsilon.
+$$
+
+For $f(z)=e^z$, since $f'(z)=e^z$,
+
+$$
+e^{z_0+z_1\varepsilon}
+=
+e^{z_0}+z_1 e^{z_0}\varepsilon
+=
+e^{z_0}(1+z_1\varepsilon).
+$$
+
+So the ordinary complex part is just:
+
+$$
+e^{z_0}.
+$$
+
+The dual part is:
+
+$$
+z_1 e^{z_0}.
+$$
+
+That dual part tells you how the infinitesimal tangent vector transforms under the exponential map.
+
+## In real coordinates
+
+Let
+
+$$
+z_0=x+iy,\qquad z_1=u+iv.
+$$
+
+Then
+
+$$
+e^{z_0}=e^x(\cos y+i\sin y).
+$$
+
+The extra dual component is:
+
+$$
+z_1e^{z_0}
+=
+(u+iv)e^x(\cos y+i\sin y).
+$$
+
+Multiplying out:
+
+$$
+z_1e^{z_0}
+=
+e^x\big[(u\cos y-v\sin y)+i(u\sin y+v\cos y)\big].
+$$
+
+So:
+
+$$
+e^{(x+iy)+(u+iv)\varepsilon}
+=
+e^x(\cos y+i\sin y)
++
+e^x\big[(u\cos y-v\sin y)+i(u\sin y+v\cos y)\big]\varepsilon.
+$$
+
+The first two real dimensions give the new point:
+
+$$
+(X,Y)=\big(e^x\cos y,\ e^x\sin y\big).
+$$
+
+The extra two real dimensions give the pushed-forward tangent vector:
+
+$$
+(U,V)=
+\big(
+e^x(u\cos y-v\sin y),
+e^x(u\sin y+v\cos y)
+\big).
+$$
+
+## What the extra two dimensions “mean”
+
+They are not another independent position. They are a **directional perturbation** at the point.
+
+If
+
+$$
+z_0=x+iy
+$$
+
+is your actual point, then
+
+$$
+z_0+z_1\varepsilon
+$$
+
+means:
+
+> start at $z_0$, and remember the infinitesimal direction $z_1$.
+
+After applying $e^z$, the point moves to $e^{z_0}$, and the tangent vector gets transformed by the derivative:
+
+$$
+z_1 \mapsto e^{z_0}z_1.
+$$
+
+So the exponential map does two things:
+
+1. sends the base point $z_0$ to $e^{z_0}$;
+2. sends the attached tangent vector $z_1$ through the local linear approximation of $e^z$.
+
+## Concrete example
+
+Take
+
+$$
+z_0=0,\qquad z_1=1.
+$$
+
+Then
+
+$$
+e^{0+1\varepsilon}=1+\varepsilon.
+$$
+
+The point $0$ maps to $1$.  
+The tangent vector $1$ maps to $1$.
+
+Now take
+
+$$
+z_0=i\pi/2,\qquad z_1=1.
+$$
+
+Then
+
+$$
+e^{i\pi/2+\varepsilon}=i+i\varepsilon.
+$$
+
+The point maps to $i$, and the tangent vector $1$ has been rotated to $i$.
+
+So the extra dimensions tell you the **local differential behavior** of the function at the point.
+
+## Best mental model
+
+A dual-complex number is not really “a 4D number” in the same way a quaternion is.
+
+Better map:
+
+$$
+z_0+z_1\varepsilon
+$$
+
+means:
+
+$$
+\text{point in } \mathbb C
++
+\text{tangent vector in } T_{z_0}\mathbb C.
+$$
+
+So the space of dual-complex numbers is essentially the **tangent bundle of the complex plane**:
+
+$$
+T\mathbb C \cong \mathbb C\times\mathbb C.
+$$
+
+The first $\mathbb C$ gives location.  
+The second $\mathbb C$ gives infinitesimal direction/velocity.
+
+That is the practical meaning: complex dual arithmetic automatically carries along first-order derivative information.
+
+---
+
+## User
+
+Seems like there will be a whole family of these types of numbers for different epsilon^n = 0.
+
+---
+
+## Assistant
+
+Yes. There is a whole family:
+
+$$
+\mathbb R[\varepsilon]/(\varepsilon^n)
+$$
+
+or, over complex numbers,
+
+$$
+\mathbb C[\varepsilon]/(\varepsilon^n).
+$$
+
+These are often called **truncated polynomial rings**, **nilpotent extensions**, or, in geometric contexts, **jet algebras**.
+
+The usual dual numbers are the case
+
+$$
+\varepsilon^2=0.
+$$
+
+That keeps only first-order information:
+
+$$
+a_0+a_1\varepsilon.
+$$
+
+If instead
+
+$$
+\varepsilon^3=0,
+$$
+
+then numbers look like
+
+$$
+a_0+a_1\varepsilon+a_2\varepsilon^2.
+$$
+
+Now you retain information up to **second order**.
+
+More generally, with
+
+$$
+\varepsilon^n=0,
+$$
+
+you get
+
+$$
+a_0+a_1\varepsilon+a_2\varepsilon^2+\cdots+a_{n-1}\varepsilon^{n-1}.
+$$
+
+The Taylor expansion stops automatically:
+
+$$
+f(a_0+a_1\varepsilon+a_2\varepsilon^2+\cdots)
+$$
+
+contains only powers below $\varepsilon^n$. So these objects carry finite Taylor data.
+
+For the simplest case
+
+$$
+x = a + b\varepsilon,
+\qquad \varepsilon^3=0,
+$$
+
+we get
+
+$$
+f(a+b\varepsilon)
+=
+f(a)+bf'(a)\varepsilon+\frac{b^2}{2}f''(a)\varepsilon^2.
+$$
+
+So:
+
+| Algebra | What it carries |
+|---|---|
+| $\varepsilon^2=0$ | value + first derivative / tangent |
+| $\varepsilon^3=0$ | value + first + second derivative |
+| $\varepsilon^4=0$ | value + first + second + third derivative |
+| $\varepsilon^n=0$ | Taylor data through order $n-1$ |
+
+With complex coefficients:
+
+$$
+z=z_0+z_1\varepsilon+z_2\varepsilon^2+\cdots+z_{n-1}\varepsilon^{n-1},
+\qquad z_i\in\mathbb C,
+$$
+
+you get a complex point plus higher-order infinitesimal structure. Geometrically, this corresponds to not just a tangent vector, but a **jet**: a local Taylor-germ-like description of a curve or function near a point.
+
+For example, under the exponential,
+
+$$
+e^{z_0+z_1\varepsilon+z_2\varepsilon^2}
+$$
+
+with $\varepsilon^3=0$ becomes
+
+$$
+e^{z_0}
+\left[
+1
++
+z_1\varepsilon
++
+\left(z_2+\frac{z_1^2}{2}\right)\varepsilon^2
+\right].
+$$
+
+So the extra coefficients transform according to the chain rule, including higher-order terms. First order transforms linearly; second order includes curvature/acceleration-like correction.
+
+The practical interpretation:
+
+$$
+z_0+z_1\varepsilon+z_2\varepsilon^2+\cdots
+$$
+
+means:
+
+> a point $z_0$, plus infinitesimal first-order, second-order, third-order, etc. information attached to it.
+
+So yes: dual numbers are just the first nontrivial member of a ladder of nilpotent number systems. They are finite Taylor calculators built into arithmetic.
+
+---
+
+## User
+
+It also looks like these dual numbers can give you all sorts of "close enough" math. Any relation with tropical algebras?
+
+---
+
+## Assistant
+
+Yes, there is a relation, but not because dual numbers and tropical numbers are the same kind of “approximation.” They encode **different notions of closeness**.
+
+## The shared theme
+
+Both dual-number algebra and tropical algebra come from asking:
+
+> What remains of ordinary algebra when I only care about some coarse or infinitesimal part of the answer?
+
+But they coarse-grain in opposite directions.
+
+## Dual numbers: infinitesimal closeness
+
+Dual numbers keep a value plus infinitesimal correction:
+
+$$
+a+b\varepsilon,\qquad \varepsilon^2=0.
+$$
+
+They say:
+
+> I care about the exact value and the first-order nearby behavior.
+
+So they model **local approximation**:
+
+$$
+f(a+b\varepsilon)=f(a)+bf'(a)\varepsilon.
+$$
+
+This is “close enough” in the differential sense: ignore second-order and higher effects.
+
+Dual numbers answer:
+
+> What happens infinitesimally near this point?
+
+## Tropical algebra: dominant-term closeness
+
+Tropical algebra usually replaces
+
+$$
++ \quad\text{by}\quad \min
+$$
+
+and
+
+$$
+\times \quad\text{by}\quad +
+$$
+
+or sometimes uses $\max$ instead of $\min$.
+
+So in the min-plus convention:
+
+$$
+a\oplus b = \min(a,b),
+$$
+
+$$
+a\odot b = a+b.
+$$
+
+This often arises by taking a logarithmic or valuation limit. For example, if
+
+$$
+x=e^{-A/t},\qquad y=e^{-B/t},
+$$
+
+then as $t\to 0^+$,
+
+$$
+xy=e^{-(A+B)/t},
+$$
+
+so multiplication becomes addition:
+
+$$
+A\odot B=A+B.
+$$
+
+And
+
+$$
+x+y=e^{-A/t}+e^{-B/t}
+$$
+
+is dominated by the larger exponential term, corresponding to smaller exponent:
+
+$$
+A\oplus B=\min(A,B).
+$$
+
+So tropical algebra says:
+
+> I care only about the dominant scale/order of magnitude.
+
+It ignores lower-order terms, not higher derivatives.
+
+## Side-by-side
+
+| System | Keeps | Throws away | Best mental model |
+|---|---:|---:|---|
+| Dual numbers | value + infinitesimal correction | second order and higher | tangent approximation |
+| $\varepsilon^n=0$ numbers | finite Taylor jet | terms order $n$ and above | higher-order local approximation |
+| Tropical algebra | dominant valuation/order | subdominant terms | asymptotic scale approximation |
+
+## Deeper relation: both use “shadow algebra”
+
+A nice unifying abstraction:
+
+- Dual numbers live in a ring with a **nilpotent infinitesimal**:
+  
+  $$
+  \varepsilon^2=0.
+  $$
+
+- Tropical numbers often arise from a ring/field with a **valuation**:
+
+  $$
+  v(xy)=v(x)+v(y),
+  $$
+
+  $$
+  v(x+y)\ge \min(v(x),v(y)).
+  $$
+
+The valuation forgets most of the number and remembers only its leading scale. So tropicalization is a kind of **projection** from ordinary algebra to a coarser algebra of orders.
+
+Dual-numberization is different: it thickens a point with infinitesimal tangent information.
+
+So:
+
+$$
+\text{dual numbers} \approx \text{infinitesimal thickening}
+$$
+
+while
+
+$$
+\text{tropical algebra} \approx \text{asymptotic skeleton}.
+$$
+
+## A bridge: Puiseux / Laurent series
+
+The strongest connection comes through series.
+
+Consider something like a formal series:
+
+$$
+x(t)=c_0t^{\alpha_0}+c_1t^{\alpha_1}+c_2t^{\alpha_2}+\cdots
+$$
+
+with increasing exponents.
+
+A tropical viewpoint often keeps only the leading exponent:
+
+$$
+v(x)=\alpha_0.
+$$
+
+A jet/dual-number viewpoint instead keeps finitely many local coefficients near a point.
+
+So both arise from formal expansions, but choose different summaries:
+
+$$
+\text{tropical: keep leading exponent}
+$$
+
+$$
+\text{jets/dual numbers: keep low-order Taylor coefficients}
+$$
+
+That is probably the cleanest bridge.
+
+## Practical intuition
+
+Suppose you compute a quantity and write it as:
+
+$$
+Q = Q_0 + Q_1\varepsilon + Q_2\varepsilon^2+\cdots
+$$
+
+A dual-number method says:
+
+> Keep $Q_0$ and $Q_1$. That gives value and sensitivity.
+
+A tropical method says something more like:
+
+$$
+Q(t)=3t^2+7t^5+\cdots
+$$
+
+and keeps:
+
+$$
+2
+$$
+
+because $t^2$ gives the leading scale.
+
+So yes, both support “close enough math,” but with different notions of approximation:
+
+- **Dual numbers**: close in position; preserve derivatives.
+- **Tropical algebra**: close in scale; preserve dominant combinatorial structure.
+
+## Best slogan
+
+Dual numbers turn calculus into algebra.
+
+Tropical algebra turns asymptotics into combinatorics.
+
+They are cousins in the larger family of “algebras of approximation,” but they sit on different branches.
+
+---
+
+## User
+
+I thought there as also something where (a + b)^n = a^n + b^n in tropical space, reminiscent of the dual numbers.
+
+---
+
+## Assistant
+
+Yes — you’re thinking of the **freshman’s dream** pattern:
+
+$$
+(a+b)^n = a^n+b^n
+$$
+
+which normally fails over ordinary real/complex numbers because of binomial cross terms:
+
+$$
+(a+b)^n=a^n+\binom n1a^{n-1}b+\cdots+b^n.
+$$
+
+But there are algebraic worlds where the middle terms disappear or collapse.
+
+## 1. Tropical version: addition is idempotent
+
+In tropical algebra, “addition” usually means either max or min. Using max-plus notation:
+
+$$
+a\oplus b=\max(a,b),
+\qquad
+a\odot b=a+b.
+$$
+
+Then tropical powers mean repeated tropical multiplication:
+
+$$
+a^{\odot n}=na.
+$$
+
+Now compute:
+
+$$
+(a\oplus b)^{\odot n}
+=
+n\max(a,b).
+$$
+
+But
+
+$$
+a^{\odot n}\oplus b^{\odot n}
+=
+\max(na,nb).
+$$
+
+These are equal:
+
+$$
+n\max(a,b)=\max(na,nb).
+$$
+
+So in tropical notation:
+
+$$
+(a\oplus b)^n = a^n \oplus b^n.
+$$
+
+This works because tropical addition is **idempotent**:
+
+$$
+a\oplus a=a.
+$$
+
+Repeated copies do not accumulate. Coefficients like $\binom nk$ do not matter the same way they do in ordinary algebra.
+
+## 2. Boolean algebra has the same flavor
+
+Boolean OR/AND also gives:
+
+$$
+a\vee a=a.
+$$
+
+So powers and repeated terms collapse. This is another idempotent algebra. Tropical algebra is a richer numerical version of that idea.
+
+## 3. Finite fields: another freshman’s dream
+
+In characteristic $p$,
+
+$$
+(a+b)^p=a^p+b^p.
+$$
+
+For example over $\mathbb F_p$, all middle binomial coefficients are divisible by $p$:
+
+$$
+\binom pk \equiv 0 \pmod p
+$$
+
+for $0<k<p$.
+
+So here the cross terms vanish because the **coefficients vanish**.
+
+## 4. Dual numbers: related but different
+
+Dual numbers do not generally satisfy
+
+$$
+(a+b)^n=a^n+b^n.
+$$
+
+But they do have a related “cross terms vanish after low order” behavior because
+
+$$
+\varepsilon^2=0.
+$$
+
+For example:
+
+$$
+(a+b\varepsilon)^n
+=
+a^n+n a^{n-1}b\varepsilon.
+$$
+
+Everything involving $\varepsilon^2$ or higher disappears.
+
+So dual numbers keep the **first cross term**, while tropical algebra often collapses to the **dominant term**.
+
+That distinction matters:
+
+$$
+(a+b\varepsilon)^n
+\neq
+a^n+(b\varepsilon)^n
+$$
+
+in general. Since $(b\varepsilon)^n=0$ for $n\ge2$, the right side would just be $a^n$, but the left side has the derivative term:
+
+$$
+n a^{n-1}b\varepsilon.
+$$
+
+So dual numbers do not erase all interaction. They preserve first-order interaction.
+
+## The unifying abstraction
+
+There are several ways to make binomial cross terms disappear:
+
+| Algebraic setting | Why middle terms disappear/collapse |
+|---|---|
+| Tropical / idempotent semiring | repeated addition collapses: $x\oplus x=x$ |
+| Boolean algebra | OR/AND are idempotent |
+| Characteristic $p$ fields | binomial coefficients vanish mod $p$ |
+| Dual numbers | higher-order infinitesimals vanish: $\varepsilon^2=0$ |
+
+Your intuition is good: these systems all modify ordinary arithmetic so that some part of the binomial expansion no longer behaves normally.
+
+But the maps differ:
+
+$$
+\text{tropical: keep the winner}
+$$
+
+$$
+\text{dual: keep the tangent correction}
+$$
+
+$$
+\text{characteristic }p\text{: coefficients vanish mod }p.
+$$
+
+The closest named idea for the tropical case is **idempotent algebra** or **idempotent semiring**. Tropical algebra is one of the central examples.
+
+---
+
+## User
+
+Back a bit. What is this auto diff?
+
+---
+
+## Assistant
+
+**Automatic differentiation** means computing derivatives by running ordinary-looking code while carrying derivative information along with every number.
+
+It is not symbolic differentiation, and it is not numerical finite differences.
+
+It gives derivatives to machine precision by applying the chain rule mechanically through the computation.
+
+## Three ways to get a derivative
+
+Suppose
+
+$$
+f(x)=\sin(x^2+3x).
+$$
+
+### 1. Symbolic differentiation
+
+A system rewrites the formula:
+
+$$
+f'(x)=\cos(x^2+3x)(2x+3).
+$$
+
+Good for algebraic expressions, but awkward for large programs with loops, branches, arrays, etc.
+
+### 2. Finite differences
+
+Approximate:
+
+$$
+f'(x)\approx \frac{f(x+h)-f(x)}{h}.
+$$
+
+Simple, but numerically fragile. Too large $h$: inaccurate. Too small $h$: floating-point cancellation.
+
+### 3. Automatic differentiation
+
+Run the computation while carrying a pair:
+
+$$
+\text{value} + \text{derivative}\cdot \varepsilon.
+$$
+
+This is where dual numbers enter.
+
+Let
+
+$$
+x = a + 1\varepsilon.
+$$
+
+Then
+
+$$
+f(a+\varepsilon)=f(a)+f'(a)\varepsilon.
+$$
+
+So after evaluating the ordinary function using dual numbers, the real part gives $f(a)$, and the $\varepsilon$-coefficient gives $f'(a)$.
+
+## Example
+
+Take
+
+$$
+f(x)=x^2+3x.
+$$
+
+Evaluate at $x=5$ using
+
+$$
+x=5+\varepsilon.
+$$
+
+Then
+
+$$
+x^2=(5+\varepsilon)^2=25+10\varepsilon+\varepsilon^2=25+10\varepsilon.
+$$
+
+And
+
+$$
+3x=15+3\varepsilon.
+$$
+
+So
+
+$$
+f(5+\varepsilon)=40+13\varepsilon.
+$$
+
+Meaning:
+
+$$
+f(5)=40,
+$$
+
+$$
+f'(5)=13.
+$$
+
+Indeed,
+
+$$
+f'(x)=2x+3,
+$$
+
+so
+
+$$
+f'(5)=13.
+$$
+
+## For nested functions
+
+Now take
+
+$$
+g(x)=\sin(x^2+3x).
+$$
+
+We already found
+
+$$
+x^2+3x=40+13\varepsilon.
+$$
+
+Then
+
+$$
+\sin(40+13\varepsilon)
+=
+\sin(40)+13\cos(40)\varepsilon.
+$$
+
+So:
+
+$$
+g(5)=\sin(40),
+$$
+
+$$
+g'(5)=13\cos(40).
+$$
+
+The chain rule happened automatically.
+
+## What autodiff does in code
+
+A number becomes a little object:
+
+```python
+class Dual:
+    def __init__(self, value, deriv):
+        self.value = value
+        self.deriv = deriv
+```
+
+Then arithmetic rules propagate derivatives:
+
+```python
+def add(x, y):
+    return Dual(x.value + y.value, x.deriv + y.deriv)
+
+def mul(x, y):
+    return Dual(
+        x.value * y.value,
+        x.deriv * y.value + x.value * y.deriv,
+    )
+
+def sin(x):
+    return Dual(
+        math.sin(x.value),
+        math.cos(x.value) * x.deriv,
+    )
+```
+
+So when your program computes a value, it also computes the derivative.
+
+## Forward-mode autodiff
+
+The dual-number version is called **forward-mode automatic differentiation**.
+
+You seed one input direction:
+
+$$
+x = a + 1\varepsilon
+$$
+
+and then compute one directional derivative.
+
+For a function
+
+$$
+f:\mathbb R^n\to\mathbb R^m,
+$$
+
+forward mode efficiently computes:
+
+$$
+Jv
+$$
+
+where $J$ is the Jacobian and $v$ is an input direction.
+
+Best when there are **few inputs** or you need directional derivatives.
+
+## Reverse-mode autodiff
+
+Modern machine learning usually uses **reverse-mode autodiff**, also called **backpropagation**.
+
+For
+
+$$
+f:\mathbb R^n\to\mathbb R
+$$
+
+with many inputs and one scalar output, reverse mode efficiently computes the full gradient:
+
+$$
+\nabla f.
+$$
+
+That is why neural networks use it: millions or billions of parameters, one loss function.
+
+Forward mode asks:
+
+> If I perturb the input this way, how does the output change?
+
+Reverse mode asks:
+
+> How sensitive is the output to every intermediate quantity and input?
+
+## Practical meaning
+
+Autodiff lets you write a computation normally, then get exact derivatives of that computation.
+
+Used for:
+
+- neural network training
+- optimization
+- curve fitting
+- physical simulation
+- probabilistic modeling
+- differentiable programming
+- sensitivity analysis
+- scientific computing
+
+For your mental map:
+
+$$
+\text{dual numbers} \rightarrow \text{forward-mode autodiff}
+$$
+
+$$
+\text{chain rule on computation graph} \rightarrow \text{reverse-mode autodiff / backprop}
+$$
+
+The dual-number story gives the cleanest conceptual entrance: autodiff works because numbers can be enlarged to carry derivative information, and ordinary arithmetic then propagates that information automatically.
+
+---
+
+## User
+
+You brushed a lot of stuff under the rug please unpack.
+
+---
+
+## Assistant
+
+Fair. I compressed several distinct ideas into “carry derivative information along.” Here is the unpacked version.
+
+## 1. AD differentiates a *computation*, not merely a formula
+
+Suppose you write:
+
+```python
+def f(x, y):
+    u = x * y
+    v = sin(u)
+    w = x * x
+    return v + w
+```
+
+Mathematically this computes
+
+$$
+f(x,y)=\sin(xy)+x^2.
+$$
+
+But automatic differentiation does not need to symbolically rewrite the whole expression. It treats the program as a sequence of primitive operations:
+
+$$
+u = xy
+$$
+
+$$
+v = \sin(u)
+$$
+
+$$
+w = x^2
+$$
+
+$$
+L = v+w
+$$
+
+Then it applies local derivative rules to each step.
+
+So AD works because a big computation is a composition of small differentiable pieces.
+
+## 2. Forward-mode AD: carry a tangent with every value
+
+In forward mode, every variable carries two pieces of data:
+
+$$
+\text{value},\quad \text{tangent}
+$$
+
+or symbolically:
+
+$$
+x+\dot{x}\varepsilon
+$$
+
+where
+
+$$
+\varepsilon^2=0.
+$$
+
+The ordinary part is the value. The $\varepsilon$-coefficient is the derivative/tangent.
+
+For example, if
+
+$$
+x = a+\dot{x}\varepsilon,
+\qquad
+y=b+\dot{y}\varepsilon,
+$$
+
+then multiplication gives:
+
+$$
+xy
+=
+(a+\dot{x}\varepsilon)(b+\dot{y}\varepsilon)
+$$
+
+$$
+=
+ab + a\dot{y}\varepsilon + b\dot{x}\varepsilon + \dot{x}\dot{y}\varepsilon^2.
+$$
+
+Since
+
+$$
+\varepsilon^2=0,
+$$
+
+this becomes:
+
+$$
+xy = ab + (a\dot{y}+b\dot{x})\varepsilon.
+$$
+
+That $\varepsilon$-coefficient is exactly the product rule:
+
+$$
+\frac{d}{dt}(xy)=x\frac{dy}{dt}+y\frac{dx}{dt}.
+$$
+
+So the nilpotent rule $\varepsilon^2=0$ is not decorative. It enforces “keep first-order terms, discard second-order terms.”
+
+## 3. The tangent is usually a directional derivative
+
+For a one-variable function,
+
+$$
+f:\mathbb R\to\mathbb R,
+$$
+
+you seed
+
+$$
+x=a+1\varepsilon.
+$$
+
+Then
+
+$$
+f(a+\varepsilon)=f(a)+f'(a)\varepsilon.
+$$
+
+The $\varepsilon$-coefficient is $f'(a)$.
+
+For a many-variable function,
+
+$$
+f:\mathbb R^n\to\mathbb R^m,
+$$
+
+you seed a direction vector
+
+$$
+v=(v_1,\ldots,v_n).
+$$
+
+That means you replace each input by
+
+$$
+x_i = a_i+v_i\varepsilon.
+$$
+
+Then AD computes
+
+$$
+f(a+v\varepsilon)=f(a)+J_f(a)v\varepsilon.
+$$
+
+So the $\varepsilon$-coefficient is not necessarily the whole Jacobian. It is the **Jacobian-vector product**:
+
+$$
+Jv.
+$$
+
+This matters.
+
+Forward-mode AD naturally answers:
+
+> If I nudge the input in direction $v$, how does the output change?
+
+To get $\partial f/\partial x_j$, choose
+
+$$
+v=e_j,
+$$
+
+the basis vector in the $j$-th coordinate.
+
+To get a full gradient of a scalar function with $n$ inputs using simple forward mode, you usually need $n$ passes, one for each basis direction. Or you carry an $n$-dimensional tangent vector with every variable, which amounts to doing those directions in parallel.
+
+## 4. Worked forward-mode example
+
+Take
+
+$$
+f(x,y)=\sin(xy)+x^2.
+$$
+
+Evaluate at
+
+$$
+x=2,\qquad y=3.
+$$
+
+Suppose we want $\partial f/\partial x$. Seed:
+
+$$
+x=2+1\varepsilon,
+\qquad
+y=3+0\varepsilon.
+$$
+
+Now compute step by step.
+
+First:
+
+$$
+u=xy=(2+\varepsilon)(3)=6+3\varepsilon.
+$$
+
+Then:
+
+$$
+v=\sin(u)=\sin(6+3\varepsilon).
+$$
+
+Using
+
+$$
+\sin(a+b\varepsilon)=\sin(a)+b\cos(a)\varepsilon,
+$$
+
+we get:
+
+$$
+v=\sin(6)+3\cos(6)\varepsilon.
+$$
+
+Next:
+
+$$
+w=x^2=(2+\varepsilon)^2=4+4\varepsilon.
+$$
+
+Finally:
+
+$$
+L=v+w
+$$
+
+$$
+L=\sin(6)+4 + \left(3\cos(6)+4\right)\varepsilon.
+$$
+
+Therefore:
+
+$$
+f(2,3)=\sin(6)+4,
+$$
+
+and
+
+$$
+\frac{\partial f}{\partial x}(2,3)=3\cos(6)+4.
+$$
+
+That matches the symbolic derivative:
+
+$$
+\frac{\partial}{\partial x}\left[\sin(xy)+x^2\right]
+=
+y\cos(xy)+2x.
+$$
+
+At $(2,3)$:
+
+$$
+3\cos(6)+4.
+$$
+
+The point: AD got this without forming the symbolic expression.
+
+## 5. Reverse-mode AD: propagate sensitivities backward
+
+Forward mode pushes tangents forward:
+
+$$
+\text{input perturbation} \longrightarrow \text{output perturbation}.
+$$
+
+Reverse mode does the opposite. It pulls sensitivities backward from the output.
+
+For the same computation:
+
+$$
+u=xy
+$$
+
+$$
+v=\sin(u)
+$$
+
+$$
+w=x^2
+$$
+
+$$
+L=v+w
+$$
+
+reverse mode asks:
+
+> How much does $L$ depend on each intermediate variable?
+
+We introduce adjoints:
+
+$$
+\bar{x}=\frac{\partial L}{\partial x},
+\qquad
+\bar{u}=\frac{\partial L}{\partial u},
+$$
+
+and so on.
+
+Start with:
+
+$$
+\bar{L}=1.
+$$
+
+Because
+
+$$
+L=v+w,
+$$
+
+we get:
+
+$$
+\bar{v} += 1,
+\qquad
+\bar{w} += 1.
+$$
+
+Because
+
+$$
+w=x^2,
+$$
+
+we get:
+
+$$
+\bar{x} += \bar{w}\cdot 2x.
+$$
+
+Because
+
+$$
+v=\sin(u),
+$$
+
+we get:
+
+$$
+\bar{u} += \bar{v}\cdot \cos(u).
+$$
+
+Because
+
+$$
+u=xy,
+$$
+
+we get:
+
+$$
+\bar{x} += \bar{u}\cdot y,
+$$
+
+$$
+\bar{y} += \bar{u}\cdot x.
+$$
+
+Putting it together:
+
+$$
+\frac{\partial L}{\partial x}
+=
+2x+y\cos(xy),
+$$
+
+$$
+\frac{\partial L}{\partial y}
+=
+x\cos(xy).
+$$
+
+Same derivatives, different direction of accumulation.
+
+## 6. Why reverse mode matters for machine learning
+
+For a scalar-output function
+
+$$
+f:\mathbb R^n\to\mathbb R,
+$$
+
+the gradient has $n$ components:
+
+$$
+\nabla f=
+\left(
+\frac{\partial f}{\partial x_1},
+\ldots,
+\frac{\partial f}{\partial x_n}
+\right).
+$$
+
+Forward mode naturally computes one directional derivative:
+
+$$
+Jv.
+$$
+
+For a scalar output, $J$ is a row vector, so $Jv$ is one number. To reconstruct the whole gradient, simple forward mode needs many directions.
+
+Reverse mode, by contrast, can compute the whole gradient of a scalar output in one backward sweep, up to a small constant-factor overhead relative to evaluating the original function.
+
+That is why neural networks use reverse-mode AD. They have millions or billions of parameters and usually one scalar loss.
+
+So:
+
+$$
+\text{few inputs, many outputs} \Rightarrow \text{forward mode is attractive}
+$$
+
+$$
+\text{many inputs, one output} \Rightarrow \text{reverse mode is attractive}
+$$
+
+$$
+\text{many inputs, many outputs} \Rightarrow \text{full Jacobian is expensive either way}
+$$
+
+## 7. The clean abstraction: JVPs and VJPs
+
+Modern AD systems often talk about two primitives.
+
+Forward mode computes a **Jacobian-vector product**:
+
+$$
+Jv.
+$$
+
+This is called a **JVP**.
+
+Reverse mode computes a **vector-Jacobian product**:
+
+$$
+v^T J.
+$$
+
+This is called a **VJP**.
+
+For scalar loss functions, reverse mode starts with
+
+$$
+v=1
+$$
+
+at the output and returns
+
+$$
+1^T J = \nabla f.
+$$
+
+That is backpropagation.
+
+## 8. Why this is not finite differences
+
+Finite differences approximate:
+
+$$
+f'(x)\approx \frac{f(x+h)-f(x)}{h}.
+$$
+
+That has a step-size problem.
+
+Too large $h$: truncation error.
+
+Too small $h$: floating-point cancellation.
+
+AD does not choose $h$. It does not compare two nearby function values. It propagates derivative information exactly through the primitive operations of the program.
+
+So for
+
+$$
+f(x)=x^2,
+$$
+
+finite differences compute something like:
+
+$$
+\frac{(x+h)^2-x^2}{h}
+=
+2x+h.
+$$
+
+Then one hopes $h$ is small enough.
+
+Dual-number AD computes:
+
+$$
+(x+\varepsilon)^2=x^2+2x\varepsilon.
+$$
+
+The derivative coefficient is exactly
+
+$$
+2x.
+$$
+
+No limiting process.
+
+## 9. Why this is not symbolic differentiation
+
+Symbolic differentiation tries to rewrite expressions:
+
+$$
+\sin(x^2+3x)
+\mapsto
+\cos(x^2+3x)(2x+3).
+$$
+
+AD does not need to produce that formula.
+
+It just evaluates the program while carrying derivative data.
+
+That means AD handles code structures that symbolic systems find annoying:
+
+```python
+for i in range(100):
+    x = tanh(A @ x + b)
+```
+
+AD does not need to simplify this into a closed expression. It differentiates the executed sequence of operations.
+
+But the flip side: AD usually gives derivatives **at a point**, not a nice closed-form expression.
+
+## 10. The “exact derivative” claim needs qualification
+
+When people say AD gives “exact derivatives,” they usually mean:
+
+> exact derivatives of the implemented sequence of elementary operations, up to ordinary floating-point arithmetic.
+
+It does **not** mean:
+
+> exact derivative of the mathematical ideal you had in your head.
+
+For example, suppose your program approximates a function using 20 iterations of an algorithm. AD differentiates the 20-iteration computation, not necessarily the limiting function.
+
+Suppose your code has an `if` statement:
+
+```python
+if x > 0:
+    return x
+else:
+    return 0
+```
+
+That is ReLU:
+
+$$
+f(x)=\max(0,x).
+$$
+
+At $x>0$, the derivative is 1.
+
+At $x<0$, the derivative is 0.
+
+At $x=0$, the derivative is not classically defined.
+
+An AD framework may return 0, 1, or a chosen subgradient depending on implementation. That value is a convention, not a mathematical theorem.
+
+So the precise statement is:
+
+> AD gives mechanically correct chain-rule derivatives through the executed differentiable primitives, with framework-defined behavior at nonsmooth points.
+
+## 11. What happens with branches and loops?
+
+Loops are usually fine.
+
+If your program says:
+
+```python
+for i in range(10):
+    x = sin(x) + x*x
+```
+
+AD differentiates all 10 iterations.
+
+Dynamic loops can also work in many systems:
+
+```python
+while x > threshold:
+    x = update(x)
+```
+
+But there is a subtlety: the derivative follows the executed path. It generally does not account for how the number of loop iterations changes discontinuously when $x$ crosses a threshold.
+
+Branches behave similarly. AD differentiates the branch that actually happened.
+
+So a program like:
+
+```python
+if x > 0:
+    y = x*x
+else:
+    y = -x
+```
+
+has two local derivatives:
+
+$$
+2x \quad \text{on the positive branch}
+$$
+
+and
+
+$$
+-1 \quad \text{on the negative branch}.
+$$
+
+At the boundary, AD needs a convention or fails to represent the discontinuity.
+
+## 12. What dual numbers have to do with tangent bundles
+
+The dual-number expression
+
+$$
+x+\dot{x}\varepsilon
+$$
+
+should not be read as “a weird real number.”
+
+A better reading is:
+
+$$
+\text{base point} + \text{tangent vector}.
+$$
+
+So evaluating $f$ on dual numbers means lifting $f$ to the tangent bundle:
+
+$$
+f: M\to N
+$$
+
+becomes
+
+$$
+Tf: TM\to TN.
+$$
+
+For ordinary Euclidean spaces:
+
+$$
+T\mathbb R^n\cong \mathbb R^n\times\mathbb R^n.
+$$
+
+An input consists of:
+
+$$
+(x,\dot{x}).
+$$
+
+The output is:
+
+$$
+(f(x), Df_x(\dot{x})).
+$$
+
+That second component is the pushed-forward tangent vector.
+
+This is the geometric heart of forward-mode AD.
+
+## 13. Reverse mode lives in the cotangent world
+
+Forward mode pushes tangent vectors forward.
+
+Reverse mode pulls covectors backward.
+
+Geometrically:
+
+$$
+\text{forward mode}:\quad TM\to TN
+$$
+
+$$
+\text{reverse mode}:\quad T^*N\to T^*M
+$$
+
+For a scalar-valued function
+
+$$
+f:\mathbb R^n\to\mathbb R,
+$$
+
+the output cotangent starts as
+
+$$
+1\in T^*_{f(x)}\mathbb R.
+$$
+
+Pulling that back gives:
+
+$$
+df_x\in T_x^*\mathbb R^n,
+$$
+
+which is the gradient covector.
+
+That is the geometric reason reverse mode is the right shape for scalar losses.
+
+## 14. Higher derivatives
+
+Dual numbers with
+
+$$
+\varepsilon^2=0
+$$
+
+carry first-order information.
+
+If you want higher derivatives, you can use higher nilpotents:
+
+$$
+\varepsilon^3=0,
+$$
+
+$$
+\varepsilon^4=0,
+$$
+
+and so on.
+
+For example, with
+
+$$
+\varepsilon^3=0,
+$$
+
+we keep terms through $\varepsilon^2$:
+
+$$
+f(a+b\varepsilon)
+=
+f(a)+bf'(a)\varepsilon+\frac{b^2}{2}f''(a)\varepsilon^2.
+$$
+
+More generally, truncated polynomial arithmetic carries Taylor jets.
+
+Modern AD systems often compute higher derivatives by composing forward and reverse mode:
+
+$$
+\text{forward-over-reverse}
+$$
+
+$$
+\text{reverse-over-forward}
+$$
+
+For example, Hessian-vector products are often much cheaper than forming the full Hessian.
+
+## 15. What about complex numbers?
+
+For holomorphic functions,
+
+$$
+f:\mathbb C\to\mathbb C,
+$$
+
+complex dual numbers work cleanly:
+
+$$
+f(z_0+z_1\varepsilon)
+=
+f(z_0)+z_1f'(z_0)\varepsilon.
+$$
+
+So
+
+$$
+z_1
+$$
+
+is a complex tangent vector.
+
+But many useful complex-valued computations are not holomorphic. For example:
+
+$$
+f(z)=\bar{z}
+$$
+
+or
+
+$$
+f(z)=|z|^2
+$$
+
+do not behave like holomorphic complex functions.
+
+Then you should treat
+
+$$
+z=x+iy
+$$
+
+as two real variables:
+
+$$
+(x,y)\in\mathbb R^2.
+$$
+
+AD still works, but the derivative is a real Jacobian, or one may express it using Wirtinger derivatives. The naive holomorphic rule only applies to holomorphic operations.
+
+## 16. How real AD systems implement this
+
+There are two common implementation styles.
+
+One is **operator overloading**. You create a special number object that carries value and derivative, and overload `+`, `*`, `sin`, `exp`, etc. That mirrors the dual-number story.
+
+The other is **tracing / source transformation**. The system records the computation graph or transforms the program into another program that computes derivatives.
+
+For reverse mode, the system usually does a forward pass, stores intermediate values, then performs a backward pass. The stored values matter because local derivative rules often need them. For example, differentiating
+
+$$
+u=xy
+$$
+
+backward requires knowing the primal values of $x$ and $y$.
+
+That creates the classic reverse-mode tradeoff:
+
+$$
+\text{fast gradients}
+$$
+
+but
+
+$$
+\text{memory cost from storing intermediates}.
+$$
+
+Techniques like checkpointing trade extra recomputation for lower memory.
+
+## 17. The rug lumps, in one table
+
+| Slogan | What it hides |
+|---|---|
+| “AD computes derivatives automatically” | It differentiates the executed primitive operations, not necessarily the mathematical ideal |
+| “Dual numbers give derivatives” | They give forward-mode directional derivatives, i.e. JVPs |
+| “Backprop is AD” | Backprop is reverse-mode AD specialized to scalar losses / neural networks |
+| “Exact derivatives” | Exact chain-rule derivatives up to floating-point arithmetic and implementation choices |
+| “Works on code” | Smooth primitives work cleanly; branches, discontinuities, mutation, randomness, and solvers need care |
+| “Complex AD works” | Clean for holomorphic functions; otherwise treat complex values as pairs of real variables |
+| “Higher derivatives are possible” | Yes, but cost and representation grow; Hessian-vector products often beat full Hessians |
+
+## The compact version
+
+Automatic differentiation works because every elementary operation has a local linear approximation.
+
+Forward mode carries that local linear approximation forward with the values:
+
+$$
+(x,\dot{x})\mapsto(f(x), Df_x\dot{x}).
+$$
+
+Dual numbers implement exactly that:
+
+$$
+x+\dot{x}\varepsilon.
+$$
+
+Reverse mode runs the computation forward, then propagates output sensitivities backward:
+
+$$
+\bar{y}\mapsto \bar{y}D f_x.
+$$
+
+That is why forward mode naturally computes directional derivatives, while reverse mode naturally computes gradients of scalar losses.
+
+Confidence: high.
+
+---
+
+## User
+
+can you please write out the full content of this conversation to a markdown file and/or pdf for download?
+
+---
+
+## Assistant
+
+I’ll compile the full dual-numbers/autodiff thread into a clean Markdown transcript and a matching PDF.

--- a/docs/design/notebook-handoff/conversations/README.md
+++ b/docs/design/notebook-handoff/conversations/README.md
@@ -1,0 +1,18 @@
+# The seed conversations
+
+Two conversations supplied by Dan on 2026-07-17 — the first named by him as
+"the seed for this entire study," the second a follow-on of related themes.
+(Their export stamps read July 2026; the seed status is Dan's statement of
+lineage, not a timestamp claim.) Saved **verbatim** — primary sources for
+the journal (`public/number-planes/journal.html`) and for
+[`../THE-UNFOLDING.md`](../THE-UNFOLDING.md), which indexes them as Step 0.
+
+| File | What it is |
+|---|---|
+| `2026-07-complex-analysis-and-the-three-number-systems.md` | **The seed.** Starts from "why do trig functions feel unnatural?"; dissolves the question (naturalness names a relation to chosen primitives, not a property); Euler's actual route to e^(iθ); exp as Cartesian→polar; conformality = the Jacobian forced to a scaled rotation; then the pivotal turn — "what are other *natural* choices for ℝ²→ℝ² beyond Jacobian constraints?" — yields the trichotomy K² = −1, 0, +1 (complex/dual/split · elliptic/parabolic/hyperbolic · circle/parallel-lines/hyperbola) and closes by tracing its own reasoning into conic sections ("the complex function *is* the cone before cutting"). The number-plane trichotomy is first met here **as the classification of arithmetically-closed Jacobians** — a residue of a different question. |
+| `2026-07-dual-numbers-galilean-autodiff.md` | The follow-on (exported 2026-07-17): dual numbers ↔ Galilean/degenerate geometry (boost = shear; z·z̄ = x² — one direction invisible to the metric), complex-dual numbers as the tangent bundle of ℂ, the ε^n jet ladder, tropical algebra as a *different* algebra of approximation (idempotency vs nilpotency vs characteristic p — three ways to kill cross terms), and forward/reverse autodiff. Feeds the dual-world card, the autodiff seal, and the tropical postmark. |
+
+Provenance note: Dan's later seed phrasing — "When I think of 'the number
+plane' I think of complex numbers… are there other options?" — descends from
+the first conversation's trichotomy; the session archive picks up from there
+(THE-UNFOLDING.md Step 1, 2026-06-20).

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,24 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟣 decision · 02:00 — Ground the entries in the RECORDED evolution, not an invented arc
+**Why:** Dan pointed at the session notes as the true source: "There are already
+some examples in place of how this sort of process evolved… conversations that
+are recorded in our session notes that provide a very good idea of how we get
+to one animation from the other. So the question started with: 'When I think
+of the number plane I think of complex numbers.' Are there other options?"
+
+That seed question is the real entry 01. The probe's six entries used an
+invented question-arc (grounded in card math but not in the project's actual
+history); the journal's time dimension should instead follow the recorded
+chain — Argand app birth (06-20) → five-hat review + the Number Planes page
+plan (06-24) → the rename (06-25) → first guide page + trail (06-29) → the
+living-notebook design conversations (07-03) → reviews + leak plan (07-08) →
+notebook complete (07-13). Dispatched a mining workflow (7 readers over the
+~30 session files + a git historian, then a chronology-threading synthesis)
+to extract the verbatim Dan quotes, driving questions, findings, and artifact
+dates with citations. Entries get rewritten from that chain.
+
 ### 🟡 milestone · 01:30 — The journal probe is built and verified headless
 **Why:** the scaffold + drafted entries Dan asked for exist and pass every check.
 

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,34 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟣 decision · 04:30 — The sculpture-garden reading; three walks designed
+**Why:** Dan, in discussion mode: the seed conversation's flow is "erratic
+and idiosyncratic… ideally the journey for any user is its own unique pass
+through these concepts — sculpture garden? … a room that opens up off of
+complex analysis (and there is no privileged direction to the door, what is
+in and what is out)." Then: "generate three paths through this and suggest
+different ways of approaching the material."
+
+Discussion landed on: grounds primary (cards + instruments + adjacencies),
+every linear presentation a *leaflet*; the journal = leaflet #1, the
+founder's recorded walk (its erraticness is authenticity, not flaw); the
+sculptures are the instruments (walk-around, no inherent order — Dan's
+"circling" is the sculpture-garden behavior); one sample walk still ships
+because pure free-wander already failed once (June-24 web → single-thread
+reversal). The unprivileged door is structurally true both ways (annex vs
+entrance hall; ℂ = the p<0 room's interior) and echoes inversion swapping
+inside/outside the unit circle.
+
+Designed and committed `docs/design/notebook-handoff/WALKS.md`: three
+walks distinguished by what the visitor trusts at the gate and where the
+knob appears — **Residents' Walk** (senses; knob last; needs the dual-world
+interior built), **Analysis Door** (theorems; knob as the door; needs the
+wiggle test + Jacobian microscope; = entry 00 expanded), **Machines Walk**
+(tools; knob hidden in hardware; needs the dual-number calculator +
+rapidity meter), plus the Quadratic Thread kept as a drawer sketch, and a
+ranked shared build inventory (dual interior first — a placard with no
+furniture).
+
 ### 🟡 milestone · 03:40 — The seed conversations arrive; the journal gains entry 00
 **Why:** Dan uploaded the two chat transcripts (the share links were
 sandbox-blocked) and named the first "the seed for this entire study."

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,19 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟣 decision · 02:15 — The record is the style, not the script
+**Why:** Dan, refining the grounding directive: "this is still a
+'construction' so while that is the 'style' we do not have to literally
+follow my precise chain of unfolding. the goal is clarity with fun and
+excitement of learning together."
+
+So the mined chain feeds the entries as *material and register* — real
+questions, real quotes, real dead ends where they serve — but each entry is
+constructed for clarity and the excitement of discovery, free to reorder,
+compress, or invent beats when that teaches better. "Learning together" =
+the reader rides alongside the unfolding (which the no-reader-address voice
+already supports); it is a feel, not a switch to didactic address.
+
 ### 🟣 decision · 02:00 — Ground the entries in the RECORDED evolution, not an invented arc
 **Why:** Dan pointed at the session notes as the true source: "There are already
 some examples in place of how this sort of process evolved… conversations that

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -6,11 +6,12 @@ title: Number Planes notebook — directional pivot
 branch: claude/number-plane-directional-pivot-za1hzy
 slug: number-plane-directional-pivot-za1hzy
 status: in-progress
-build: unknown
+build: passed
 followup: null
 pr: null
 app: number-plane, docs
-next: Dan to define what the "directional pivot" is — a new direction for the notebook presentation.
+signals: needs-dan, phone-needed
+next: Dan reads journal.html (the entry-format probe) and rewrites the six drafted entries in his own voice.
 ---
 
 # Number Planes notebook — directional pivot
@@ -29,6 +30,93 @@ has since **merged** (`531bbe5` is on this branch's base), so this session
 starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
+
+### 🟡 milestone · 01:30 — The journal probe is built and verified headless
+**Why:** the scaffold + drafted entries Dan asked for exist and pass every check.
+
+`public/number-planes/journal.html` — six entries, ~29KB, chapter skeleton
+(guide-theme tokens, all 8 skins). Verified per R1 with a scratchpad shooter
+(`jshoot.mjs`, patterns from S03): desktop 1280 + phone 390 screenshots
+eyeballed; p driven via `window.__journal.setP` to +1 and re-shot (knob,
+level-curve, roots, header all track); Daylight light-skin shot; invariants —
+zero horizontal overflow, and the flip-card faces' boxes ≡ the vat's box at
+exactly 150px (the iOS definite-height rule; the sole `.vat` here carries a
+fixed height at every width). `npm run build` passes. Gotcha rediscovered: the
+guide skin key `animath:v1:chrome:skin` stores the **raw id** (not JSON), and
+`shoot.mjs` force-rewrites its arg into a `#/` hash route, so static pages
+need their own shooter. Fonts fail sandbox-only (known).
+
+Draft prose = placeholder register for Dan to rewrite; the math is from the
+cards (L1, AX, L2, PL, DV, QD) and is meant to survive the rewrite.
+
+### 🟢 code · 01:00 — journal.html: the entry format, built as a probe
+**Why:** Dan chose scaffold + drafted entries; this is the reversible probe
+(R2) enacting the fusion register.
+
+The format decisions, each mapping a piece of Dan's description:
+
+- **Entries in time**: one inked timeline down the left, a dot per entry lit
+  by scroll (IntersectionObserver); entry labels are non-literal time
+  (`ENTRY 02 · NEXT DAY`, `· A GOOD DAY`) — order, not dates.
+- **Sacred-text fusion**: each entry is a two-column grid — central working
+  prose (Newsreader, ≤60ch) + a hand-font gloss margin. **Backward refs live
+  in the prose; forward refs are `later —` margin notes** (`.mgn.later`,
+  voice-colored, left-ruled): the notebook conceit that the writer came back
+  and annotated, which is how a real notebook points forward. On phone the
+  margin folds under the prose as left-bordered slips.
+- **Plates used sparingly**: figures are "pasted in" (`.fig`, ±0.35° rotate,
+  mono `FIG. n` labels): the ×(−1) mirror (drag a), a taped-in worked
+  computation (strangers, zero divisors), **the j² knob** (chapter grammar,
+  same geometry), the unit-curve x²−p·y²=1, and t²=p roots — for p<0 the two
+  roots float **off the line** as hollow dots on the j-axis ("one floor up"),
+  which stages FTA honestly. One sealed orb (FTA) as the only flip card.
+- **One p per page** honored: entries 4–6 all read the single S.p; the knob
+  is its writer (chips in entry 5 too — all projections of p).
+- Cover: journal added as the first side-door leaf (doors grid → 2×2).
+
+Content arc (all grounded in the cards): the wrong question (L1) → the
+demands force the line (L3/L4/AX) → the strangers experiment (L2, logged as
+a disappointment) → one knob (PL) → three worlds, strangers resolved (DV) →
+the quadratic + sealed FTA (QD). The "disappointment → resolution" thread
+across entries 3→5 is the format's proof: it shows why time-order teaches
+something the spatial grids can't.
+
+### 🟣 decision · 00:40 — The three forks settled (voice · structure · deliverable)
+**Why:** asked Dan before building; his answers pin the register.
+
+1. **Voice** — "why would I address myself in a notebook?": the natural
+   notebook register. Working prose that thinks on the page, dropped-subject
+   ("Wrote the demands down…"), never addressing a reader as "you", no
+   didactic "we"; reflection appears only as it would. This intentionally
+   diverges from the cards' "we/you" house voice — the cards keep theirs;
+   the two registers are distinguishable on purpose.
+2. **Structure** — "a fusion of plates and the journal format… both sparingly
+   and in the correct register — see some of the examples like sacred text":
+   not journal-vs-chapters but one page where sparse central prose and
+   pasted-in plates share the space, margins carrying the glosses.
+3. **Deliverable** — scaffold + drafted entries (placeholder prose for Dan to
+   rewrite; something concrete to react to).
+
+### 🟣 decision · 00:20 — The pivot defined: the notebook needs voice + entries in time
+**Why:** Dan named the direction he'd been avoiding and now wants.
+
+Dan: he was avoiding a style that "felt like a webpage or had too much
+narration," but the notebook **does need voice** — written explanation that ties
+together "how the different parts arise from questions on top of questions and
+we find things out and play with them along the way." Format: **a notebook with
+entries in time** — not literal in the time dimension or presentation, but
+digestible chunks of small answers that tie into the bigger picture, navigable
+forward and back, with "things from before and things that come after" visible.
+
+Orientation finding: the card spec (`cards-reference/README.md`) already says
+"order is a *view*; the graph lives in each card's `links`" — but every view
+built so far is **spatial** (plate grids/chapters, the cover, the walk-in). The
+pivot asks for the missing **temporal** view: an entry spine that linearizes
+the card graph (`opens` / `leans-on` edges are latent question-arrows) into a
+narrated sequence. The card voice spec says "we/you — never autobiographical
+I"; an entries-in-time journal may bend that — flagged as an open question for
+Dan, along with whether the journal becomes the primary reading path or a
+parallel one beside the chapters.
 
 ### 🟡 milestone · 00:00 — Session started, oriented, awaiting the pivot
 **Why:** /start-session on a fresh branch; the focus names a "directional pivot"

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,30 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟡 milestone · 06:10 — PR #251 opened (stacked) + the notebook packaged for Dan's side project
+**Why:** Dan asked for the PR "to the notebook branch" and a one-place
+package to refine the text offline.
+
+**Stacking discovery:** the real `main` does NOT contain the notebook — PR
+#246 merged into `number-plane-guide` (the stack trunk), and this branch
+descends from that trunk (531bbe5 = #246's merge commit). An accidental
+`merge origin/main` (started before checking, per finalize habit) was
+ABORTED — it dragged Division Bells/Trinary into the diff, exactly what the
+stacked-branch rule warns about. PR #251 opened with base
+`number-plane-guide`: https://github.com/piyarsquare/animath/pull/251.
+The trunk's own merge to main (#244) is where the notebook eventually goes
+live.
+
+**Package** (delivered as number-planes.zip, 308K/106 files; built in the
+scratchpad, not committed): `site/` (all pages self-contained — theme files
+copied in, `../guide-*` paths rewritten), `text/` (MANUSCRIPT.md — journal/
+cover/dual prose extracted from the RENDERED pages via puppeteer so it
+can't drift, margins tagged `[later]`; plus the 38 canonical card .md's),
+`record/` (THE-UNFOLDING, WALKS, seed conversations, design-handoff README,
+S03 handoff), `designs/` (pristine .dc.html references). README maps
+package↔repo paths and states the text-first workflow + port-back
+invariants (one p per page, definite flip heights, resting glosses).
+
 ### 🟢 code · 05:30 — The dual room built (first interior) + the pocket dial
 **Why:** Dan: some knobs must be reachable everywhere (knob + level curves +
 the square of the j vector); wants autodiff examples; wants the dual seen

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -8,7 +8,7 @@ slug: number-plane-directional-pivot-za1hzy
 status: in-progress
 build: passed
 followup: null
-pr: null
+pr: https://github.com/piyarsquare/animath/pull/251
 app: number-plane, docs
 signals: needs-dan, phone-needed
 next: Dan reads journal.html (the entry-format probe) and rewrites the six drafted entries in his own voice.

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -1,0 +1,56 @@
+---
+kind: progress
+session: 2026-07-16-S01
+date: 2026-07-16
+title: Number Planes notebook — directional pivot
+branch: claude/number-plane-directional-pivot-za1hzy
+slug: number-plane-directional-pivot-za1hzy
+status: in-progress
+build: unknown
+followup: null
+pr: null
+app: number-plane, docs
+next: Dan to define what the "directional pivot" is — a new direction for the notebook presentation.
+---
+
+# Number Planes notebook — directional pivot
+
+## Session purpose
+
+Continue work on the Number Planes notebooks (`public/number-planes/`), with a
+**directional pivot** — a change of direction Dan will specify at session start.
+
+## Previous session
+
+[2026-07-13-S03 — notebook complete](../../handoff/number-plane-notebook-kxvxzj/2026-07-13-S03-notebook-complete.md):
+the whole notebook shipped — cover + chapters I·II·III + cards + walk-in, with
+the void/touch/phone fixes and the iOS flip-card definite-height fix. PR #246
+has since **merged** (`531bbe5` is on this branch's base), so this session
+starts from main with the notebook landed. First tracked session on this branch.
+
+## Working notes
+
+### 🟡 milestone · 00:00 — Session started, oriented, awaiting the pivot
+**Why:** /start-session on a fresh branch; the focus names a "directional pivot"
+whose content isn't yet specified — orientation first, no implementation.
+
+Read the S03 handoff (notebook complete, PR #246 now merged) and the backlog.
+Open notebook items inherited from S03 / TODO.md, in rough priority order:
+
+- **iPhone confirmation** of the flip-card fix (1ae28f9) — `phone-needed`,
+  though the PR merged.
+- **Harvest notebook.html** keeper animations into the chapters (told-FOIL →
+  C2's Hmm seam; settle-the-dots; cover fold; Hmm? pop-out), then retire it.
+- **Leak/re-grid annex** (S02 plan, reviewed adopt-with-corrections) — blocked
+  on Dan's prototype or an approved rebuild.
+- **Leaf-ification** of DV and L2 (QD is the model).
+- **Shared notebook.css** extraction (4 pages × ~30KB duplicated skeleton; a
+  fifth page triggers it).
+- **The 274KB working-copy port** — unstarted, a project of its own.
+
+Standing constraints carried forward: one p per page; flip cards need
+**definite heights** (iOS Safari resolves `height:100%` against
+min-height-only boxes as zero); glosses rest visible by design (don't
+"restore" hover-only); copy chapter-3's skeleton for any new chapter page.
+
+Awaiting Dan's direction on what the pivot is.

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,34 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟢 code · 05:30 — The dual room built (first interior) + the pocket dial
+**Why:** Dan: some knobs must be reachable everywhere (knob + level curves +
+the square of the j vector); wants autodiff examples; wants the dual seen
+"from either side as a common degeneracy."
+
+`public/number-planes/dual.html` — chapter skeleton, page p defaults to 0
+(home), every plate listens as p roams. **The mathematical find that
+organizes the page:** the j-slot of f(a + b·j) IS the derivative-estimator
+family — centered finite difference at p>0 (samples on the rails at a±h,
+h=b√p), exact forward-mode AD at p=0 (no samples, no limit), and the
+complex-step derivative at p<0 (samples one floor up, Im f(a+ih)/h; the
+journal's entry-06 motif recurs) — so "approached from either side as a
+common degeneracy" is literally numerical differentiation converging to
+autodiff. Plates: AD hub (4 presets, draggable a, step-b slider, estimate
+vs true tangent, error readout), GR Galilean ruler (N = x²−p·y², vertical
+invisible at home), SH composer (angles/velocities/rapidities add), DG wall
+(curve + mirror at −p + the wall), claim plate, 6 seals (jets · screws ·
+tropical · Galileo · backprop · lineage — Clifford/Study/Yaglom/
+Squire–Trapp/Wengert, standard attributions only). The **pocket dial**
+(knob + mini level-curve + the j² landing dot) is position:sticky — the
+everywhere-reachable cluster, prototyped here; rolling it across all pages
+is the follow-up that should trigger the shared notebook.css extraction.
+Cover gains the dual-room leaf. Verified headless: p = 0 / +1 / −0.4 / 0.4
+states coherent (error 0.549→0 as p→0 on sin 3x), phone 390px overflow
+fixed (row-plates stack), flip faces ≡ vat at definite heights, build
+green. Bugs caught by eyeballing: slope line overrun, "+ −" sign clash,
+"velocity vs add" plural clash — all fixed. `signals: phone-needed` stands.
+
 ### 🟣 decision · 04:30 — The sculpture-garden reading; three walks designed
 **Why:** Dan, in discussion mode: the seed conversation's flow is "erratic
 and idiosyncratic… ideally the journey for any user is its own unique pass

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,31 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟡 milestone · 03:00 — The chain mined (287 moments → 17 steps) and the entries regrounded
+**Why:** the workflow returned; the record is now citable and the journal
+constructs from it.
+
+The mining pass (8 readers + threading synthesis, 287 moments) reconstructed
+the full question-chain 06-20 → 07-16 with verbatim Dan quotes, 17 recorded
+dead ends, and provenance caveats — committed as
+`docs/design/notebook-handoff/THE-UNFOLDING.md` (source material beside the
+cards; intro carries Dan's construction license). Key finds fed straight into
+the journal rewrite: entry 01 now opens on the true seed ("When I think of
+'the number plane,' I think of complex numbers… are there other options?" —
+its staged descendant is the cover's question, now cross-linked); entry 03
+carries Dan's recorded constraints question as a "from the record" margin
+mark (the marginalia register the notebook already established: revision
+marks, not narration); entry 04's margin quotes "the family was a slider
+before it was a theory"; entry 05 closes on the recorded resolution — split
+multiplication IS slot-by-slot in its diagonal basis; the trichotomy measures
+how much the axes entangle. Re-verified headless (desktop shot eyeballed,
+invariants pass, build green).
+
+Blocked/waiting: two shared chat conversations Dan pointed at (chatgpt.com +
+claude.ai share links) are unreachable from the sandbox (network-policy 403 /
+Cloudflare challenge) — asked Dan to paste or commit them; THE-UNFOLDING.md
+notes their absence.
+
 ### 🟣 decision · 02:15 — The record is the style, not the script
 **Why:** Dan, refining the grounding directive: "this is still a
 'construction' so while that is the 'style' we do not have to literally

--- a/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
+++ b/docs/sessions/progress/number-plane-directional-pivot-za1hzy/2026-07-16-S01-notebook-directional-pivot.md
@@ -31,6 +31,26 @@ starts from main with the notebook landed. First tracked session on this branch.
 
 ## Working notes
 
+### 🟡 milestone · 03:40 — The seed conversations arrive; the journal gains entry 00
+**Why:** Dan uploaded the two chat transcripts (the share links were
+sandbox-blocked) and named the first "the seed for this entire study."
+
+Saved verbatim under `docs/design/notebook-handoff/conversations/` (+ README
+provenance note — seed status is Dan's lineage claim, not a timestamp claim;
+the exports stamp July 2026). The true origin predates the plane question:
+the study began as a *complaint about trigonometry*, which dissolved
+("naturalness names a relation to the licensed primitives, not a property"),
+and the trichotomy K² = −1, 0, +1 was met almost in passing as the answer to
+"what are other natural choices for ℝ²→ℝ² beyond Jacobian constraints?" —
+a residue that became the whole subject. The second transcript (dual/
+Galilean/tropical/autodiff) feeds the dual-world card, the autodiff seal,
+and the tropical postmark. THE-UNFOLDING.md gained a Step 0 indexing both;
+the journal gained **ENTRY 00 · FOUND LATER, FILED FIRST — "a complaint
+about trigonometry"** (the conceit is the honest provenance: the seed
+surfaced after the pages were underway), with later-margins pointing at
+entry 04 (the special element's square became the knob) and entry 05 (the
+three curves became fig. 4). Header now ENTRIES 00–06. Re-verified headless.
+
 ### 🟡 milestone · 03:00 — The chain mined (287 moments → 17 steps) and the entries regrounded
 **Why:** the workflow returned; the record is now citable and the journal
 constructs from it.

--- a/public/number-planes/dual.html
+++ b/public/number-planes/dual.html
@@ -1,0 +1,562 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Number Planes · the dual room</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='13' fill='none' stroke='%235fa8ff' stroke-width='3'/%3E%3Ccircle cx='16' cy='3' r='3' fill='%234cc878'/%3E%3C/svg%3E">
+<link rel="stylesheet" href="../guide-theme.css">
+<script src="../guide-skin.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..700;1,6..72,200..700&family=Caveat:wght@400..700&family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Space+Grotesk:wght@400..700&family=Shadows+Into+Light&family=VT323&display=swap" rel="stylesheet">
+<style>
+/* ═══════════════════════════════════════════════════════════════
+   The dual room — the first world INTERIOR (p = 0 is home), built
+   on the chapter skeleton. The page's p defaults to 0 but the
+   sticky POCKET DIAL (knob + level curve + the j² landing point —
+   the everywhere-reachable core cluster, per Dan) lets you lean
+   out both windows: every plate degenerates/regenerates as p
+   roams. Centerpiece: the derivative-estimator hub — the j-slot
+   of f(a + b·j) IS centered difference (p>0) · exact autodiff
+   (p=0) · complex step (p<0). One formula, one dial.
+   ═══════════════════════════════════════════════════════════════ */
+@keyframes pr-pulse{0%,100%{opacity:.3}50%{opacity:1}}
+html,body{margin:0;padding:0}
+*{box-sizing:border-box}
+.nbr{
+  --desk:color-mix(in srgb, var(--bg) 88%, #000);
+  --deskimg:radial-gradient(120% 90% at 50% -10%,
+    color-mix(in srgb, var(--bg) 88%, var(--fg)) 0%, var(--bg) 55%,
+    color-mix(in srgb, var(--bg) 90%, #000) 100%);
+  --paper:var(--card); --paper2:color-mix(in srgb, var(--card) 93%, var(--fg));
+  --grid:color-mix(in srgb, var(--fg) 7%, transparent);
+  --border:var(--rule); --border-strong:color-mix(in srgb, var(--fg) 34%, transparent);
+  --ink:var(--fg); --dim:var(--muted); --dim2:color-mix(in srgb, var(--muted) 70%, var(--bg));
+  --live:var(--accent2); --live-soft:color-mix(in srgb, var(--accent2) 13%, transparent);
+  --voice:var(--accent); --seal:var(--accent); --seal-fg:var(--bg);
+  --d1:light-dark(#2b57c9, #5fa8ff);
+  --ok:light-dark(#149e57, #4cc878);
+  --d5:light-dark(#bd5f1c, #ff9a5f);
+  --hand:'Caveat',cursive; --serif:'Newsreader',Georgia,serif;
+  --mono:'Space Mono',monospace; --disp:'Space Grotesk',sans-serif;
+  --spd:0.75;
+}
+[data-theme="light"] .nbr{--live:#2f6df0; --voice:#9a4a32; --d1:#3565c8; --ok:#4a7d46; --d5:#b0592a}
+[data-theme="primary"] .nbr{--live:#1f4fd6; --voice:#e63327; --d1:#2b57c9; --ok:#149e57; --d5:#e6731f}
+[data-theme="blueprint"] .nbr{--d1:#c9a8ff; --ok:#7fe0a8; --d5:#ffab7a;
+  --hand:'Shadows Into Light',cursive; --serif:'Space Grotesk',sans-serif}
+[data-theme="phosphor"] .nbr{--d1:#5adcff; --ok:#9dff5a; --d5:#ffa05a;
+  --hand:'VT323',monospace; --serif:'Space Mono',monospace}
+
+/* the pocket dial — sticky, so the core knobs are reachable everywhere */
+.pocket{position:sticky;top:0;z-index:40;background:color-mix(in srgb, var(--desk) 88%, transparent);
+  backdrop-filter:blur(6px);-webkit-backdrop-filter:blur(6px);
+  border-bottom:1px solid var(--border);margin:0 calc(-1 * clamp(14px,3.5vw,56px));
+  padding:8px clamp(14px,3.5vw,56px)}
+.pocket-in{width:min(1160px,100%);margin:0 auto;display:flex;align-items:center;gap:14px;flex-wrap:wrap}
+/* flip plates */
+.vat{perspective:1000px;cursor:pointer}
+.vat .in{position:relative;width:100%;height:100%;transform-style:preserve-3d;
+  transition:transform calc(.55s / var(--spd)) cubic-bezier(.3,.85,.35,1)}
+.vat[data-on="1"] .in{transform:rotateY(180deg) !important}
+.vat:not([data-on="1"]):hover .in{transform:rotateY(-11deg);transition-timing-function:cubic-bezier(.3,1.25,.45,1)}
+.vat.sm:not([data-on="1"]):hover .in{transform:rotateY(-20deg)}
+.fgl{opacity:.62;transition:opacity .3s ease}
+.vat:hover .fgl{opacity:1}
+.vat .fc,.vat .bk{position:absolute;inset:0;backface-visibility:hidden;-webkit-backface-visibility:hidden;
+  border:1px solid var(--border);border-radius:2px;background:var(--paper);padding:9px 11px;
+  display:flex;flex-direction:column}
+.vat:hover .fc{border-color:var(--border-strong)}
+.vat .bk{transform:rotateY(180deg);border-color:var(--border-strong);background:var(--paper2)}
+button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:pointer}
+.pill{font-family:var(--mono);font-size:10px;border:1px solid var(--border);border-radius:3px;padding:2px 7px}
+.pill[data-on="1"]{color:var(--live);border-color:var(--live);background:var(--live-soft)}
+.plate{position:relative;background:var(--paper);border:1px solid var(--border);border-radius:2px;
+  padding:10px 12px;display:flex;flex-direction:column}
+.plab{font-family:var(--mono);font-size:8px;letter-spacing:.22em;color:var(--dim);
+  display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.plab .pulse{width:5px;height:5px;border-radius:50%;background:var(--live);
+  animation:pr-pulse 2.6s ease-in-out infinite;flex:none}
+.hand{font-family:var(--hand);font-size:14.5px;color:var(--dim)}
+.plategrid{display:grid;grid-template-columns:repeat(5,208px);grid-auto-rows:208px;
+  gap:12px;justify-content:start}
+.sealgrid{display:grid;grid-template-columns:repeat(3,1fr);grid-template-rows:repeat(2,1fr);gap:8px}
+@media (hover:none){
+  .fgl{opacity:.85}
+  .vat:not([data-on="1"]):hover .in,.vat.sm:not([data-on="1"]):hover .in{transform:none}
+}
+@media (max-width:1140px){
+  .plategrid{grid-template-columns:repeat(2,minmax(0,1fr));grid-auto-rows:auto;gap:10px}
+  .plategrid>div{grid-column:auto !important;grid-row:auto !important;min-height:0}
+  #plateAD{grid-column:1/-1 !important;min-height:560px}
+  #plateGR,#plateSH,#plateDG{min-height:0;flex-direction:column !important;align-items:stretch !important}
+  #plateGR svg,#plateSH svg,#plateDG svg{width:min(200px,100%);max-height:200px;margin:0 auto;flex:none}
+  #plateWALL{grid-column:1/-1 !important;min-height:170px}
+  .sealgrid{grid-column:1/-1 !important;grid-template-rows:none;grid-template-columns:repeat(2,1fr)}
+  /* definite heights: flip faces live in a height:100% wrapper — iOS resolves
+     that against min-height-only boxes as ZERO (see chapter pages) */
+  .sealgrid .vat{height:150px !important}
+}
+@media (max-width:700px){
+  #hdrRead{white-space:normal !important;text-align:right}
+  #plateGR,#plateSH,#plateDG{grid-column:1/-1 !important}
+}
+@media (prefers-reduced-motion: reduce){*{transition:none !important;animation:none !important}}
+</style>
+</head>
+<body>
+<div class="nbr" id="nbr" style="min-height:100vh;background-color:var(--desk);background-image:var(--deskimg);padding:0 clamp(14px,3.5vw,56px) 80px;color:var(--ink);font-family:var(--serif);">
+<div style="width:min(1160px,100%);margin:0 auto;display:flex;flex-direction:column;gap:20px;">
+
+  <header style="display:flex;align-items:baseline;gap:16px;flex-wrap:wrap;padding-top:30px;">
+    <h1 style="margin:0;font-family:var(--disp);font-weight:600;font-size:26px;letter-spacing:-.015em;">Number Planes &middot; the dual room</h1>
+    <span style="font-family:var(--mono);font-size:9px;letter-spacing:.3em;color:var(--dim);">THE FIRST INTERIOR &middot; p = 0 IS HOME &middot; LEAN OUT EITHER WINDOW</span>
+    <span style="margin-left:auto;display:flex;align-items:center;gap:14px;">
+      <span id="hdrRead" style="font-family:var(--mono);font-size:11px;color:var(--live);white-space:nowrap;"></span>
+      <span id="skin-picker"></span>
+    </span>
+  </header>
+
+  <!-- ══ the pocket dial: knob + level curve + the j² landing point ══ -->
+  <div class="pocket">
+    <div class="pocket-in">
+      <svg id="psl" viewBox="0 0 600 30" style="display:block;flex:1;min-width:220px;max-width:560px;touch-action:none;cursor:pointer;user-select:none;">
+        <line x1="14" y1="15" x2="300" y2="15" stroke="var(--d1)" stroke-width="4" stroke-linecap="round" opacity=".55"></line>
+        <line x1="300" y1="15" x2="586" y2="15" stroke="var(--d5)" stroke-width="4" stroke-linecap="round" opacity=".55"></line>
+        <circle cx="300" cy="15" r="3.5" fill="var(--ok)"></circle>
+        <g id="pTicks"></g>
+        <circle id="pk1" cx="300" cy="15" r="9" fill="var(--paper2)" stroke="var(--ok)" stroke-width="2.4"></circle>
+        <circle id="pk2" cx="300" cy="15" r="2.5" fill="var(--ok)"></circle>
+      </svg>
+      <svg id="pocketLvl" viewBox="-46 -46 92 92" style="display:block;height:64px;width:64px;flex:none;">
+        <line x1="-42" y1="0" x2="42" y2="0" stroke="var(--dim2)" stroke-width="1"></line>
+        <line x1="0" y1="-42" x2="0" y2="42" stroke="var(--dim2)" stroke-width="1"></line>
+        <path id="pkCurve" fill="none" stroke-width="1.8"></path>
+        <circle cx="18" cy="0" r="1.8" fill="var(--ink)"></circle>
+        <circle id="pkJ2" cx="-18" cy="0" r="2.6" fill="var(--ok)"></circle>
+      </svg>
+      <span style="display:flex;flex-direction:column;gap:1px;flex:none;">
+        <span id="pkRead" style="font-family:var(--mono);font-size:12px;font-weight:700;"></span>
+        <span id="pkName" style="font-style:italic;font-size:13.5px;"></span>
+        <span class="hand" style="font-size:13px;">j&sup2; lands at the dot &larr;</span>
+      </span>
+    </div>
+  </div>
+
+  <div class="hand" style="font-size:16.5px;margin-top:-4px;">the wall between the two houses &mdash; where the neighbors&rsquo; approximations become exact. home is <span style="font-family:var(--mono);font-size:13px;color:var(--ok);">p = 0</span>; drag the knob to lean out either window and watch every plate degenerate back to it.</div>
+
+  <div class="plategrid">
+
+    <!-- ══ AD · the derivative machine, hub 3×3 ══ -->
+    <div class="plate" id="plateAD" style="grid-column:1/4;grid-row:1/4;">
+      <div class="plab"><span class="pulse"></span><span>AD &middot; THREE WAYS TO TAKE A DERIVATIVE &mdash; THE j-SLOT OF f(a + b&middot;j)</span>
+        <span style="flex:1;"></span>
+        <button class="pill fpill" data-f="0">x&sup2;+3x</button>
+        <button class="pill fpill" data-f="1">sin 3x</button>
+        <button class="pill fpill" data-f="2">x&sup3;&minus;2x</button>
+        <button class="pill fpill" data-f="3">e^(x/2)</button>
+      </div>
+      <svg id="adPlot" viewBox="0 0 560 330" style="display:block;width:100%;flex:1;min-height:0;touch-action:none;user-select:none;">
+        <g id="adGrid"></g>
+        <line id="adAxX" stroke="var(--dim2)" stroke-width="1"></line>
+        <path id="adCurve" fill="none" stroke="var(--dim)" stroke-width="2"></path>
+        <line id="adTrue" stroke="var(--dim2)" stroke-width="1.4" stroke-dasharray="3 4"></line>
+        <line id="adEst" stroke-width="2.6"></line>
+        <line id="adStem1" stroke="var(--dim2)" stroke-width="1" stroke-dasharray="2 3"></line>
+        <line id="adStem2" stroke="var(--dim2)" stroke-width="1" stroke-dasharray="2 3"></line>
+        <circle id="adS1" r="5" fill="transparent" stroke-width="2"></circle>
+        <circle id="adS2" r="5" fill="transparent" stroke-width="2"></circle>
+        <circle id="adA" r="9" fill="var(--live-soft)" stroke="var(--live)" stroke-width="2" style="cursor:grab;"></circle>
+        <text id="adFloor" font-family="var(--hand)" font-size="14" fill="var(--d1)" opacity="0">samples one floor up</text>
+      </svg>
+      <div style="display:flex;align-items:center;gap:8px;flex-wrap:wrap;margin:2px 0;">
+        <span style="font-family:var(--mono);font-size:9px;letter-spacing:.18em;color:var(--dim);">STEP b</span>
+        <svg id="bsl" viewBox="0 0 200 22" style="display:block;width:170px;touch-action:none;cursor:pointer;user-select:none;">
+          <line x1="8" y1="11" x2="192" y2="11" stroke="var(--dim2)" stroke-width="2.5" stroke-linecap="round"></line>
+          <circle id="bk" cx="100" cy="11" r="7" fill="var(--paper2)" stroke="var(--voice)" stroke-width="2"></circle>
+        </svg>
+        <span id="bRead" style="font-family:var(--mono);font-size:11px;color:var(--voice);"></span>
+        <span id="adBadge" style="font-family:var(--mono);font-size:9.5px;letter-spacing:.14em;padding:2px 8px;border:1px solid var(--border);border-radius:3px;"></span>
+      </div>
+      <div style="display:flex;gap:6px 18px;flex-wrap:wrap;align-items:baseline;">
+        <span id="adSlot" style="font-family:var(--mono);font-size:12px;color:var(--ink);"></span>
+        <span id="adErr" style="font-family:var(--mono);font-size:11px;"></span>
+      </div>
+      <div class="hand">the j-slot &divide; b is a slope. split samples the rails &middot; complex samples one floor up &middot; the dual takes no samples at all &mdash; and both windows close onto it as p &rarr; 0.</div>
+    </div>
+
+    <!-- ══ GR · the Galilean ruler ══ -->
+    <div class="plate" id="plateGR" style="grid-column:4/6;grid-row:1;flex-direction:row;gap:12px;align-items:center;">
+      <svg id="grPlot" viewBox="-95 -95 190 190" style="display:block;height:100%;max-height:180px;flex:none;touch-action:none;user-select:none;">
+        <line x1="-90" y1="0" x2="90" y2="0" stroke="var(--dim2)" stroke-width="1"></line>
+        <line x1="0" y1="-90" x2="0" y2="90" stroke="var(--dim2)" stroke-width="1"></line>
+        <path id="grLvl" fill="none" stroke-width="1.6" stroke-dasharray="5 4"></path>
+        <line id="grShadow" y1="0" y2="0" stroke="var(--voice)" stroke-width="3.5" opacity=".85"></line>
+        <line id="grVec" x1="0" y1="0" stroke="var(--live)" stroke-width="2.2"></line>
+        <circle id="grZ" r="8" fill="var(--live-soft)" stroke="var(--live)" stroke-width="2" style="cursor:grab;"></circle>
+      </svg>
+      <div style="min-width:0;display:flex;flex-direction:column;gap:4px;">
+        <div class="plab">GR &middot; THE RULER</div>
+        <div id="grRead" style="font-family:var(--mono);font-size:11.5px;color:var(--ink);"></div>
+        <div id="grCap" class="hand"></div>
+      </div>
+    </div>
+
+    <!-- ══ SH · parameters add ══ -->
+    <div class="plate" id="plateSH" style="grid-column:4/6;grid-row:2;flex-direction:row;gap:12px;align-items:center;">
+      <svg id="shPlot" viewBox="-95 -95 190 190" style="display:block;height:100%;max-height:180px;flex:none;">
+        <line x1="-90" y1="0" x2="90" y2="0" stroke="var(--dim2)" stroke-width="1"></line>
+        <line x1="0" y1="-90" x2="0" y2="90" stroke="var(--dim2)" stroke-width="1"></line>
+        <path id="shCurve" fill="none" stroke-width="1.6"></path>
+        <circle id="shU1" r="5" fill="var(--live)"></circle>
+        <circle id="shU2" r="5" fill="var(--voice)"></circle>
+        <circle id="shU3" r="6.5" fill="transparent" stroke="var(--ink)" stroke-width="2.2"></circle>
+      </svg>
+      <div style="min-width:0;display:flex;flex-direction:column;gap:4px;flex:1;">
+        <div class="plab">SH &middot; HOW MOTION COMPOSES</div>
+        <svg id="v1s" viewBox="0 0 200 20" style="display:block;width:100%;max-width:170px;touch-action:none;cursor:pointer;"><line x1="8" y1="10" x2="192" y2="10" stroke="var(--dim2)" stroke-width="2.5" stroke-linecap="round"></line><circle id="v1k" cx="120" cy="10" r="6.5" fill="var(--paper2)" stroke="var(--live)" stroke-width="2"></circle></svg>
+        <svg id="v2s" viewBox="0 0 200 20" style="display:block;width:100%;max-width:170px;touch-action:none;cursor:pointer;"><line x1="8" y1="10" x2="192" y2="10" stroke="var(--dim2)" stroke-width="2.5" stroke-linecap="round"></line><circle id="v2k" cx="80" cy="10" r="6.5" fill="var(--paper2)" stroke="var(--voice)" stroke-width="2"></circle></svg>
+        <div id="shRead" style="font-family:var(--mono);font-size:10.5px;color:var(--ink);"></div>
+        <div id="shCap" class="hand" style="font-size:13.5px;"></div>
+      </div>
+    </div>
+
+    <!-- ══ DG · the wall from both sides ══ -->
+    <div class="plate" id="plateDG" style="grid-column:4/6;grid-row:3;flex-direction:row;gap:12px;align-items:center;">
+      <svg id="dgPlot" viewBox="-95 -95 190 190" style="display:block;height:100%;max-height:180px;flex:none;">
+        <line x1="-90" y1="0" x2="90" y2="0" stroke="var(--dim2)" stroke-width="1"></line>
+        <line x1="0" y1="-90" x2="0" y2="90" stroke="var(--dim2)" stroke-width="1"></line>
+        <path id="dgHome" fill="none" stroke="var(--ok)" stroke-width="2.4"></path>
+        <path id="dgMe" fill="none" stroke-width="2"></path>
+        <path id="dgMirror" fill="none" stroke-width="2" stroke-dasharray="5 4" opacity=".7"></path>
+      </svg>
+      <div style="min-width:0;display:flex;flex-direction:column;gap:4px;">
+        <div class="plab">DG &middot; THE WALL, FROM BOTH SIDES</div>
+        <div id="dgRead" style="font-family:var(--mono);font-size:10.5px;color:var(--ink);"></div>
+        <div class="hand" style="font-size:13.5px;">your curve, its mirror at &minus;p, and the wall both fall onto. rotation and boost degenerate to the same shear.</div>
+      </div>
+    </div>
+
+    <!-- ══ WALL · the claim ══ -->
+    <div class="plate" id="plateWALL" style="grid-column:1/3;grid-row:4;justify-content:center;gap:5px;">
+      <div class="plab">THE CLAIM</div>
+      <div style="font-style:italic;font-size:18px;color:var(--ink);">the dual plane is the common wall</div>
+      <div style="font-size:12.5px;line-height:1.55;color:var(--ink);">Ellipse and hyperbola both flatten onto the line pair. Rotation and boost both degenerate to the shear. Centered difference and complex step both close onto the exact slot. Two houses, one wall &mdash; and the wall is where the derivative lives.</div>
+    </div>
+
+    <!-- ══ seals ══ -->
+    <div class="sealgrid" style="grid-column:3/6;grid-row:4;">
+      <div class="vat sm" data-t="jets" data-on="0" style="position:relative;height:100%;">
+        <div class="in">
+          <div class="fc" style="align-items:center;justify-content:center;gap:3px;padding:5px;border-style:dashed;">
+            <span style="width:26px;height:26px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;font-weight:700;">&epsilon;&sup3;</span>
+            <span class="hand" style="font-size:13px;line-height:1;text-align:center;">jets</span>
+          </div>
+          <div class="bk" style="padding:6px 7px;"><div style="flex:1;display:flex;align-items:center;font-size:10.5px;line-height:1.4;color:var(--ink);overflow:hidden;">&epsilon;&sup3; = 0 carries the second derivative too; &epsilon;&#8319; = 0 carries a whole Taylor jet. A ladder of rooms behind this one.</div></div>
+        </div>
+      </div>
+      <div class="vat sm" data-t="screws" data-on="0" style="position:relative;height:100%;">
+        <div class="in">
+          <div class="fc" style="align-items:center;justify-content:center;gap:3px;padding:5px;border-style:dashed;">
+            <span style="width:26px;height:26px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;font-weight:700;">&#8663;</span>
+            <span class="hand" style="font-size:13px;line-height:1;text-align:center;">screws</span>
+          </div>
+          <div class="bk" style="padding:6px 7px;"><div style="flex:1;display:flex;align-items:center;font-size:10.5px;line-height:1.4;color:var(--ink);overflow:hidden;">Dual quaternions carry rotation + translation in one number &mdash; robot arms and rigid-body motion run on them.</div></div>
+        </div>
+      </div>
+      <div class="vat sm" data-t="tropical" data-on="0" style="position:relative;height:100%;">
+        <div class="in">
+          <div class="fc" style="align-items:center;justify-content:center;gap:3px;padding:5px;border-style:dashed;">
+            <span style="width:26px;height:26px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:8px;font-weight:700;">min</span>
+            <span class="hand" style="font-size:13px;line-height:1;text-align:center;">tropical</span>
+          </div>
+          <div class="bk" style="padding:6px 7px;"><div style="flex:1;display:flex;align-items:center;font-size:10.5px;line-height:1.4;color:var(--ink);overflow:hidden;">A different &ldquo;close enough&rdquo;: keep the dominant scale, not the tangent. Nilpotent vs idempotent &mdash; two ways to kill cross terms.</div></div>
+        </div>
+      </div>
+      <div class="vat sm" data-t="galileo" data-on="0" style="position:relative;height:100%;">
+        <div class="in">
+          <div class="fc" style="align-items:center;justify-content:center;gap:3px;padding:5px;border-style:dashed;">
+            <span style="width:26px;height:26px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:7.5px;font-weight:700;">t&#8202;=&#8202;t&prime;</span>
+            <span class="hand" style="font-size:13px;line-height:1;text-align:center;">Galileo</span>
+          </div>
+          <div class="bk" style="padding:6px 7px;"><div style="flex:1;display:flex;align-items:center;font-size:10.5px;line-height:1.4;color:var(--ink);overflow:hidden;">Newton&rsquo;s spacetime IS this room: absolute time, boosts as shears, one direction invisible to the ruler.</div></div>
+        </div>
+      </div>
+      <div class="vat sm" data-t="backprop" data-on="0" style="position:relative;height:100%;">
+        <div class="in">
+          <div class="fc" style="align-items:center;justify-content:center;gap:3px;padding:5px;border-style:dashed;">
+            <span style="width:26px;height:26px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;font-weight:700;">&nabla;</span>
+            <span class="hand" style="font-size:13px;line-height:1;text-align:center;">backprop</span>
+          </div>
+          <div class="bk" style="padding:6px 7px;"><div style="flex:1;display:flex;align-items:center;font-size:10.5px;line-height:1.4;color:var(--ink);overflow:hidden;">Forward-mode AD is this plate run through a whole program; reverse mode runs the tape backward. ML trains on it.</div></div>
+        </div>
+      </div>
+      <div class="vat sm" data-t="lineage" data-on="0" style="position:relative;height:100%;">
+        <div class="in">
+          <div class="fc" style="align-items:center;justify-content:center;gap:3px;padding:5px;border-style:dashed;">
+            <span style="width:26px;height:26px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;font-weight:700;">&#8756;</span>
+            <span class="hand" style="font-size:13px;line-height:1;text-align:center;">lineage</span>
+          </div>
+          <div class="bk" style="padding:6px 7px;"><div style="flex:1;display:flex;align-items:center;font-size:10px;line-height:1.35;color:var(--ink);overflow:hidden;">Dual numbers: Clifford (1873), Study&rsquo;s dual angles; Galilean geometry: Yaglom; the complex-step trick: Squire &amp; Trapp (1998); forward AD: Wengert (1964).</div></div>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <div class="hand" style="font-size:16px;display:flex;flex-wrap:wrap;gap:4px 10px;align-items:baseline;">home is the wall; the houses are the views.
+    <a href="./" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">the cover</a>
+    &middot; <a href="journal.html" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">the journal</a>
+    &middot; <a href="chapter-3.html" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">three worlds</a>
+    &middot; <a href="cards/" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">the cards</a>
+  </div>
+
+</div>
+</div>
+
+<script>
+/* ═══════ the dual room — one p (default 0), every plate listens ═══════ */
+const $=id=>document.getElementById(id);
+const S={p:0, a:0.9, b:0.6, fi:1, gx:1.4, gy:0.9, v1:0.5, v2:-0.35};
+const fmt=(v,d=2)=>{let r=Math.round(v*10**d)/10**d; if(Object.is(r,-0)) r=0;
+  let s=r.toFixed(d).replace(/\.?0+$/,''); if(s==='') s='0';
+  if(s[0]==='-') s='−'+s.slice(1); return s;};
+const NS='http://www.w3.org/2000/svg';
+
+/* presets: f, f′, and the real/imag parts of f(a+ih) for the complex window */
+const FS=[
+ {name:'x²+3x', f:x=>x*x+3*x, df:x=>2*x+3,
+  cre:(a,h)=>a*a-h*h+3*a, cim:(a,h)=>2*a*h+3*h, yr:[-4,12]},
+ {name:'sin 3x', f:x=>Math.sin(3*x), df:x=>3*Math.cos(3*x),
+  cre:(a,h)=>Math.sin(3*a)*Math.cosh(3*h), cim:(a,h)=>Math.cos(3*a)*Math.sinh(3*h), yr:[-1.6,1.6]},
+ {name:'x³−2x', f:x=>x*x*x-2*x, df:x=>3*x*x-2,
+  cre:(a,h)=>a*a*a-3*a*h*h-2*a, cim:(a,h)=>3*a*a*h-h*h*h-2*h, yr:[-6,6]},
+ {name:'e^(x/2)', f:x=>Math.exp(x/2), df:x=>Math.exp(x/2)/2,
+  cre:(a,h)=>Math.exp(a/2)*Math.cos(h/2), cim:(a,h)=>Math.exp(a/2)*Math.sin(h/2), yr:[-.5,6]},
+];
+
+/* pocket slider ticks */
+(function(){const g=$('pTicks');
+  for(const m of [-2,-1,0,1,2]){const x=300+m*143;
+    const l=document.createElementNS(NS,'line');
+    l.setAttribute('x1',x);l.setAttribute('x2',x);l.setAttribute('y1',9);l.setAttribute('y2',21);
+    l.setAttribute('stroke','var(--dim2)');l.setAttribute('stroke-width','1.2');g.appendChild(l);
+    const t=document.createElementNS(NS,'text');
+    t.setAttribute('x',x);t.setAttribute('y',30);t.setAttribute('text-anchor','middle');
+    t.setAttribute('font-family','var(--mono)');t.setAttribute('font-size','9');
+    t.setAttribute('fill','var(--dim2)');t.textContent=(m<0?'−'+(-m):'+'+m);g.appendChild(t);
+  }})();
+
+function setP(v){ S.p=v; render(); }
+
+/* level-set path in a viewBox of half-size R with unit U */
+function lvlPath(p,U,R){
+  if(p<-.001){const ry=Math.min(U/Math.sqrt(-p),R*3);
+    return 'M '+U+' 0 A '+U+' '+ry.toFixed(1)+' 0 1 1 '+(-U)+' 0 A '+U+' '+ry.toFixed(1)+' 0 1 1 '+U+' 0';}
+  if(p<.001){return 'M '+U+' '+(-R)+' L '+U+' '+R+' M '+(-U)+' '+(-R)+' L '+(-U)+' '+R;}
+  const s=Math.sqrt(p); let d='';
+  for(const br of [1,-1]){let seg='';
+    for(let i=0;i<=36;i++){const t=-2.2+i*(4.4/36);
+      const x=br*Math.cosh(t)*U, y=-Math.sinh(t)/s*U;
+      if(Math.abs(y)>R&&i>0&&i<36) continue;
+      seg+=(seg?' L ':'M ')+x.toFixed(1)+' '+y.toFixed(1);}
+    d+=seg+' ';}
+  return d;
+}
+
+function render(){
+  const p=Math.max(-2,Math.min(2,S.p));
+  const neg=p<-.001, pos=p>.001, zero=!neg&&!pos;
+  const pColor=neg?'var(--d1)':pos?'var(--d5)':'var(--ok)';
+  const planeName=neg?'the complex plane':pos?'the split plane':'the dual plane · home';
+
+  $('hdrRead').textContent='j² = '+fmt(p)+' · '+(zero?'home':planeName);
+
+  /* — pocket — */
+  const kx=Math.max(14,Math.min(586,300+p*143));
+  $('pk1').setAttribute('cx',kx); $('pk2').setAttribute('cx',kx);
+  $('pk1').setAttribute('stroke',pColor); $('pk2').setAttribute('fill',pColor);
+  $('pkCurve').setAttribute('d',lvlPath(p,18,42)); $('pkCurve').setAttribute('stroke',pColor);
+  $('pkJ2').setAttribute('cx',Math.max(-40,Math.min(40,18*p))); $('pkJ2').setAttribute('fill',pColor);
+  $('pkRead').textContent='j² = '+fmt(p); $('pkRead').style.color=pColor;
+  $('pkName').textContent=planeName; $('pkName').style.color=pColor;
+
+  /* — AD hub — */
+  const F=FS[S.fi], a=S.a, b=S.b;
+  document.querySelectorAll('.fpill').forEach(el=>el.dataset.on=el.dataset.f==String(S.fi)?'1':'0');
+  const X=v=>70+(v+3)*(470/6), yr=F.yr, Y=v=>310-(v-yr[0])*(290/(yr[1]-yr[0]));
+  /* axis + curve */
+  $('adAxX').setAttribute('x1',70);$('adAxX').setAttribute('x2',540);
+  $('adAxX').setAttribute('y1',Y(0));$('adAxX').setAttribute('y2',Y(0));
+  let d='';
+  for(let i=0;i<=140;i++){const x=-3+i*(6/140);let y=F.f(x);
+    y=Math.max(yr[0]-1,Math.min(yr[1]+1,y));
+    d+=(d?' L ':'M ')+X(x).toFixed(1)+' '+Y(y).toFixed(1);}
+  $('adCurve').setAttribute('d',d);
+  if(!render.gDone){render.gDone=true;const g=$('adGrid');
+    for(let x=-3;x<=3;x++){const l=document.createElementNS(NS,'line');
+      l.setAttribute('x1',X(x));l.setAttribute('x2',X(x));l.setAttribute('y1',20);l.setAttribute('y2',310);
+      l.setAttribute('stroke','var(--grid)');g.appendChild(l);
+      const t=document.createElementNS(NS,'text');t.setAttribute('x',X(x));t.setAttribute('y',326);
+      t.setAttribute('text-anchor','middle');t.setAttribute('font-family','var(--mono)');
+      t.setAttribute('font-size','9');t.setAttribute('fill','var(--dim2)');
+      t.textContent=(x<0?'−'+(-x):x);g.appendChild(t);}}
+  /* the estimator: h = b·√|p| */
+  const h=b*Math.sqrt(Math.abs(p));
+  const fa=F.f(a), tru=F.df(a);
+  let est, val, badge, mode;
+  if(pos){est=(F.f(a+h)-F.f(a-h))/(2*h); val=(F.f(a+h)+F.f(a-h))/2;
+    badge='CENTERED DIFFERENCE · rails at a ± '+fmt(h); mode='split';}
+  else if(neg){est=F.cim(a,h)/h; val=F.cre(a,h);
+    badge='COMPLEX STEP · samples one floor up (± '+fmt(h)+'i)'; mode='cx';}
+  else {est=tru; val=fa; badge='EXACT — THE DUAL SLOT · no samples, no limit'; mode='dual';}
+  /* slope lines through (a, value-anchor) */
+  const anchor=fa;
+  const L=Math.min(1.6, 2.6/Math.max(1,Math.abs(est),Math.abs(tru)));
+  $('adTrue').setAttribute('x1',X(a-L));$('adTrue').setAttribute('y1',Y(anchor-tru*L));
+  $('adTrue').setAttribute('x2',X(a+L));$('adTrue').setAttribute('y2',Y(anchor+tru*L));
+  $('adEst').setAttribute('x1',X(a-L));$('adEst').setAttribute('y1',Y(anchor-est*L));
+  $('adEst').setAttribute('x2',X(a+L));$('adEst').setAttribute('y2',Y(anchor+est*L));
+  $('adEst').setAttribute('stroke',pColor);
+  $('adA').setAttribute('cx',X(a));$('adA').setAttribute('cy',Y(fa));
+  /* samples */
+  const s1=$('adS1'),s2=$('adS2'),st1=$('adStem1'),st2=$('adStem2'),fl=$('adFloor');
+  if(mode==='split'){
+    s1.setAttribute('stroke','var(--d5)');s2.setAttribute('stroke','var(--d5)');
+    s1.setAttribute('stroke-dasharray','');s2.setAttribute('stroke-dasharray','');
+    s1.setAttribute('cx',X(a-h));s1.setAttribute('cy',Y(F.f(a-h)));s1.setAttribute('opacity','1');
+    s2.setAttribute('cx',X(a+h));s2.setAttribute('cy',Y(F.f(a+h)));s2.setAttribute('opacity','1');
+    st1.setAttribute('opacity','0');st2.setAttribute('opacity','0');fl.setAttribute('opacity','0');
+  } else if(mode==='cx'){
+    const dy=Math.min(70,h*70);
+    s1.setAttribute('stroke','var(--d1)');s2.setAttribute('stroke','var(--d1)');
+    s1.setAttribute('stroke-dasharray','3 3');s2.setAttribute('stroke-dasharray','3 3');
+    s1.setAttribute('cx',X(a));s1.setAttribute('cy',Y(fa)-dy);s1.setAttribute('opacity','1');
+    s2.setAttribute('cx',X(a));s2.setAttribute('cy',Y(fa)+dy);s2.setAttribute('opacity','1');
+    st1.setAttribute('x1',X(a));st1.setAttribute('x2',X(a));
+    st1.setAttribute('y1',Y(fa)-dy);st1.setAttribute('y2',Y(fa)+dy);st1.setAttribute('opacity','1');
+    st2.setAttribute('opacity','0');
+    fl.setAttribute('x',X(a)+12);fl.setAttribute('y',Y(fa)-dy-6);fl.setAttribute('opacity','.9');
+  } else {
+    s1.setAttribute('opacity','0');s2.setAttribute('opacity','0');
+    st1.setAttribute('opacity','0');st2.setAttribute('opacity','0');fl.setAttribute('opacity','0');
+  }
+  /* readouts */
+  $('bk').setAttribute('cx',8+((b-0.05)/1.45)*184);
+  $('bRead').textContent='b = '+fmt(b);
+  const bd=$('adBadge'); bd.textContent=badge; bd.style.color=pColor; bd.style.borderColor=pColor;
+  const slot=est*b;
+  $('adSlot').textContent='f(a + b·j) = '+fmt(val,3)+(slot<0?' − '+fmt(-slot,3):' + '+fmt(slot,3))+'·j   →   slope = '+fmt(est,4);
+  const err=Math.abs(est-tru);
+  $('adErr').textContent=zero?'error 0 — exact':'true f′(a) = '+fmt(tru,4)+' · error '+(err<1e-12?'≈ 0':fmt(err,4));
+  $('adErr').style.color=zero?'var(--ok)':(err<0.005?'var(--ok)':'var(--voice)');
+
+  /* — GR ruler — */
+  const gx=S.gx, gy=S.gy, GU=38;
+  $('grVec').setAttribute('x2',gx*GU);$('grVec').setAttribute('y2',-gy*GU);
+  $('grZ').setAttribute('cx',gx*GU);$('grZ').setAttribute('cy',-gy*GU);
+  $('grShadow').setAttribute('x1',0);$('grShadow').setAttribute('x2',gx*GU);
+  const N=gx*gx-p*gy*gy;
+  /* level curve of N through z: x² − p·y² = N */
+  let gd='';
+  if(Math.abs(N)>.02){const sN=Math.sqrt(Math.abs(N));
+    if(p<-.001){const rx=sN*GU, ry=Math.min(sN/Math.sqrt(-p)*GU,260);
+      gd='M '+rx.toFixed(1)+' 0 A '+rx.toFixed(1)+' '+ry.toFixed(1)+' 0 1 1 '+(-rx).toFixed(1)+' 0 A '+rx.toFixed(1)+' '+ry.toFixed(1)+' 0 1 1 '+rx.toFixed(1)+' 0';}
+    else if(p<.001){const x0=sN*GU; gd=N>0?('M '+x0+' -88 L '+x0+' 88 M '+(-x0)+' -88 L '+(-x0)+' 88'):'';}
+    else {const s=Math.sqrt(p);
+      if(N>0){for(const br of [1,-1]){let seg='';
+        for(let i=0;i<=30;i++){const t=-2+i*(4/30);
+          const x=br*sN*Math.cosh(t)*GU, y=-sN/s*Math.sinh(t)*GU;
+          if(Math.abs(y)>88&&i>0&&i<30) continue;
+          seg+=(seg?' L ':'M ')+x.toFixed(1)+' '+y.toFixed(1);}
+        gd+=seg+' ';}}
+      else {for(const br of [1,-1]){let seg='';
+        for(let i=0;i<=30;i++){const t=-2+i*(4/30);
+          const y=-br*sN/s*Math.cosh(t)*GU, x=sN*Math.sinh(t)*GU;
+          if(Math.abs(x)>88&&i>0&&i<30) continue;
+          seg+=(seg?' L ':'M ')+x.toFixed(1)+' '+y.toFixed(1);}
+        gd+=seg+' ';}}}}
+  $('grLvl').setAttribute('d',gd); $('grLvl').setAttribute('stroke',pColor);
+  $('grRead').innerHTML='z = '+fmt(gx)+' + '+fmt(gy)+'·j<br>N = x² − p·y² = <b style="color:'+ (zero?'var(--ok)':'var(--ink)') +'">'+fmt(N)+'</b>';
+  $('grCap').textContent=zero?'the ruler reads the shadow only — the vertical is invisible. drag z up and down: N holds still.'
+    :neg?'leaning out the complex window: both directions count. N is a real length².'
+    :'leaning out the split window: the vertical counts NEGATIVELY. N can vanish on the rails.';
+
+  /* — SH composition — */
+  const U2=52;
+  $('shCurve').setAttribute('d',lvlPath(p,U2,88)); $('shCurve').setAttribute('stroke',pColor);
+  const uPt=(t)=>{ /* unit element at parameter t, per plane */
+    if(neg){const s=Math.sqrt(-p);return [Math.cos(t)*U2, -Math.sin(t)/s*U2];}
+    if(zero) return [U2, -t*U2];
+    const s=Math.sqrt(p);return [Math.cosh(t)*U2, -Math.sinh(t)/s*U2];
+  };
+  const c1=uPt(S.v1), c2=uPt(S.v2), c3=uPt(S.v1+S.v2);
+  $('shU1').setAttribute('cx',c1[0]);$('shU1').setAttribute('cy',c1[1]);
+  $('shU2').setAttribute('cx',c2[0]);$('shU2').setAttribute('cy',c2[1]);
+  $('shU3').setAttribute('cx',c3[0]);$('shU3').setAttribute('cy',c3[1]);
+  $('v1k').setAttribute('cx',100+S.v1*76.6);
+  $('v2k').setAttribute('cx',100+S.v2*76.6);
+  const pname=neg?'angles':zero?'velocities':'rapidities';
+  $('shRead').textContent=fmt(S.v1)+' ∘ '+fmt(S.v2)+' = '+fmt(S.v1+S.v2)+'  ('+pname+' add)';
+  $('shCap').textContent=neg?'multiplying unit numbers turns: angles add around the circle.'
+    :zero?'multiplying unit numbers shears: velocities add along the line — Galileo’s rule, exact.'
+    :'multiplying unit numbers boosts: rapidities add along the hyperbola (velocities saturate).';
+
+  /* — DG wall — */
+  $('dgHome').setAttribute('d',lvlPath(0,52,88));
+  const me=$('dgMe'), mir=$('dgMirror');
+  if(zero){me.setAttribute('d','');mir.setAttribute('d','');}
+  else{me.setAttribute('d',lvlPath(p,52,88));me.setAttribute('stroke',pColor);
+    mir.setAttribute('d',lvlPath(-p,52,88));mir.setAttribute('stroke',p>0?'var(--d1)':'var(--d5)');}
+  $('dgRead').textContent=zero?'p = 0 — you are the wall':'p = '+fmt(p)+' and its mirror −p, both → the wall';
+}
+
+/* ——— pointer plumbing ——— */
+function slider(el,onMove){el.setAttribute('data-dragel','');let dn=false;
+  const go=e=>{const r=el.getBoundingClientRect();onMove((e.clientX-r.left)/r.width);};
+  el.addEventListener('pointerdown',e=>{dn=true;el.setPointerCapture(e.pointerId);go(e);e.preventDefault();});
+  el.addEventListener('pointermove',e=>{if(dn)go(e);});
+  addEventListener('pointerup',()=>{dn=false;});}
+slider($('psl'),f=>{let p=(f*600-300)/143;p=Math.max(-2,Math.min(2,p));
+  for(const m of [-1,0,1]) if(Math.abs(p-m)<.09){p=m;break;}
+  setP(Math.round(p*100)/100);});
+slider($('bsl'),f=>{S.b=Math.max(.05,Math.min(1.5,.05+f*1.45));render();});
+slider($('v1s'),f=>{S.v1=Math.max(-1.15,Math.min(1.15,(f-.5)*2.4));render();});
+slider($('v2s'),f=>{S.v2=Math.max(-1.15,Math.min(1.15,(f-.5)*2.4));render();});
+
+/* drag a on the AD plot */
+(function(){const plot=$('adPlot'),hd=$('adA');hd.setAttribute('data-dragel','');let dn=false;
+  hd.addEventListener('pointerdown',e=>{dn=true;hd.setPointerCapture(e.pointerId);e.preventDefault();e.stopPropagation();});
+  hd.addEventListener('pointermove',e=>{if(!dn)return;
+    const r=plot.getBoundingClientRect();
+    let a=((e.clientX-r.left)/r.width*560-70)/(470/6)-3;
+    S.a=Math.max(-2.6,Math.min(2.6,Math.round(a*20)/20));render();});
+  hd.addEventListener('pointerup',()=>{dn=false;});})();
+
+/* drag z on the ruler */
+(function(){const plot=$('grPlot'),hd=$('grZ');hd.setAttribute('data-dragel','');let dn=false;
+  hd.addEventListener('pointerdown',e=>{dn=true;hd.setPointerCapture(e.pointerId);e.preventDefault();e.stopPropagation();});
+  hd.addEventListener('pointermove',e=>{if(!dn)return;
+    const r=plot.getBoundingClientRect();
+    let x=((e.clientX-r.left)/r.width*190-95)/38;
+    let y=-((e.clientY-r.top)/r.height*190-95)/38;
+    S.gx=Math.max(-2.2,Math.min(2.2,Math.round(x*20)/20));
+    S.gy=Math.max(-2.2,Math.min(2.2,Math.round(y*20)/20));render();});
+  hd.addEventListener('pointerup',()=>{dn=false;});})();
+
+/* clicks: presets + seals */
+document.addEventListener('click',e=>{
+  if(e.target.closest('a')||e.target.closest('[data-dragel]')) return;
+  const fp=e.target.closest('.fpill');
+  if(fp){S.fi=parseInt(fp.dataset.f,10);render();return;}
+  const t=e.target.closest('[data-t]');
+  if(t){t.dataset.on=t.dataset.on==='1'?'0':'1';}
+});
+
+/* expose for headless verification */
+window.__dual={get:()=>({...S}), setP};
+render();
+</script>
+</body>
+</html>

--- a/public/number-planes/index.html
+++ b/public/number-planes/index.html
@@ -141,6 +141,10 @@ html,body{margin:0;padding:0}
       <span style="font-family:var(--mono);font-size:8.5px;letter-spacing:.24em;color:var(--voice);">THE JOURNAL &middot; NEW</span>
       <span style="font-family:var(--hand);font-size:16px;color:var(--ink);">entries in time &mdash; questions on top of questions, small answers kept in order.</span>
     </a>
+    <a class="leaf" href="dual.html">
+      <span style="font-family:var(--mono);font-size:8.5px;letter-spacing:.24em;color:var(--voice);">THE DUAL ROOM &middot; NEW</span>
+      <span style="font-family:var(--hand);font-size:16px;color:var(--ink);">the first interior &mdash; autodiff exact at home, and both neighbors&rsquo; approximations closing onto it.</span>
+    </a>
     <a class="leaf" href="notebook.html">
       <span style="font-family:var(--mono);font-size:8.5px;letter-spacing:.24em;color:var(--dim);">THE WALK IN</span>
       <span style="font-family:var(--hand);font-size:16px;color:var(--ink);">a staged first passage &mdash; the question, the sign, the motions, the mirror.</span>

--- a/public/number-planes/index.html
+++ b/public/number-planes/index.html
@@ -59,7 +59,7 @@ html,body{margin:0;padding:0}
 .leaf:hover{border-color:var(--border-strong)}
 @media (hover:none){.chp .go{opacity:.85}}
 .shelf{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
-.doors{display:grid;grid-template-columns:repeat(3,1fr);gap:14px}
+.doors{display:grid;grid-template-columns:repeat(2,1fr);gap:14px}
 @media (max-width:900px){.shelf,.doors{grid-template-columns:1fr}}
 @media (prefers-reduced-motion: reduce){*{transition:none !important;animation:none !important}}
 </style>
@@ -137,6 +137,10 @@ html,body{margin:0;padding:0}
 
   <!-- ══ side doors ══ -->
   <div class="doors">
+    <a class="leaf" href="journal.html">
+      <span style="font-family:var(--mono);font-size:8.5px;letter-spacing:.24em;color:var(--voice);">THE JOURNAL &middot; NEW</span>
+      <span style="font-family:var(--hand);font-size:16px;color:var(--ink);">entries in time &mdash; questions on top of questions, small answers kept in order.</span>
+    </a>
     <a class="leaf" href="notebook.html">
       <span style="font-family:var(--mono);font-size:8.5px;letter-spacing:.24em;color:var(--dim);">THE WALK IN</span>
       <span style="font-family:var(--hand);font-size:16px;color:var(--ink);">a staged first passage &mdash; the question, the sign, the motions, the mirror.</span>

--- a/public/number-planes/journal.html
+++ b/public/number-planes/journal.html
@@ -1,0 +1,511 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+<title>Number Planes · the journal — entries in time</title>
+<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Ccircle cx='16' cy='16' r='13' fill='none' stroke='%235fa8ff' stroke-width='3'/%3E%3Ccircle cx='16' cy='3' r='3' fill='%234cc878'/%3E%3C/svg%3E">
+<link rel="stylesheet" href="../guide-theme.css">
+<script src="../guide-skin.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,opsz,wght@0,6..72,200..700;1,6..72,200..700&family=Caveat:wght@400..700&family=Space+Mono:ital,wght@0,400;0,700;1,400&family=Space+Grotesk:wght@400..700&family=Shadows+Into+Light&family=VT323&display=swap" rel="stylesheet">
+<style>
+/* ═══════════════════════════════════════════════════════════════
+   The journal — the notebook's TEMPORAL spine (probe build).
+   Entries in time: central working prose in the notebook voice,
+   margins carrying the cross-time glosses (backward refs live in
+   the prose; FORWARD refs are later-added margin notes), plates
+   pasted in sparingly. One p drives every figure on the page.
+   DRAFT PROSE: scaffold copy for Dan to rewrite in his own hand.
+   Skeleton shared with the chapters (guide-theme tokens, .vat).
+   ═══════════════════════════════════════════════════════════════ */
+@keyframes pr-pulse{0%,100%{opacity:.3}50%{opacity:1}}
+html,body{margin:0;padding:0}
+*{box-sizing:border-box}
+.nbr{
+  --desk:color-mix(in srgb, var(--bg) 88%, #000);
+  --deskimg:radial-gradient(120% 90% at 50% -10%,
+    color-mix(in srgb, var(--bg) 88%, var(--fg)) 0%, var(--bg) 55%,
+    color-mix(in srgb, var(--bg) 90%, #000) 100%);
+  --paper:var(--card); --paper2:color-mix(in srgb, var(--card) 93%, var(--fg));
+  --grid:color-mix(in srgb, var(--fg) 7%, transparent);
+  --border:var(--rule); --border-strong:color-mix(in srgb, var(--fg) 34%, transparent);
+  --ink:var(--fg); --dim:var(--muted); --dim2:color-mix(in srgb, var(--muted) 70%, var(--bg));
+  --live:var(--accent2); --live-soft:color-mix(in srgb, var(--accent2) 13%, transparent);
+  --voice:var(--accent); --seal:var(--accent); --seal-fg:var(--bg);
+  --d1:light-dark(#2b57c9, #5fa8ff);
+  --ok:light-dark(#149e57, #4cc878);
+  --d5:light-dark(#bd5f1c, #ff9a5f);
+  --hand:'Caveat',cursive; --serif:'Newsreader',Georgia,serif;
+  --mono:'Space Mono',monospace; --disp:'Space Grotesk',sans-serif;
+  --spd:0.75;
+}
+[data-theme="light"] .nbr{--live:#2f6df0; --voice:#9a4a32; --d1:#3565c8; --ok:#4a7d46; --d5:#b0592a}
+[data-theme="primary"] .nbr{--live:#1f4fd6; --voice:#e63327; --d1:#2b57c9; --ok:#149e57; --d5:#e6731f}
+[data-theme="blueprint"] .nbr{--d1:#c9a8ff; --ok:#7fe0a8; --d5:#ffab7a;
+  --hand:'Shadows Into Light',cursive; --serif:'Space Grotesk',sans-serif}
+[data-theme="phosphor"] .nbr{--d1:#5adcff; --ok:#9dff5a; --d5:#ffa05a;
+  --hand:'VT323',monospace; --serif:'Space Mono',monospace}
+
+/* ——— the time rail: entries hang off one inked line ——— */
+.entries{position:relative;display:flex;flex-direction:column;gap:52px;padding-left:30px}
+.entries::before{content:'';position:absolute;left:7px;top:6px;bottom:6px;width:1px;
+  background:linear-gradient(var(--border-strong), var(--border))}
+.entry{position:relative}
+.tdot{position:absolute;left:-27px;top:5px;width:9px;height:9px;border-radius:50%;
+  background:var(--desk);border:2px solid var(--dim);transition:border-color .3s ease,background .3s ease}
+.entry[data-here="1"] .tdot{border-color:var(--live);background:var(--live)}
+.elab{font-family:var(--mono);font-size:8.5px;letter-spacing:.26em;color:var(--dim)}
+.etitle{margin:2px 0 0;font-style:italic;font-weight:400;font-size:26px;line-height:1.12;
+  letter-spacing:-.01em;color:var(--ink)}
+/* ——— sacred-text split: prose column + gloss margin ——— */
+.ebody{display:grid;grid-template-columns:minmax(0,1fr) 205px;gap:8px 26px;margin-top:10px}
+.prose{font-size:15.5px;line-height:1.72;color:var(--ink);max-width:60ch}
+.prose p{margin:0 0 .85em}
+.prose p:last-child{margin-bottom:0}
+.prose .q{font-style:italic;color:var(--live)}
+.prose .m{font-family:var(--mono);font-size:13px}
+.margin{display:flex;flex-direction:column;gap:14px;padding-top:4px}
+.mgn{font-family:var(--hand);font-size:15.5px;line-height:1.35;color:var(--dim);
+  transform:rotate(-.6deg)}
+.mgn.later{color:var(--voice);border-left:2px solid color-mix(in srgb, var(--voice) 40%, transparent);
+  padding-left:9px;transform:rotate(.4deg)}
+.mgn a{color:inherit;text-decoration:none;border-bottom:1px dotted currentColor}
+.prose a{color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live)}
+/* ——— pasted-in figures ——— */
+.fig{background:var(--paper);border:1px solid var(--border);border-radius:2px;
+  padding:10px 12px 8px;margin:14px 0 4px;
+  box-shadow:0 1px 0 color-mix(in srgb, var(--fg) 6%, transparent)}
+.fig:nth-of-type(odd){transform:rotate(-.35deg)}
+.fig:nth-of-type(even){transform:rotate(.3deg)}
+.flab{font-family:var(--mono);font-size:8px;letter-spacing:.22em;color:var(--dim);
+  display:flex;gap:10px;align-items:center;flex-wrap:wrap}
+.flab .pulse{width:5px;height:5px;border-radius:50%;background:var(--live);
+  animation:pr-pulse 2.6s ease-in-out infinite;flex:none}
+.fcap{font-family:var(--hand);font-size:14.5px;color:var(--dim);margin-top:4px}
+/* flip plates (the sealed orb) — DEFINITE height: iOS resolves height:100%
+   against min-height-only boxes as zero (see chapter pages) */
+.vat{perspective:1000px;cursor:pointer;height:150px}
+.vat .in{position:relative;width:100%;height:100%;transform-style:preserve-3d;
+  transition:transform calc(.55s / var(--spd)) cubic-bezier(.3,.85,.35,1)}
+.vat[data-on="1"] .in{transform:rotateY(180deg) !important}
+.vat:not([data-on="1"]):hover .in{transform:rotateY(-11deg);transition-timing-function:cubic-bezier(.3,1.25,.45,1)}
+.vat .fc,.vat .bk{position:absolute;inset:0;backface-visibility:hidden;-webkit-backface-visibility:hidden;
+  border:1px solid var(--border);border-radius:2px;background:var(--paper);padding:9px 11px;
+  display:flex;flex-direction:column}
+.vat:hover .fc{border-color:var(--border-strong)}
+.vat .bk{transform:rotateY(180deg);border-color:var(--border-strong);background:var(--paper2)}
+.fgl{opacity:.62;transition:opacity .3s ease}
+.vat:hover .fgl{opacity:1}
+button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:pointer}
+.pchip{font-family:var(--mono);font-size:10.5px;border:1px solid var(--border);
+  border-radius:3px;padding:2px 8px}
+@media (hover:none){
+  .fgl{opacity:.85}
+  .vat:not([data-on="1"]):hover .in{transform:none}
+}
+/* ——— phone: the margin folds under the prose as inline slips ——— */
+@media (max-width:860px){
+  .ebody{grid-template-columns:1fr}
+  .margin{padding-top:0;gap:8px}
+  .mgn{transform:none;border-left:2px solid color-mix(in srgb, var(--dim) 35%, transparent);padding-left:9px}
+  .mgn.later{transform:none}
+  .entries{padding-left:22px}
+  .tdot{left:-19px}
+  .fig:nth-of-type(odd),.fig:nth-of-type(even){transform:none}
+}
+@media (prefers-reduced-motion: reduce){*{transition:none !important;animation:none !important}}
+</style>
+</head>
+<body>
+<div class="nbr" id="nbr" style="min-height:100vh;background-color:var(--desk);background-image:var(--deskimg);padding:34px clamp(14px,3.5vw,56px) 90px;color:var(--ink);font-family:var(--serif);">
+<div style="width:min(880px,100%);margin:0 auto;display:flex;flex-direction:column;gap:34px;">
+
+  <header style="display:flex;align-items:baseline;gap:16px;flex-wrap:wrap;">
+    <div>
+      <div style="font-family:var(--mono);font-size:9px;letter-spacing:.4em;color:var(--voice);margin-bottom:10px;">A NOTEBOOK IN TIME &middot; ENTRIES 01&ndash;06 &middot; ONE p UNDER EVERYTHING BELOW</div>
+      <h1 style="margin:0;font-style:italic;font-weight:400;font-size:clamp(34px,6vw,48px);line-height:.98;letter-spacing:-.015em;">the journal</h1>
+      <div style="font-family:var(--hand);font-size:19px;color:var(--live);margin-top:10px;">questions on top of questions &mdash; small answers, kept in the order they came.</div>
+    </div>
+    <span style="margin-left:auto;display:flex;align-items:center;gap:14px;">
+      <span id="hdrRead" style="font-family:var(--mono);font-size:11px;color:var(--live);white-space:nowrap;"></span>
+      <span id="skin-picker"></span>
+    </span>
+  </header>
+
+  <div style="font-family:var(--hand);font-size:15.5px;color:var(--dim);margin-top:-16px;">so far:
+    <a href="#e1" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">the wrong question</a> &middot;
+    <a href="#e2" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">the demands</a> &middot;
+    <a href="#e3" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">strangers</a> &middot;
+    <a href="#e4" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">one knob</a> &middot;
+    <a href="#e5" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">three worlds</a> &middot;
+    <a href="#e6" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">the quadratic</a>
+  </div>
+
+  <div class="entries">
+
+    <!-- ══ ENTRY 01 ══ -->
+    <article class="entry" id="e1">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 01 &middot; EARLY</span>
+      <h2 class="etitle">the wrong question</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p><span class="q">What is a complex number?</span> &mdash; that was the question as first written. It has the wrong shape. A dot in the plane isn&rsquo;t a number, any more than a bead on a wire is. What made the line <em>numbers</em> was never its points &mdash; it was the two ways of combining them. An addition. A multiplication. Fix those two rules and everything else follows them around.</p>
+          <p>So the question worth keeping: <span class="q">on the plane, which two rules?</span></p>
+        </div>
+        <aside class="margin">
+          <div class="mgn">a number system is the pair of rules, not the set of dots. <a href="cards/index.html#L1">card L1</a></div>
+          <div class="mgn later">later &mdash; the whole notebook came out of this re-asking.</div>
+        </aside>
+      </div>
+    </article>
+
+    <!-- ══ ENTRY 02 ══ -->
+    <article class="entry" id="e2">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 02 &middot; NEXT DAY</span>
+      <h2 class="etitle">the demands, tried where the answer is known</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p>Wrote the demands down before touching the plane, to test them where nothing can go wrong. Of a multiplication: it should <strong>distribute</strong> over addition, and something should play <strong>1</strong>. Addition itself stays fixed &mdash; points add like arrows, and subtraction must always undo it.</p>
+          <p>On the line the demands leave no room at all. Every product is forced &mdash; even the sign rule: <span class="m">0 = (&minus;1)&middot;(1 + (&minus;1)) = (&minus;1) + (&minus;1)(&minus;1)</span>, so <span class="m">(&minus;1)(&minus;1)</span> has no choice but <span class="m">+1</span>. A theorem, not a convention.</p>
+          <div class="fig">
+            <div class="flab"><span class="pulse"></span>FIG. 1 &middot; PASTED IN &middot; &times;(&minus;1) IS THE MIRROR &middot; DRAG a</div>
+            <svg id="mirror" viewBox="0 0 560 108" style="display:block;width:100%;touch-action:none;user-select:none;">
+              <line x1="20" y1="64" x2="540" y2="64" stroke="var(--dim2)" stroke-width="1.2"></line>
+              <g id="mTicks"></g>
+              <path id="mArc" fill="none" stroke="var(--voice)" stroke-width="1.6" stroke-dasharray="5 4"></path>
+              <circle id="mB" r="7" fill="var(--paper2)" stroke="var(--voice)" stroke-width="2.2"></circle>
+              <circle id="mA" r="9" fill="var(--live-soft)" stroke="var(--live)" stroke-width="2.2" style="cursor:grab;"></circle>
+              <text id="mAl" y="94" text-anchor="middle" font-family="var(--hand)" font-size="16" fill="var(--live)">a</text>
+              <text id="mBl" y="94" text-anchor="middle" font-family="var(--hand)" font-size="16" fill="var(--voice)">(&minus;1)&middot;a</text>
+            </svg>
+            <div class="fcap">the mirror, twice, is home &mdash; that is all (&minus;1)(&minus;1) = +1 says.</div>
+          </div>
+          <p>The line is finished before it starts. If any choice exists, it lives upstairs.</p>
+        </div>
+        <aside class="margin">
+          <div class="mgn">why hold + fixed? arrows add; and every move must be undoable. <a href="cards/index.html#AX">card AX</a></div>
+          <div class="mgn">(drop the undo and a strange door opens &mdash; tropical. not this trail.)</div>
+          <div class="mgn later">later &mdash; the plane leaves <em>exactly one</em> choice. <a href="#e4">&rarr; entry 04</a></div>
+        </aside>
+      </div>
+    </article>
+
+    <!-- ══ ENTRY 03 ══ -->
+    <article class="entry" id="e3">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 03 &middot; LATER THAT WEEK</span>
+      <h2 class="etitle">the strangers experiment</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p>Tried the laziest plane multiplication first: keep the coordinates apart, strangers to each other &mdash; multiply each slot on its own.</p>
+          <div class="fig">
+            <div class="flab">FIG. 2 &middot; A WORKED COMPUTATION, TAPED IN</div>
+            <div style="font-family:var(--mono);font-size:14px;line-height:2;color:var(--ink);padding:6px 2px 2px;">
+              (a, b) &middot; (c, d) &nbsp;=&nbsp; (a&middot;c,&nbsp; b&middot;d)<br>
+              (1, 0) &middot; (0, 1) &nbsp;=&nbsp; <span style="color:var(--voice);font-weight:700;">(0, 0)</span>
+            </div>
+            <div class="fcap">two honest nonzero numbers, and their product is nothing.</div>
+          </div>
+          <p>It <em>works</em> &mdash; distributes, and <span class="m">(1,1)</span> plays 1. But it feels like two lines taped side by side, not a plane: nothing ever crosses between the slots, and the zero-product pairs sit there like a leak in the boat.</p>
+          <p>Logged as a disappointment. Question kept anyway: <span class="q">is this the only way to multiply a plane &mdash; or one of many?</span></p>
+        </div>
+        <aside class="margin">
+          <div class="mgn"><a href="cards/index.html#L2">card L2</a> &mdash; the strangers product.</div>
+          <div class="mgn later">much later &mdash; not a dead end at all. this was j&sup2; = +1 wearing a disguise. <a href="#e5">&rarr; entry 05</a></div>
+        </aside>
+      </div>
+    </article>
+
+    <!-- ══ ENTRY 04 ══ -->
+    <article class="entry" id="e4">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 04 &middot; A GOOD DAY</span>
+      <h2 class="etitle">one knob</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p>Ran the demands on the plane properly this time. Write a point as <span class="m">x + y&middot;j</span>, with <span class="m">j</span> the unit of the new direction. Distributivity spends nearly all the freedom at once: every product reduces to real arithmetic plus the one product it cannot reach &mdash; <span class="m">j&middot;j</span>.</p>
+          <p>Whatever <span class="m">j&sup2;</span> is declared to be &mdash; call it <span class="m">p</span> &mdash; the entire multiplication follows. All the freedom of the plane, promised by the line&rsquo;s finished table, is <strong>one real number</strong>.</p>
+          <div class="fig">
+            <div class="flab"><span class="pulse"></span>FIG. 3 &middot; THE KNOB ITSELF &middot; DRAG &mdash; EVERY FIGURE BELOW LISTENS</div>
+            <svg id="psl" viewBox="0 0 600 30" style="display:block;width:100%;margin-top:4px;touch-action:none;cursor:pointer;user-select:none;">
+              <line x1="14" y1="15" x2="300" y2="15" stroke="var(--d1)" stroke-width="4" stroke-linecap="round" opacity=".55"></line>
+              <line x1="300" y1="15" x2="586" y2="15" stroke="var(--d5)" stroke-width="4" stroke-linecap="round" opacity=".55"></line>
+              <circle cx="300" cy="15" r="3.5" fill="var(--ok)"></circle>
+              <g id="pTicks"></g>
+              <circle id="pk1" cx="157" cy="15" r="9" fill="var(--paper2)" stroke="var(--d1)" stroke-width="2.4"></circle>
+              <circle id="pk2" cx="157" cy="15" r="2.5" fill="var(--d1)"></circle>
+            </svg>
+            <div style="display:flex;align-items:baseline;gap:12px;flex-wrap:wrap;margin-top:4px;">
+              <span id="pRead" style="font-family:var(--mono);font-size:12.5px;font-weight:700;color:var(--ink);"></span>
+              <span id="pName" style="font-style:italic;font-size:15px;"></span>
+            </div>
+            <div class="fcap">set it, and see. (the same knob the chapters turn &mdash; one p per page.)</div>
+          </div>
+        </div>
+        <aside class="margin">
+          <div class="mgn">j&sup2; = p &mdash; the knob the rest of this notebook keeps turning. <a href="cards/index.html#PL">card PL</a></div>
+          <div class="mgn">the &ldquo;exactly one&rdquo; promised back in <a href="#e2">entry 02</a>.</div>
+        </aside>
+      </div>
+    </article>
+
+    <!-- ══ ENTRY 05 ══ -->
+    <article class="entry" id="e5">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 05 &middot; TURNING IT</span>
+      <h2 class="etitle">three worlds, not a continuum</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p>Expected a continuum of arithmetics, one per <span class="m">p</span>. Got three. Stretching <span class="m">j</span> is only a change of unit, and it rescales <span class="m">p</span> by any positive amount &mdash; so only the <em>sign</em> of <span class="m">p</span> survives honest bookkeeping. Three signs, three worlds; <span class="m">&minus;1, 0, +1</span> the clean representatives.</p>
+          <div class="fig">
+            <div class="flab"><span class="pulse"></span>FIG. 4 &middot; THE UNIT &ldquo;CIRCLE&rdquo; OF EACH WORLD &middot; x&sup2; &minus; p&middot;y&sup2; = 1</div>
+            <div style="display:flex;gap:16px;align-items:center;flex-wrap:wrap;">
+              <svg id="lvl" viewBox="-130 -130 260 260" style="display:block;width:min(240px,58vw);flex:none;">
+                <g id="lvlGrid"></g>
+                <line x1="-126" y1="0" x2="126" y2="0" stroke="var(--dim2)" stroke-width="1"></line>
+                <line x1="0" y1="-126" x2="0" y2="126" stroke="var(--dim2)" stroke-width="1"></line>
+                <path id="lvlRails" fill="none" stroke-width="1.4" stroke-dasharray="6 5" opacity=".75"></path>
+                <path id="lvlCurve" fill="none" stroke-width="2.4"></path>
+                <circle cx="52" cy="0" r="2.5" fill="var(--ink)"></circle>
+                <text x="58" y="14" font-family="var(--mono)" font-size="10" fill="var(--dim)">1</text>
+                <circle cx="0" cy="-52" r="2.5" fill="var(--ink)"></circle>
+                <text x="7" y="-56" font-family="var(--mono)" font-size="10" fill="var(--dim)">j</text>
+              </svg>
+              <div style="display:flex;flex-direction:column;gap:9px;min-width:150px;flex:1;">
+                <div style="display:flex;gap:6px;flex-wrap:wrap;">
+                  <button data-pset="-1" class="pchip">&minus;1</button>
+                  <button data-pset="0" class="pchip">0</button>
+                  <button data-pset="1" class="pchip">+1</button>
+                </div>
+                <div id="railRead" style="font-family:var(--mono);font-size:11px;letter-spacing:.14em;"></div>
+                <div style="font-family:var(--hand);font-size:15px;color:var(--dim);">0 rails turn &middot; 1 rail shears &middot; 2 rails squeeze.</div>
+              </div>
+            </div>
+          </div>
+          <p>And the two-rail world &mdash; the hyperbola riding its crossed asymptotes &mdash; is the strangers experiment of <a href="#e3">entry 03</a>, found again from the inside. The disappointment was a world all along.</p>
+        </div>
+        <aside class="margin">
+          <div class="mgn"><a href="cards/index.html#DV">card DV</a> &mdash; three planes, at the cuts.</div>
+          <div class="mgn later">&larr; <a href="#e3">entry 03</a>, resolved. file nothing as a dead end again.</div>
+        </aside>
+      </div>
+    </article>
+
+    <!-- ══ ENTRY 06 ══ -->
+    <article class="entry" id="e6">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 06 &middot; AFTER THAT</span>
+      <h2 class="etitle">the quadratic was there all along</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p>The count <span class="m">2 / 1 / 0</span> keeps following the sign of <span class="m">p</span> around &mdash; rails, and now roots. <span class="m">t&sup2; = p</span> is the notebook in one equation: two solutions when <span class="m">p &gt; 0</span>, one doubled at <span class="m">p = 0</span>, and for <span class="m">p &lt; 0</span> none <em>on the line</em>.</p>
+          <div class="fig">
+            <div class="flab"><span class="pulse"></span>FIG. 5 &middot; t&sup2; = p &middot; WHERE THE ROOTS LIVE</div>
+            <svg id="roots" viewBox="0 0 560 120" style="display:block;width:100%;">
+              <line x1="30" y1="60" x2="530" y2="60" stroke="var(--dim2)" stroke-width="1.2"></line>
+              <line x1="280" y1="54" x2="280" y2="66" stroke="var(--dim2)" stroke-width="1.2"></line>
+              <line id="rAxis" x1="280" y1="14" x2="280" y2="106" stroke="var(--dim2)" stroke-width="1" stroke-dasharray="3 4" opacity="0"></line>
+              <g id="rDots"></g>
+            </svg>
+            <div id="rootRead" style="font-family:var(--mono);font-size:11px;letter-spacing:.14em;"></div>
+            <div class="fcap">when they leave the line they do not vanish &mdash; they wait, one floor up.</div>
+          </div>
+          <p>The missing pair is the door. Forcing every quadratic &mdash; every polynomial &mdash; to keep its roots is forcing <span class="m">&radic;(negative)</span> to live somewhere, and that somewhere has a name and a sign of its own. That argument deserves an entry to itself, when it&rsquo;s earned.</p>
+          <div class="vat" data-t="FTA" data-on="0" style="max-width:330px;">
+            <div class="in">
+              <div class="fc" style="align-items:center;justify-content:center;gap:4px;border-style:dashed;">
+                <span style="width:28px;height:28px;border-radius:50%;background:var(--seal);color:var(--seal-fg);display:flex;align-items:center;justify-content:center;font-family:var(--mono);font-size:9px;font-weight:700;">&radic;</span>
+                <span style="font-family:var(--hand);font-size:15px;color:var(--dim);text-align:center;">sealed &mdash; the fundamental theorem</span>
+                <span class="fgl" style="font-family:var(--hand);font-size:13.5px;color:var(--voice);">not yet in the book &middot; tap</span>
+              </div>
+              <div class="bk" style="justify-content:center;gap:4px;">
+                <div style="font-family:var(--mono);font-size:8px;letter-spacing:.2em;color:var(--voice);">FTA &middot; SEALED</div>
+                <div style="font-size:12px;line-height:1.5;color:var(--ink);">Demand that roots always exist and the dial is forced to &minus;1: the complex plane is where algebra closes. The proof &mdash; and what it costs &mdash; is a future entry.</div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <aside class="margin">
+          <div class="mgn"><a href="cards/index.html#QD">card QD</a> &mdash; it was a quadratic all along.</div>
+          <div class="mgn">root count = rail count = the sign. one invariant, three costumes.</div>
+        </aside>
+      </div>
+    </article>
+
+  </div>
+
+  <div style="font-family:var(--hand);font-size:16px;color:var(--dim);display:flex;flex-wrap:wrap;gap:4px 10px;align-items:baseline;">the entries continue &mdash; this notebook is being written.
+    <a href="./" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">the cover</a>
+    &middot; <a href="chapter-2.html" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">chapter II &mdash; the room</a>
+    &middot; <a href="cards/" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);white-space:nowrap;">the cards</a>
+  </div>
+
+</div>
+</div>
+
+<script>
+/* ═══════ the journal — one p under every figure ═══════ */
+const $=id=>document.getElementById(id);
+const S={p:-1, a:1.6};
+const fmt=v=>{let r=Math.round(v*100)/100; if(Object.is(r,-0)) r=0;
+  let s=String(r); if(s[0]==='-') s='−'+s.slice(1); return s;};
+const NS='http://www.w3.org/2000/svg';
+
+/* slider ticks */
+(function(){const g=$('pTicks');
+  for(const m of [-2,-1,0,1,2]){const x=300+m*143;
+    const l=document.createElementNS(NS,'line');
+    l.setAttribute('x1',x);l.setAttribute('x2',x);l.setAttribute('y1',9);l.setAttribute('y2',21);
+    l.setAttribute('stroke','var(--dim2)');l.setAttribute('stroke-width','1.2');g.appendChild(l);
+    const t=document.createElementNS(NS,'text');
+    t.setAttribute('x',x);t.setAttribute('y',30);t.setAttribute('text-anchor','middle');
+    t.setAttribute('font-family','var(--mono)');t.setAttribute('font-size','9');
+    t.setAttribute('fill','var(--dim2)');t.textContent=(m<0?'−'+(-m):'+'+m);g.appendChild(t);
+  }})();
+
+/* mirror-line ticks */
+(function(){const g=$('mTicks');
+  for(let u=-4;u<=4;u++){const x=280+u*60;
+    const l=document.createElementNS(NS,'line');
+    l.setAttribute('x1',x);l.setAttribute('x2',x);l.setAttribute('y1',u===0?56:60);l.setAttribute('y2',u===0?72:68);
+    l.setAttribute('stroke','var(--dim2)');l.setAttribute('stroke-width',u===0?'1.4':'1');g.appendChild(l);
+  }})();
+
+function setP(v){ S.p=v; render(); }
+
+function render(){
+  const p=Math.max(-2,Math.min(2,S.p));
+  const neg=p<-.001, pos=p>.001, zero=!neg&&!pos;
+  const pColor=neg?'var(--d1)':pos?'var(--d5)':'var(--ok)';
+  const planeName=neg?'the complex plane':pos?'the split plane':'the dual plane';
+
+  $('hdrRead').textContent='j² = '+fmt(p)+' · '+planeName;
+
+  /* fig 1 — the mirror (independent of p) */
+  const ax=280+S.a*60, bx=280-S.a*60;
+  $('mA').setAttribute('cx',ax); $('mA').setAttribute('cy',64);
+  $('mB').setAttribute('cx',bx); $('mB').setAttribute('cy',64);
+  $('mAl').setAttribute('x',ax); $('mBl').setAttribute('x',bx);
+  const mid=(ax+bx)/2, w=Math.abs(ax-bx);
+  $('mArc').setAttribute('d','M '+ax+' 56 Q '+mid+' '+(56-Math.min(46,w*.22))+' '+bx+' 56');
+
+  /* fig 3 — the knob */
+  const kx=Math.max(14,Math.min(586,300+p*143));
+  $('pk1').setAttribute('cx',kx); $('pk2').setAttribute('cx',kx);
+  $('pk1').setAttribute('stroke',pColor); $('pk2').setAttribute('fill',pColor);
+  $('pRead').textContent='j² = '+fmt(p);
+  $('pName').textContent=planeName; $('pName').style.color=pColor;
+
+  /* chips */
+  document.querySelectorAll('.pchip').forEach(ch=>{
+    const v=parseFloat(ch.dataset.pset);
+    const on=(v===-1&&neg)||(v===0&&zero)||(v===1&&pos);
+    const col=v===-1?'var(--d1)':v===0?'var(--ok)':'var(--d5)';
+    ch.style.color=on?col:'var(--ink)';
+    ch.style.background=on?'var(--live-soft)':'var(--grid)';
+    ch.style.borderColor=on?col:'var(--border)';
+  });
+
+  /* fig 4 — the level set x² − p·y² = 1, unit U = 52 */
+  const U=52; let d='', rails='';
+  if(neg){const ry=Math.min(U/Math.sqrt(-p),320);
+    d='M '+U+' 0 A '+U+' '+ry.toFixed(1)+' 0 1 1 '+(-U)+' 0 A '+U+' '+ry.toFixed(1)+' 0 1 1 '+U+' 0';}
+  else if(zero){d='M '+U+' -126 L '+U+' 126 M '+(-U)+' -126 L '+(-U)+' 126';}
+  else {const s=Math.sqrt(p); const pts=b=>{let seg='';
+      for(let i=0;i<=36;i++){const t=-1.9+i*(3.8/36);
+        const x=b*Math.cosh(t)*U, y=-Math.sinh(t)/s*U;
+        if(Math.abs(y)>126&&i>0&&i<36) continue;
+        seg+=(seg?' L ':'M ')+x.toFixed(1)+' '+y.toFixed(1);}
+      return seg+' ';};
+    d=pts(1)+pts(-1);
+    const rx=126*s>126?126:126*s, ry=126*s>126?126/s:126;
+    rails='M '+(-rx)+' '+ry+' L '+rx+' '+(-ry)+' M '+(-rx)+' '+(-ry)+' L '+rx+' '+ry;}
+  $('lvlCurve').setAttribute('d',d); $('lvlCurve').setAttribute('stroke',pColor);
+  $('lvlRails').setAttribute('d',rails); $('lvlRails').setAttribute('stroke',pColor);
+  $('railRead').textContent=neg?'0 RAILS · AN ELLIPSE':zero?'1 RAIL · TWO LINES':'2 RAILS · A HYPERBOLA';
+  $('railRead').style.color=pColor;
+
+  /* fig 5 — roots of t² = p (60 px per unit; off-line pair floats on the j-axis) */
+  const g=$('rDots'); g.innerHTML='';
+  const dot=(x,y,hollow)=>{const c=document.createElementNS(NS,'circle');
+    c.setAttribute('cx',280+x*60); c.setAttribute('cy',60-y*38);
+    c.setAttribute('r','7');
+    c.setAttribute('fill',hollow?'transparent':pColor);
+    c.setAttribute('stroke',pColor); c.setAttribute('stroke-width','2.2');
+    if(hollow) c.setAttribute('stroke-dasharray','3 3');
+    g.appendChild(c);};
+  $('rAxis').setAttribute('opacity',neg?'.7':'0');
+  if(pos){const s=Math.sqrt(p); dot(s,0,false); dot(-s,0,false);
+    $('rootRead').textContent='2 REAL ROOTS · t = ±'+fmt(s);}
+  else if(zero){dot(0,0,false);
+    $('rootRead').textContent='1 ROOT, DOUBLED · t = 0';}
+  else {const s=Math.sqrt(-p); dot(0,s,true); dot(0,-s,true);
+    $('rootRead').textContent='0 ON THE LINE · t = ±'+fmt(s)+'·j — one floor up';}
+  $('rootRead').style.color=pColor;
+
+  /* level-set grid, drawn once */
+  if(!render.gridDone){render.gridDone=true; const gg=$('lvlGrid');
+    for(let k=-2;k<=2;k++){ if(!k) continue;
+      const v=document.createElementNS(NS,'line');
+      v.setAttribute('x1',k*U); v.setAttribute('x2',k*U);
+      v.setAttribute('y1',-126); v.setAttribute('y2',126);
+      v.setAttribute('stroke','var(--grid)'); gg.appendChild(v);
+      const h=document.createElementNS(NS,'line');
+      h.setAttribute('y1',k*U); h.setAttribute('y2',k*U);
+      h.setAttribute('x1',-126); h.setAttribute('x2',126);
+      h.setAttribute('stroke','var(--grid)'); gg.appendChild(h);}}
+}
+
+/* ——— clicks: chips + flips ——— */
+document.addEventListener('click',e=>{
+  if(e.target.closest('a')||e.target.closest('[data-dragel]')) return;
+  const ps=e.target.closest('[data-pset]');
+  if(ps){setP(parseFloat(ps.dataset.pset)); return;}
+  const t=e.target.closest('[data-t]');
+  if(t){t.dataset.on=t.dataset.on==='1'?'0':'1';}
+});
+
+/* ——— the j² slider (sticky at −1 · 0 · +1) ——— */
+let pd=false; const psl=$('psl');
+function setFromSlider(e){
+  const r=psl.getBoundingClientRect();
+  const x=(e.clientX-r.left)/r.width*600;
+  let p=(x-300)/143;
+  p=Math.max(-2,Math.min(2,p));
+  for(const m of [-1,0,1]) if(Math.abs(p-m)<.09){p=m;break;}
+  setP(Math.round(p*100)/100);
+}
+psl.setAttribute('data-dragel','');
+psl.addEventListener('pointerdown',e=>{pd=true;psl.setPointerCapture(e.pointerId);setFromSlider(e);e.preventDefault();});
+psl.addEventListener('pointermove',e=>{if(pd)setFromSlider(e);});
+addEventListener('pointerup',()=>{pd=false;});
+
+/* ——— drag a on the mirror line ——— */
+let md=false; const mir=$('mirror'), mA=$('mA');
+mA.setAttribute('data-dragel','');
+mA.addEventListener('pointerdown',e=>{md=true;mA.setPointerCapture(e.pointerId);e.preventDefault();e.stopPropagation();});
+mA.addEventListener('pointermove',e=>{
+  if(!md) return;
+  const r=mir.getBoundingClientRect();
+  let u=((e.clientX-r.left)/r.width*560-280)/60;
+  u=Math.max(-4,Math.min(4,Math.round(u*10)/10));
+  S.a=u; render();
+});
+mA.addEventListener('pointerup',()=>{md=false;});
+
+/* ——— the time rail: light the dot of the entry in view ——— */
+const obs=new IntersectionObserver(es=>{
+  es.forEach(en=>{en.target.dataset.here=en.isIntersecting?'1':'0';});
+},{rootMargin:'-30% 0px -55% 0px'});
+document.querySelectorAll('.entry').forEach(el=>obs.observe(el));
+
+/* expose for headless verification */
+window.__journal={get:()=>({...S}), setP};
+render();
+</script>
+</body>
+</html>

--- a/public/number-planes/journal.html
+++ b/public/number-planes/journal.html
@@ -135,7 +135,7 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
   </header>
 
   <div style="font-family:var(--hand);font-size:15.5px;color:var(--dim);margin-top:-16px;">so far:
-    <a href="#e1" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">the wrong question</a> &middot;
+    <a href="#e1" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">are there other options?</a> &middot;
     <a href="#e2" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">the demands</a> &middot;
     <a href="#e3" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">strangers</a> &middot;
     <a href="#e4" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">one knob</a> &middot;
@@ -149,15 +149,16 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
     <article class="entry" id="e1">
       <span class="tdot"></span>
       <span class="elab">ENTRY 01 &middot; EARLY</span>
-      <h2 class="etitle">the wrong question</h2>
+      <h2 class="etitle">are there other options?</h2>
       <div class="ebody">
         <div class="prose">
-          <p><span class="q">What is a complex number?</span> &mdash; that was the question as first written. It has the wrong shape. A dot in the plane isn&rsquo;t a number, any more than a bead on a wire is. What made the line <em>numbers</em> was never its points &mdash; it was the two ways of combining them. An addition. A multiplication. Fix those two rules and everything else follows them around.</p>
-          <p>So the question worth keeping: <span class="q">on the plane, which two rules?</span></p>
+          <p><span class="q">When I think of &ldquo;the number plane,&rdquo; I think of complex numbers.</span> That was the first sentence in these pages &mdash; and underneath it, the question that would not sit still: <span class="q">are there other options?</span></p>
+          <p>Before hunting for options, a sharper look at the thing itself. A dot in the plane isn&rsquo;t a number, any more than a bead on a wire is. What made the line <em>numbers</em> was never its points &mdash; it was the two ways of combining them. An addition. A multiplication. Fix those two rules and everything else follows them around.</p>
+          <p>So the hunt has a shape now: keep the plane&rsquo;s points, and ask <span class="q">which rules could govern them.</span></p>
         </div>
         <aside class="margin">
           <div class="mgn">a number system is the pair of rules, not the set of dots. <a href="cards/index.html#L1">card L1</a></div>
-          <div class="mgn later">later &mdash; the whole notebook came out of this re-asking.</div>
+          <div class="mgn later">later &mdash; the question found its final form on <a href="./">the cover</a>: does the number plane <em>have</em> to be complex? let&rsquo;s find out.</div>
         </aside>
       </div>
     </article>
@@ -201,7 +202,7 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
       <h2 class="etitle">the strangers experiment</h2>
       <div class="ebody">
         <div class="prose">
-          <p>Tried the laziest plane multiplication first: keep the coordinates apart, strangers to each other &mdash; multiply each slot on its own.</p>
+          <p>Complex numbers are defined by their addition and their multiplication. But other ways of multiplying a plane are easy to write down &mdash; so easy it&rsquo;s almost suspicious that one of them gets all the fame. Tried the laziest first: keep the coordinates apart, strangers to each other &mdash; multiply each slot on its own.</p>
           <div class="fig">
             <div class="flab">FIG. 2 &middot; A WORKED COMPUTATION, TAPED IN</div>
             <div style="font-family:var(--mono);font-size:14px;line-height:2;color:var(--ink);padding:6px 2px 2px;">
@@ -211,9 +212,10 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
             <div class="fcap">two honest nonzero numbers, and their product is nothing.</div>
           </div>
           <p>It <em>works</em> &mdash; distributes, and <span class="m">(1,1)</span> plays 1. But it feels like two lines taped side by side, not a plane: nothing ever crosses between the slots, and the zero-product pairs sit there like a leak in the boat.</p>
-          <p>Logged as a disappointment. Question kept anyway: <span class="q">is this the only way to multiply a plane &mdash; or one of many?</span></p>
+          <p>Logged as a disappointment. But the disappointment sharpens the hunt: if lazy multiplications are this easy to invent, <span class="q">what exactly are the constraints &mdash; and how many survivors do they leave?</span></p>
         </div>
         <aside class="margin">
+          <div class="mgn">&ldquo;I can already think of other ways&hellip; but what are the constraints?&rdquo; &mdash; from the record.</div>
           <div class="mgn"><a href="cards/index.html#L2">card L2</a> &mdash; the strangers product.</div>
           <div class="mgn later">much later &mdash; not a dead end at all. this was j&sup2; = +1 wearing a disguise. <a href="#e5">&rarr; entry 05</a></div>
         </aside>
@@ -249,6 +251,7 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
         <aside class="margin">
           <div class="mgn">j&sup2; = p &mdash; the knob the rest of this notebook keeps turning. <a href="cards/index.html#PL">card PL</a></div>
           <div class="mgn">the &ldquo;exactly one&rdquo; promised back in <a href="#e2">entry 02</a>.</div>
+          <div class="mgn later">&ldquo;the family was a slider before it was a theory&rdquo; &mdash; from the record. the knob was played with long before it was understood.</div>
         </aside>
       </div>
     </article>
@@ -286,7 +289,7 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
               </div>
             </div>
           </div>
-          <p>And the two-rail world &mdash; the hyperbola riding its crossed asymptotes &mdash; is the strangers experiment of <a href="#e3">entry 03</a>, found again from the inside. The disappointment was a world all along.</p>
+          <p>And the two-rail world &mdash; the hyperbola riding its crossed asymptotes &mdash; is the strangers experiment of <a href="#e3">entry 03</a>, found again from the inside: tilt to the split plane&rsquo;s own diagonal basis and its multiplication is exactly slot-by-slot. The disappointment was a world all along. So the trichotomy was never a zoo of exotic rules &mdash; it measures one thing: <span class="q">how much the two axes entangle.</span></p>
         </div>
         <aside class="margin">
           <div class="mgn"><a href="cards/index.html#DV">card DV</a> &mdash; three planes, at the cuts.</div>

--- a/public/number-planes/journal.html
+++ b/public/number-planes/journal.html
@@ -124,7 +124,7 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
 
   <header style="display:flex;align-items:baseline;gap:16px;flex-wrap:wrap;">
     <div>
-      <div style="font-family:var(--mono);font-size:9px;letter-spacing:.4em;color:var(--voice);margin-bottom:10px;">A NOTEBOOK IN TIME &middot; ENTRIES 01&ndash;06 &middot; ONE p UNDER EVERYTHING BELOW</div>
+      <div style="font-family:var(--mono);font-size:9px;letter-spacing:.4em;color:var(--voice);margin-bottom:10px;">A NOTEBOOK IN TIME &middot; ENTRIES 00&ndash;06 &middot; ONE p UNDER EVERYTHING BELOW</div>
       <h1 style="margin:0;font-style:italic;font-weight:400;font-size:clamp(34px,6vw,48px);line-height:.98;letter-spacing:-.015em;">the journal</h1>
       <div style="font-family:var(--hand);font-size:19px;color:var(--live);margin-top:10px;">questions on top of questions &mdash; small answers, kept in the order they came.</div>
     </div>
@@ -135,6 +135,7 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
   </header>
 
   <div style="font-family:var(--hand);font-size:15.5px;color:var(--dim);margin-top:-16px;">so far:
+    <a href="#e0" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">a complaint about trigonometry</a> &middot;
     <a href="#e1" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">are there other options?</a> &middot;
     <a href="#e2" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">the demands</a> &middot;
     <a href="#e3" style="color:var(--live);text-decoration:none;border-bottom:1px dotted var(--live);">strangers</a> &middot;
@@ -144,6 +145,25 @@ button{font:inherit;color:inherit;background:none;border:0;padding:0;cursor:poin
   </div>
 
   <div class="entries">
+
+    <!-- ══ ENTRY 00 ══ -->
+    <article class="entry" id="e0">
+      <span class="tdot"></span>
+      <span class="elab">ENTRY 00 &middot; FOUND LATER, FILED FIRST</span>
+      <h2 class="etitle">a complaint about trigonometry</h2>
+      <div class="ebody">
+        <div class="prose">
+          <p>An older conversation, surfaced after these pages were underway and filed here at the front, because everything below descends from it. It began not with a plane but with a grievance: <span class="q">why do sin and cos feel unnatural next to polynomials and exponentials?</span></p>
+          <p>The grievance dissolved on inspection &mdash; &ldquo;natural&rdquo; names a relation between a function and whichever operations are licensed as primitive, not a property of the function &mdash; and Euler collapsed the gap anyway: <span class="m">e<sup>i&theta;</sup> = cos&thinsp;&theta; + i&middot;sin&thinsp;&theta;</span>. The trig functions are the exponential, met along the wrong axis.</p>
+          <p>But the conversation left a residue. Asking which maps of the plane deserve the name <em>differentiable</em> turned into asking which 2&times;2 matrices form a number system &mdash; and there were exactly three, by what the special element squares to: <span class="m">&minus;1, 0, +1</span>. A circle, a pair of lines, a hyperbola. Filed at the time as a curiosity, three doors passed in a hallway on the way to somewhere else. It was the whole subject, waiting.</p>
+        </div>
+        <aside class="margin">
+          <div class="mgn">the whole conversation is kept in the record &mdash; the seed, verbatim (docs/&hellip;/conversations).</div>
+          <div class="mgn later">later &mdash; the special element became j, its square became the knob. <a href="#e4">&rarr; entry 04</a></div>
+          <div class="mgn later">and the three curves passed in the hallway became fig.&thinsp;4. <a href="#e5">&rarr; entry 05</a></div>
+        </aside>
+      </div>
+    </article>
 
     <!-- ══ ENTRY 01 ══ -->
     <article class="entry" id="e1">


### PR DESCRIPTION
## What this is

The **directional pivot**: the notebook gains its temporal spine and its first world interior, grounded in the project's own recorded history.

**Live preview:** https://claude-number-plane-directio.animath.pages.dev/number-planes/

| Piece | What it does |
|---|---|
| `journal.html` — **the journal** | Entries in time (00–06): central working prose in the notebook voice (no reader-address), hand-gloss margins where **backward refs live in the prose and forward refs are later-added margin notes**, plates pasted in sparingly, one p under every figure. Entry 00 (*a complaint about trigonometry* — FOUND LATER, FILED FIRST) opens on the seed conversation; entry 01 on the seed question; entries 3→5 carry the strangers-experiment thread from disappointment to resolution |
| `dual.html` — **the dual room** | The first world interior (p = 0 is home) with the sticky **pocket dial** (knob + level curve + the j² landing point — the everywhere-reachable core cluster). Centerpiece: the j-slot of f(a + b·j) IS the derivative-estimator family — **centered difference** (p&gt;0, rails at a±h) · **exact forward-mode autodiff** (p=0) · **complex step** (p&lt;0, samples one floor up) — both neighbors converge to the dual slot as p→0. Plus the Galilean ruler, the parameter composer (angles/velocities/rapidities add), the wall-from-both-sides plate, six seals |
| `conversations/` | The two seed chat transcripts, verbatim, with a provenance README — primary sources |
| `THE-UNFOLDING.md` | The recorded question-chain: 287 moments mined from the session archive → 17 steps with verbatim quotes + 17 kept dead ends; Step 0 indexes the seed conversations |
| `WALKS.md` | Three designed walks (sculpture-garden frame): **Residents'** (senses; knob last) · **Analysis Door** (theorems; knob as the door) · **Machines** (tools; knob in the hardware) — stations mapped to existing artifacts vs to-build, ranked shared inventory |
| Cover | Two new door leaves: the journal, the dual room |

## Design decisions carried

- **The record is the style, not the script** — entries are constructions for clarity and the fun of learning together; real questions/quotes/dead-ends woven in where they also teach best ("from the record" margin marks).
- **Sculpture-garden frame** — grounds primary, every linear presentation a leaflet; the journal is leaflet #1, the founder's recorded walk.
- Flip faces keep **definite heights** everywhere (the iOS `height:100%` rule from #246); glosses rest visible; one p per page.

## Verification

Headless Chromium on both new pages: p driven to −1/−0.4/0/+0.4/+1 (knob, level curves, estimator badge/error, ruler, composer, wall all track), zero horizontal overflow at 390px (one overflow bug found and fixed), per-face height ≡ vat invariants, full-page screenshots desktop + phone + Daylight skin. `npm run build` green. Real-device check still open (`phone-needed`), as usual.

> Base is **`number-plane-guide`** (stacked), not `main`, per the branch-sync rule — same stack as #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BQg2nynHwQiy1b2WHG95Pc

---
_Generated by [Claude Code](https://claude.ai/code/session_01BQg2nynHwQiy1b2WHG95Pc)_