### PR TITLE
Chrome hardening: WebGL failure containment, a11y batch, viewport-clamped layouts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,7 @@ animath/
     │   ├── previews.tsx        # cheap animated canvas previews for the cards
     │   ├── readouts.tsx        # Breakdown/MiniHisto/Sparkline/StatGrid/Kicker
     │   ├── usePhone.ts         # ≤740px matchMedia hook (phone re-chrome)
+    │   ├── RouteBoundary.tsx   # per-route error boundary (named error panel; WebGL containment)
     │   └── workspace/          # the workspace engine
     │       ├── types.ts        # SectionDef / ViewDef / LayoutDef / WorkspaceProps
     │       ├── archetypes.ts   # 11 archetypes · 5 tiers (closed vocabulary)

--- a/docs/sessions/progress/chrome-hardening/2026-07-18-QUESTIONS-for-dan.md
+++ b/docs/sessions/progress/chrome-hardening/2026-07-18-QUESTIONS-for-dan.md
@@ -1,3 +1,18 @@
+---
+kind: plan
+session: 2026-07-18-S01
+date: 2026-07-18
+title: Open product-direction questions (post external review)
+branch: claude/chrome-hardening
+slug: chrome-hardening
+status: proposed
+build: n/a
+followup: null
+pr: null
+app: chrome, general
+next: Dan answers; each answer unblocks its item independently.
+---
+
 # Open questions for Dan — product direction after the external review
 
 Everything mechanical from the external review (GPT sol 5.6) is done or in PR

--- a/docs/sessions/progress/chrome-hardening/2026-07-18-QUESTIONS-for-dan.md
+++ b/docs/sessions/progress/chrome-hardening/2026-07-18-QUESTIONS-for-dan.md
@@ -1,0 +1,161 @@
+# Open questions for Dan — product direction after the external review
+
+Everything mechanical from the external review (GPT sol 5.6) is done or in PR
+#252. What remains needs your editorial judgment. Each question below is
+decision-ready: context, options, and my recommendation. Answer in any order —
+none block each other.
+
+---
+
+## 1. The gallery entrance: which three apps lead?
+
+The review's highest-leverage product suggestion is a **"Start here" row** so a
+first visitor isn't handed twelve equal cards. The mechanism is cheap (a
+`starter: true` flag in `catalog.ts`); the *choice* is editorial.
+
+**My candidates** (one per temperament):
+
+- **Counting the Ways** — the review called it the best teaching design; its
+  narrated Play-tutorial is the closest thing to a guided lesson.
+- **Trinary System** — after the overhaul it has the strongest
+  question-and-payoff arc (drop a planet in, watch predictability die).
+- **Stable Matching** — no WebGL requirement, superb step feedback, and it
+  represents the algorithms side.
+
+(Complex Particles is the historical flagship, but it's the *deepest* app, not
+the friendliest first door. It could be the fourth card or the "when you're
+ready" pointer.)
+
+**Question:** Which three? And should the hero copy name the row ("New here?
+Start with one of these") or stay quieter?
+
+## 2. Card metadata: which fields earn pixels?
+
+The review proposes level/prerequisites, expected time, guided-vs-open-lab,
+GPU requirement, and "the mathematical question being explored" on every card.
+All five would crowd the cards.
+
+**My recommendation:** two visible + one implicit —
+- **the question** (one line, italic, replacing nothing — the blurb already
+  gestures at it; this would sharpen each blurb into an actual question),
+- **guided / open-lab** (a small chip; maps to "has a tour/Play-tutorial"),
+- **GPU requirement** shown only as a tiny badge on the WebGL apps (now that
+  failure is contained, this is a courtesy, not a warning).
+
+Skip "expected time" (nobody's estimate survives contact) and "level" (the
+apps aren't leveled; pretending they are invites wrong expectations).
+
+**Question:** Agree with the two-plus-badge set? Any field you'd fight for?
+
+## 3. Category taxonomy: adopt the reviewer's five?
+
+Current categories stretch (Counting the Ways ≠ Probability's neighbor Fractals
+in any meaningful sense). The reviewer proposes: **Transformations · Iteration
+& Chaos · Algorithms & Emergence · Geometry & Topology · Probability &
+Inference**.
+
+**My take:** the proposed five are better than what's there, and re-binning is
+a 20-minute `catalog.ts` edit. The only judgment calls: Complex Particles and
+Argand (Transformations?), Trinary (Iteration & Chaos), Trees and Nets
+(Algorithms & Emergence or Geometry?).
+
+**Question:** Adopt the five as-is, adjust names, or leave categories alone?
+
+## 4. Paper as the default theme?
+
+The reviewer's aesthetic case: "Observatory looks like an excellent technical
+dashboard; Paper looks like AniMath — a mathematical notebook from slightly in
+the future." Technically free — theming v2 already lets the force-dark scenes
+(Trinary, Complex Particles) keep their dark stages under a Paper chrome, and
+returning visitors' persisted skin choices are untouched (the default only
+affects first visits).
+
+**My take:** genuinely a taste call — this is the product's face and it's
+yours. If you're 60/40 on it, the cheap experiment is flipping the default for
+a week on the Cloudflare preview and living with it.
+
+**Question:** Flip the default to Paper, trial it on preview first, or keep
+Observatory?
+
+## 5. Explainer layering: adopt the structure, and where does attribution live?
+
+The review is right that the "?" modals are encyclopedic (and occasionally
+leak implementation detail — filenames, test architecture). Proposed layering:
+
+1. Three short inline callouts (what the objects are, what colors mean, what
+   to watch) — possibly surfaced in the workspace itself, not the modal.
+2. "Why does this happen?" — the current explainer core, trimmed.
+3. Derivation — properly typeset, expandable.
+4. **Methods / Sources / Implementation** — separate tabs or sections.
+
+The wrinkle is the **"Possible sources & where to go further"** blocks: they're
+a deliberate attribution policy (ATTRIBUTION.md), not noise. Layering keeps the
+policy intact — layer 4 becomes their home — but I want your confirmation
+before restructuring every EXPLAINER.md, since it touches all thirteen apps and
+the template in BUILDING_AN_APP.md.
+
+**Question:** Adopt the four-layer structure as the new convention? Should
+implementation notes (DEEP_ZOOM method docs etc.) stay reachable from the modal
+or move to repo-only docs?
+
+## 6. Gallery previews and motion: how far to go?
+
+Unambiguous (I'll do these without further asking, next session):
+`prefers-reduced-motion` renders static frames; offscreen previews pause.
+
+The open part is the reviewer's stronger suggestion — **static until
+hover/focus** plus a "Pause previews" control. That materially changes the
+gallery's character, and the same reviewer scored the animated gallery as a
+top strength. My recommendation: don't go static-by-default; do add the pause
+control tucked into the hero row.
+
+**Question:** Reduced-motion + offscreen-pause + a pause control — enough? Or
+do you want static-until-hover?
+
+## 7. Tablet / landscape-phone mode: build it now?
+
+The phone re-chrome only engages below 740px *width*, so an 844px-wide
+landscape phone gets the draggable desktop workspace with 26–36px targets.
+The fix is a real (if contained) piece of work: a compact mode keyed on
+width × height × coarse-pointer, 44px targets, safe-area insets — and honest
+testing needs a physical device, which I don't have.
+
+**My take:** worth doing, but it's the largest remaining item and the least
+verifiable from here. I'd sequence it after the entrance work, and I'd want
+you (or a real device) in the verification loop.
+
+**Question:** Green-light it next, or park it until there's device access?
+
+## 8. Contrast + focus-color pass: pick the accessible focus colors
+
+The reviewer measured Paper's small amber text at ~3.0–3.5:1 (below WCAG's
+4.5:1 for normal text) and notes the focus ring shouldn't assume the
+decorative accent works. The fix is token-level: per-skin `--focus` (and
+possibly a darkened `--accent-strong` for small text), which changes how every
+skin looks in its details.
+
+**Question:** May I run a systematic pass that *proposes* per-skin adjusted
+tokens (with before/after screenshots per skin × mode), for you to approve
+before merge — rather than changing colors unilaterally?
+
+## 9. Leftovers from the Trinary review (still open, unchanged)
+
+Restating so they don't get lost — all four from the legibility synthesis:
+
+- **Immersive Observatory** (full-stage stars vs instrument-on-a-desk feel);
+- **Launch-speed units** (absolute vs ×circular, matching the Lab);
+- **`role: 'start'` on SectionDef** (explicit "start here" panel vs trusting
+  the emergent Button/accent hierarchy — I still recommend waiting);
+- **Anchored tour framework** (spotlight/pointing tours as a chrome feature —
+  would also serve the review's "guided grammar" goal across apps).
+
+**Question:** Any of these you want pulled forward? My priority among them
+would be the anchored tour framework, since it compounds with the entrance
+work (#1–2).
+
+---
+
+*Also noted, no question needed: the layout clamp currently runs at layout
+application, not on live window resize — shrinking the window after opening
+can still push panels off-stage until the next layout pick. Small follow-up;
+I'll fold it into whichever session touches the workspace engine next.*

--- a/docs/sessions/progress/chrome-hardening/2026-07-18-S01-chrome-hardening.md
+++ b/docs/sessions/progress/chrome-hardening/2026-07-18-S01-chrome-hardening.md
@@ -1,0 +1,104 @@
+---
+kind: progress
+session: 2026-07-18-S01
+date: 2026-07-18
+title: Chrome hardening — failure containment, a11y batch, layout clamp
+branch: claude/chrome-hardening
+slug: chrome-hardening
+status: complete
+build: passing
+followup: null
+pr: null
+app: chrome
+next: Remaining external-review items — Start-here gallery row + card metadata, layered explainers, reduced-motion previews, tablet breakpoint.
+---
+
+# Chrome hardening — failure containment, a11y batch, layout clamp
+
+## Session purpose
+
+Execute the top shared-chrome items from the external product review (GPT sol
+5.6, relayed by Dan 2026-07-18): catastrophic WebGL failure containment, the
+mechanical accessibility batch, and viewport-clamped layouts. These are the
+fix-once-benefit-everywhere items; the editorial items (Start-here row, layered
+explainers, Paper-as-default) are deliberately left for Dan's direction.
+
+## Previous session
+
+`trinary-legibility/2026-07-17-S01` — merged to main as PR #250.
+
+## Working notes
+
+### 🟢 code · 18:20 — WebGL failure containment + route titles
+**Why:** With WebGL unavailable, 3D routes threw during renderer creation and
+blanked the whole page unrecoverably (review finding #4, verified reproducible).
+
+- `chrome/RouteBoundary.tsx` — per-route error boundary, keyed by route so
+  navigation always recovers; named error panel with Home (a real link) +
+  Retry; recognizes WebGL-flavored errors and explains likely causes.
+- `Canvas3D` — `hasWebGL()` capability probe (cached) + try/catch around
+  renderer creation; on failure renders an in-place "3D view unavailable"
+  notice INSIDE the view body, so the workspace chrome (rail, panels, action
+  strip) stays fully alive — verified: under `--disable-3d-apis` the Trinary
+  workspace renders completely with only the Orbit view reporting.
+- Route titles: `document.title = "<App> · animath"` per route (appends to the
+  boot title so Cloudflare preview branch names survive).
+
+### 🟢 code · 18:24 — A11y batch (all shared chrome)
+**Why:** Review finding #5 — every item mechanical, every item fix-once.
+
+- **ExplainerModal focus trap**: focus moves into the dialog on open, Tab
+  cycles inside it, Esc closes, focus restores to the opener. Verified by
+  driving 12 Tab presses headlessly — focus never escaped, and closing put it
+  back on the "?" button.
+- **Real links**: gallery cards and the TopBar Home brand are now `<a href>`
+  (copyable, open-in-new-tab, link-list navigable) instead of hash-mutating
+  buttons; CSS normalized so they render identically.
+- **`<main>` landmark** on the gallery scroll region.
+- **`aria-pressed`** on every Pills segmented button (was CSS-color-only state).
+
+### 🟢 code · 18:26 — Viewport-clamped layouts
+**Why:** Authored layouts use absolute positions against a roomy reference
+viewport; on shorter stages panels extended past the overflow:hidden edge and
+became unreachable (Argand "Essentials runs 136px below the fold"; the same
+class bit Trinary's Sandbox during the legibility work).
+
+`clampToViewport()` in `workspace/layouts.ts` (pure, unit-tested): panels keep
+their whole card on-stage (a too-tall card pins to the top and its body
+scrolls); view rects clamp and shrink to fit. `applyLayout` takes an optional
+viewport; `DesktopWorkspace` passes the stage size (window minus the 54px bar)
+at initial load and on every layout pick. Null/degenerate viewports are no-ops
+so tests and persisted-state paths are unaffected.
+
+### 🟡 milestone · 18:30 — Verified end-to-end
+**Why:** The review's findings were empirical; the fixes must be too.
+
+Headless verification: (1) `--disable-3d-apis` browser → Trinary and Solid
+Worlds both render contained fallbacks with the chrome alive, Home reachable —
+no blank pages; (2) gallery shows 12 `<a>` cards + `<main>`; (3) route titles
+"Trinary System · animath" / "Stable Matching · animath"; (4) the focus trap
+holds and restores. `npm test` 307 pass (4 new clamp tests) · build clean ·
+lint 0 errors.
+
+## Deferred (need Dan's editorial direction)
+
+- Start-here gallery row + per-card metadata (level/time/GPU/question) —
+  additive `catalog.ts` schema, but WHICH three apps lead is Dan's call.
+- Layered explainers (callouts → why → derivation → methods/sources).
+- Paper as default theme; category taxonomy rename.
+- Reduced-motion/offscreen-paused previews; tablet breakpoint (coarse-pointer).
+
+## Self-reflection
+
+**What went well:** All three items were genuinely fix-once — no app files
+touched at all. The no-WebGL verification proved the containment design choice
+(probe in Canvas3D rather than only the boundary) right: the workspace chrome
+surviving makes the failure feel local, not fatal.
+
+**What to watch:** The clamp runs at layout application, not on window resize —
+resizing smaller after opening can still push panels off-stage until the next
+layout pick. Acceptable for now (the review's bug was at load), noted as a
+possible follow-up. `PANEL_W = 268` duplicates the CSS width constant.
+
+**Follow-up value:** MEDIUM — the deferred editorial items are the remaining
+half of the external review, and they need Dan's choices before implementation.

--- a/docs/sessions/progress/chrome-hardening/2026-07-18-S01-chrome-hardening.md
+++ b/docs/sessions/progress/chrome-hardening/2026-07-18-S01-chrome-hardening.md
@@ -5,8 +5,8 @@ date: 2026-07-18
 title: Chrome hardening — failure containment, a11y batch, layout clamp
 branch: claude/chrome-hardening
 slug: chrome-hardening
-status: complete
-build: passing
+status: completed
+build: passed
 followup: null
 pr: null
 app: chrome

--- a/src/chrome/ExplainerModal.tsx
+++ b/src/chrome/ExplainerModal.tsx
@@ -1,7 +1,37 @@
-import React, { Suspense } from 'react';
+import React, { Suspense, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Icon } from './icons';
 import { useEscLayer } from './useEscLayer';
+
+const FOCUSABLE = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+
+/** Trap Tab inside the dialog while it's open, focus it on open, and restore
+ *  focus to the opener on close — without this, Tab kept driving the controls
+ *  BEHIND the dialog, and closing dropped keyboard users at the document root. */
+function useFocusTrap(ref: React.RefObject<HTMLElement>) {
+  useEffect(() => {
+    const dlg = ref.current;
+    const opener = document.activeElement as HTMLElement | null;
+    dlg?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== 'Tab' || !dlg) return;
+      const items = Array.from(dlg.querySelectorAll<HTMLElement>(FOCUSABLE));
+      if (!items.length) return;
+      const first = items[0], last = items[items.length - 1];
+      const active = document.activeElement;
+      const escaped = !dlg.contains(active);
+      if (e.shiftKey ? active === first || escaped : active === last || escaped) {
+        e.preventDefault();
+        (e.shiftKey ? last : first).focus();
+      }
+    };
+    document.addEventListener('keydown', onKey, true);
+    return () => {
+      document.removeEventListener('keydown', onKey, true);
+      opener?.focus?.();
+    };
+  }, [ref]);
+}
 
 // Lazy so `marked` only enters the bundle when an explainer is opened.
 const Readme = React.lazy(() => import('../components/Readme'));
@@ -24,13 +54,17 @@ export function ExplainerModal({ title, markdown, onClose }: {
   onClose: () => void;
 }) {
   useEscLayer(true, onClose);
+  const dialogRef = useRef<HTMLDivElement>(null);
+  useFocusTrap(dialogRef);
   return createPortal(
     <div className="am-modal-scrim" onPointerDown={onClose} role="presentation">
       <div
+        ref={dialogRef}
         className="am-modal"
         role="dialog"
         aria-modal="true"
         aria-label={`${title} — explainer`}
+        tabIndex={-1}
         onPointerDown={e => e.stopPropagation()}
       >
         <div className="am-modal-head">

--- a/src/chrome/Gallery.tsx
+++ b/src/chrome/Gallery.tsx
@@ -23,8 +23,10 @@ export default function Gallery() {
   const stored = CARDS.filter(c => c.storeroom);
   const mainCount = CARDS.filter(c => !c.storeroom).length;
 
+  // Cards are real links (not hash-mutating buttons): copyable, open-in-new-tab,
+  // and visible to assistive tech's link navigation.
   const renderCard = (a: (typeof CARDS)[number]) => (
-    <button key={a.id} className="am-gcard" onClick={() => { window.location.hash = '#' + a.hash; }}>
+    <a key={a.id} className="am-gcard" href={'#' + a.hash}>
       <div className="am-gcard-viz"><Preview kind={a.kind} skin={skin} mode={mode} /></div>
       <div className="am-gcard-body">
         <div className="am-gcard-cat">{a.cat}</div>
@@ -32,7 +34,7 @@ export default function Gallery() {
         <div className="am-gcard-blurb">{a.blurb}</div>
         <div className="am-gcard-open">Open workspace <Icon name="chevron" size={13} /></div>
       </div>
-    </button>
+    </a>
   );
   // Randomized hero verbs — three drawn per load, the strangest one last.
   // Clicking the headline rerolls them (a quiet easter egg), cross-fading
@@ -54,7 +56,7 @@ export default function Gallery() {
         note="A toolkit for exploring mathematics through visualization"
         home={false}
       />
-      <div className="am-gal-scroll">
+      <main className="am-gal-scroll" aria-label="Animation gallery">
         <div className="am-gal-hero">
           <h1
             className={`am-gal-title am-gal-title-roll${swapping ? ' is-swapping' : ''}`}
@@ -99,7 +101,7 @@ export default function Gallery() {
             )}
           </div>
         )}
-      </div>
+      </main>
     </div>
   );
 }

--- a/src/chrome/RouteBoundary.tsx
+++ b/src/chrome/RouteBoundary.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+
+/**
+ * Error boundary around each route. Without it, a runtime error anywhere in an
+ * app (most commonly WebGL context creation in a restricted environment) blanks
+ * the whole page with no way back — Back stays blank, only a reload recovers.
+ * The boundary contains the failure to the route and offers a named error panel
+ * with Home and Retry, keeping navigation alive.
+ *
+ * Keyed by route in the router: navigating to another route remounts the
+ * boundary, so an error never follows the user across apps.
+ */
+interface State { error: Error | null; }
+
+export class RouteBoundary extends React.Component<React.PropsWithChildren, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: React.ErrorInfo) {
+    console.error('[animath] route crashed:', error, info.componentStack);
+  }
+
+  private retry = () => this.setState({ error: null });
+
+  render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+    const webgl = /webgl|context|three/i.test(`${error.name} ${error.message}`);
+    return (
+      <div style={{
+        position: 'absolute', inset: 0, display: 'grid', placeItems: 'center',
+        background: 'var(--bg)', color: 'var(--fg)', padding: 24,
+      }}>
+        <div role="alert" style={{
+          maxWidth: 460, padding: '22px 24px', borderRadius: 13,
+          background: 'var(--panel)', border: '1px solid var(--border-strong)',
+          boxShadow: 'var(--shadow)', font: '14px/1.55 var(--font-ui, system-ui)',
+        }}>
+          <h2 style={{ margin: '0 0 8px', font: '700 17px/1.3 var(--font-display, system-ui)' }}>
+            This animation hit an error
+          </h2>
+          <p style={{ margin: '0 0 6px', color: 'var(--dim)' }}>
+            {webgl
+              ? 'It looks like 3D rendering (WebGL) is unavailable or restricted in this browser. Hardware acceleration being disabled, a strict privacy mode, or a remote desktop can cause this.'
+              : 'Something went wrong while running this animation.'}
+          </p>
+          <p style={{
+            margin: '0 0 16px', color: 'var(--dim-2)',
+            font: '11.5px/1.5 var(--font-mono, monospace)', wordBreak: 'break-word',
+          }}>
+            {error.name}: {error.message}
+          </p>
+          <div style={{ display: 'flex', gap: 8 }}>
+            <a href="#/" style={{
+              padding: '9px 16px', borderRadius: 7, textDecoration: 'none',
+              background: 'var(--accent)', color: 'var(--accent-fg)', fontWeight: 600,
+            }}>
+              Home
+            </a>
+            <button onClick={this.retry} style={{
+              padding: '9px 16px', borderRadius: 7, border: '1px solid var(--border)',
+              background: 'var(--panel-2)', color: 'var(--fg)', font: 'inherit', fontWeight: 600, cursor: 'pointer',
+            }}>
+              Retry
+            </button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}

--- a/src/chrome/TopBar.tsx
+++ b/src/chrome/TopBar.tsx
@@ -42,11 +42,11 @@ export function TopBar({ title, subtitle, modes, activeMode, onModeChange, expla
   return (
     <header className="am-bar" style={compact ? { padding: '0 10px' } : undefined}>
       {home ? (
-        <button className="am-brand am-home-btn" title="Home — all animations" aria-label="Home — all animations"
-          onClick={() => { window.location.hash = '#/'; }}>
+        <a className="am-brand am-home-btn" title="Home — all animations" aria-label="Home — all animations"
+          href="#/">
           <span className="am-brand-mark">a</span>
           <Icon name="home" size={13} className="am-home-hint" />
-        </button>
+        </a>
       ) : (
         <div className="am-brand"><span className="am-brand-mark">a</span></div>
       )}

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -412,7 +412,7 @@ body {
 .am-bar-sep { width: 1px; height: 24px; background: var(--border); margin: 0 2px; }
 
 /* Home button — the brand mark returns to the gallery (the only hub) */
-.am-home-btn { display: inline-flex; align-items: center; gap: 7px; padding: 4px 8px 4px 4px; border: 1px solid transparent; border-radius: 9px; background: transparent; color: var(--fg); font: inherit; cursor: pointer; position: relative; }
+.am-home-btn { display: inline-flex; align-items: center; gap: 7px; padding: 4px 8px 4px 4px; border: 1px solid transparent; border-radius: 9px; background: transparent; color: var(--fg); font: inherit; text-decoration: none; cursor: pointer; position: relative; }
 .am-home-btn:hover { background: var(--panel-2); border-color: var(--border); }
 .am-home-hint { color: var(--dim); opacity: 0; transform: translateX(-3px); transition: all .15s var(--ease); }
 .am-home-btn:hover .am-home-hint { opacity: .85; transform: none; }
@@ -581,7 +581,7 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-chip { padding: 7px 14px; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--dim); font: inherit; font-size: 12.5px; font-weight: 700; cursor: pointer; }
 .am-chip.am-on { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 .am-gal-grid { padding: 18px 40px 48px; display: grid; grid-template-columns: repeat(auto-fill, minmax(248px, 1fr)); gap: 16px; }
-.am-gcard { text-align: left; font: inherit; color: inherit; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: var(--panel-2); cursor: pointer; transition: transform .18s var(--ease), border-color .18s, box-shadow .18s; display: flex; flex-direction: column; padding: 0; }
+.am-gcard { text-align: left; font: inherit; color: inherit; text-decoration: none; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: var(--panel-2); cursor: pointer; transition: transform .18s var(--ease), border-color .18s, box-shadow .18s; display: flex; flex-direction: column; padding: 0; }
 .am-gcard:hover { transform: translateY(-3px); border-color: var(--border-strong); box-shadow: var(--shadow); }
 .am-gcard-viz { height: 132px; position: relative; background: #000; }
 .am-gcard-viz canvas { position: absolute; inset: 0; width: 100%; height: 100%; }

--- a/src/chrome/workspace/DesktopWorkspace.tsx
+++ b/src/chrome/workspace/DesktopWorkspace.tsx
@@ -44,7 +44,10 @@ export default function DesktopWorkspace(props: WorkspaceProps) {
     const wanted = defaultLayoutId ?? appLayouts?.[0]?.id ?? 'everything';
     return builtin.find(l => l.id === wanted) ?? builtin[builtin.length - 1];
   };
-  const initial = (): PersistedWorkspace => applyLayout(sections, views, defaultLayout(), []);
+  // Stage size for clamping authored layout geometry on-screen (the stage is
+  // the window minus the 54px top bar; see --bar-h in theme.css).
+  const stageViewport = () => (typeof window === 'undefined' ? null : { w: window.innerWidth, h: window.innerHeight - 54 });
+  const initial = (): PersistedWorkspace => applyLayout(sections, views, defaultLayout(), [], stageViewport());
 
   const [raw, setRaw] = usePersistentState<PersistedWorkspace | null>(`ws:${appId}`, null);
   const state = useMemo(
@@ -176,7 +179,7 @@ export default function DesktopWorkspace(props: WorkspaceProps) {
     update(s => ({ ...s, layout: 'custom', views: { ...s.views, [id]: { ...s.views[id], collapsed: !s.views[id].collapsed } } }));
 
   /* ---- layouts ---- */
-  const pickLayout = (l: LayoutDef) => update(s => applyLayout(sections, views, l, s.saved));
+  const pickLayout = (l: LayoutDef) => update(s => applyLayout(sections, views, l, s.saved, stageViewport()));
   const saveLayout = () => {
     const name = window.prompt('Name this layout', 'My layout');
     if (!name) return;

--- a/src/chrome/workspace/__tests__/layouts.test.ts
+++ b/src/chrome/workspace/__tests__/layouts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { applyLayout, compactZ, raiseWindow, sanitize, validateLayouts } from '../layouts';
+import { applyLayout, clampToViewport, compactZ, raiseWindow, sanitize, validateLayouts } from '../layouts';
 import { WS_RAIL } from '../geometry';
 import type { LayoutDef, PersistedWorkspace, SectionDef, ViewDef } from '../types';
 
@@ -35,6 +35,47 @@ describe('validateLayouts — authored panels must clear the rail band', () => {
 
   it('accepts panels at or beyond the rail clearance', () => {
     expect(validateLayouts([layout({ function: { x: WS_RAIL, y: 18 }, playback: { x: 400, y: 18 } })])).toEqual([]);
+  });
+});
+
+describe('clampToViewport — authored geometry must stay on-stage', () => {
+  const tall: SectionDef[] = [
+    { id: 'function', title: 'Function', arch: 'subject', node: null, estHeight: 400 },
+    { id: 'playback', title: 'Playback', arch: 'playback', node: null, estHeight: 200 },
+  ];
+
+  it('pulls a below-the-fold panel back into view (the Argand Essentials bug class)', () => {
+    // Panel authored at y:700 with estHeight 400 on a 800px-tall stage would
+    // run 300px past the bottom edge into overflow:hidden space.
+    const s = ws({ open: { function: { x: 84, y: 700, z: 1 } } });
+    const c = clampToViewport(s, tall, { w: 1400, h: 800 });
+    expect(c.open.function.y).toBeLessThanOrEqual(800 - 400 - 8);
+    expect(c.open.function.y).toBeGreaterThanOrEqual(8);
+  });
+
+  it('clamps a view rect into the stage and shrinks one that cannot fit', () => {
+    const s = ws({ views: { plot: { x: 1300, y: 900, w: 700, h: 1200, z: 1 }, aux: { x: 780, y: 16, w: 300, h: 300, z: 2 } } });
+    const c = clampToViewport(s, tall, { w: 1200, h: 700 });
+    const p = c.views.plot;
+    expect(p.x + p.w).toBeLessThanOrEqual(1200 - 8);
+    expect(p.y + p.h).toBeLessThanOrEqual(700 - 8);
+    expect(p.x).toBeGreaterThanOrEqual(WS_RAIL);
+  });
+
+  it('is a no-op for a null or degenerate viewport, and leaves fitting geometry alone', () => {
+    const s = ws();
+    expect(clampToViewport(s, tall, null)).toBe(s);
+    expect(clampToViewport(s, tall, { w: 50, h: 50 })).toBe(s);
+    const c = clampToViewport(s, tall, { w: 1600, h: 1000 });
+    expect(c.open.function.x).toBe(84);
+    expect(c.open.function.y).toBe(18);
+    expect(c.views.plot).toMatchObject({ x: 360, y: 16, w: 400, h: 300 });
+  });
+
+  it('applyLayout applies the clamp when given a viewport', () => {
+    const layout: LayoutDef = { id: 'l', name: 'L', open: { function: { x: 84, y: 700 } } };
+    const out = applyLayout(tall, views, layout, [], { w: 1400, h: 800 });
+    expect(out.open.function.y).toBeLessThanOrEqual(800 - 400 - 8);
   });
 });
 

--- a/src/chrome/workspace/layouts.ts
+++ b/src/chrome/workspace/layouts.ts
@@ -60,23 +60,69 @@ export function layoutViews(views: ViewDef[], layout: LayoutDef): Record<string,
   return out;
 }
 
-/** Full workspace state for a layout (panels stamped above the views). */
+/** Panel card width (must track theme.css .am-ws-panel). */
+const PANEL_W = 268;
+const STAGE_PAD = 8;
+
+/**
+ * Clamp authored geometry into the stage. Layouts are written against a
+ * roomy reference viewport; on a shorter/narrower one an absolute-positioned
+ * panel (or view) can extend past the stage edge into overflow:hidden space —
+ * part of the panel becomes permanently unreachable (the Argand "Essentials
+ * runs 136px below the fold" bug class). Pure; a null viewport is a no-op so
+ * tests and SSR-ish callers can skip it.
+ */
+export function clampToViewport(
+  state: PersistedWorkspace, sections: SectionDef[],
+  viewport: { w: number; h: number } | null,
+): PersistedWorkspace {
+  if (!viewport) return state;
+  const { w, h } = viewport;
+  if (!(w > 200 && h > 200)) return state; // degenerate measurements: leave as authored
+  const est = (id: string) => sections.find(s => s.id === id)?.estHeight ?? DEFAULT_EST;
+
+  const open: typeof state.open = {};
+  for (const id of Object.keys(state.open)) {
+    const p = state.open[id];
+    // Keep the whole card on-stage when it fits; a card taller than the stage
+    // pins to the top (its body scrolls internally).
+    const maxX = Math.max(WS_RAIL, w - PANEL_W - STAGE_PAD);
+    const maxY = Math.max(STAGE_PAD, h - est(id) - STAGE_PAD);
+    open[id] = { ...p, x: Math.min(Math.max(p.x, WS_RAIL), maxX), y: Math.min(Math.max(p.y, STAGE_PAD), maxY) };
+  }
+
+  const views: typeof state.views = {};
+  for (const id of Object.keys(state.views)) {
+    const v = state.views[id];
+    const vw = Math.min(v.w, w - WS_RAIL - STAGE_PAD);
+    const vh = Math.min(v.h, h - 2 * STAGE_PAD);
+    const x = Math.min(Math.max(v.x, WS_RAIL), Math.max(WS_RAIL, w - vw - STAGE_PAD));
+    const y = Math.min(Math.max(v.y, STAGE_PAD), Math.max(STAGE_PAD, h - vh - STAGE_PAD));
+    views[id] = { ...v, x, y, w: vw, h: vh };
+  }
+
+  return { ...state, open, views };
+}
+
+/** Full workspace state for a layout (panels stamped above the views).
+ *  Pass the stage `viewport` to clamp authored geometry on-screen. */
 export function applyLayout(
   sections: SectionDef[], views: ViewDef[], layout: LayoutDef,
-  saved: PersistedWorkspace['saved']
+  saved: PersistedWorkspace['saved'],
+  viewport: { w: number; h: number } | null = null,
 ): PersistedWorkspace {
   const known = new Set(sections.map(s => s.id));
   const open: LayoutDef['open'] = {};
   for (const id of Object.keys(layout.open)) {
     if (known.has(id)) open[id] = layout.open[id];
   }
-  return {
+  return clampToViewport({
     v: 1,
     layout: layout.id,
     open: stampZ(open, views.length),
     views: layoutViews(views, layout),
     saved,
-  };
+  }, sections, viewport);
 }
 
 /** Validate persisted state against the app's current sections/views. */

--- a/src/components/Canvas3D.tsx
+++ b/src/components/Canvas3D.tsx
@@ -1,6 +1,23 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import * as THREE from 'three';
 import { CANVAS_CONFIG } from '../config/defaults';
+
+/** Probe once whether a WebGL context can actually be created. In restricted
+ *  environments (hardware acceleration off, strict privacy modes, some remote
+ *  desktops) `new THREE.WebGLRenderer` throws — without this probe that error
+ *  used to blank the entire page instead of just this view. */
+let webglSupport: boolean | null = null;
+export function hasWebGL(): boolean {
+  if (webglSupport === null) {
+    try {
+      const c = document.createElement('canvas');
+      webglSupport = !!(c.getContext('webgl2') || c.getContext('webgl'));
+    } catch {
+      webglSupport = false;
+    }
+  }
+  return webglSupport;
+}
 
 export interface CanvasContext {
   scene: THREE.Scene;
@@ -20,14 +37,15 @@ export interface Canvas3DProps {
 
 export default function Canvas3D({ onMount }: Canvas3DProps) {
   const mountRef = useRef<HTMLDivElement>(null);
+  const [failed, setFailed] = useState(() => !hasWebGL());
 
   useEffect(() => {
-    if (!mountRef.current) return;
-    
+    if (failed || !mountRef.current) return;
+
     const mount = mountRef.current;
     const width = mount.clientWidth;
     const height = mount.clientHeight;
-    
+
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(
       CANVAS_CONFIG.fov,
@@ -35,13 +53,22 @@ export default function Canvas3D({ onMount }: Canvas3DProps) {
       CANVAS_CONFIG.near,
       CANVAS_CONFIG.far
     );
-    
-    const renderer = new THREE.WebGLRenderer({ 
-      antialias: true,
-      alpha: true,
-      preserveDrawingBuffer: true 
-    });
-    
+
+    // The probe can pass while renderer creation still fails (context limits,
+    // driver quirks) — contain that too instead of blanking the page.
+    let renderer: THREE.WebGLRenderer;
+    try {
+      renderer = new THREE.WebGLRenderer({
+        antialias: true,
+        alpha: true,
+        preserveDrawingBuffer: true,
+      });
+    } catch (e) {
+      console.error('[animath] WebGL renderer creation failed:', e);
+      setFailed(true);
+      return;
+    }
+
     // Set initial size
     renderer.setSize(width, height);
     renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2)); // Limit DPR for performance
@@ -78,16 +105,35 @@ export default function Canvas3D({ onMount }: Canvas3DProps) {
       window.removeEventListener('resize', handleResize);
       renderer.dispose();
     };
-  }, [onMount]);
+  }, [onMount, failed]);
+
+  if (failed) {
+    // A contained, named failure: the workspace chrome (rail, panels, top bar)
+    // stays fully alive — only this view reports.
+    return (
+      <div role="alert" style={{
+        position: 'absolute', inset: 0, display: 'grid', placeItems: 'center',
+        background: 'var(--viz-bg, #0a0e16)', color: 'var(--fg, #eee)', padding: 20,
+      }}>
+        <div style={{ maxWidth: 380, textAlign: 'center', font: '13.5px/1.55 var(--font-ui, system-ui)' }}>
+          <div style={{ fontWeight: 700, fontSize: 15, marginBottom: 6 }}>3D view unavailable</div>
+          <div style={{ color: 'var(--dim, #999)' }}>
+            This view needs WebGL, which this browser or environment isn’t providing.
+            Enabling hardware acceleration or trying another browser usually restores it.
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div 
-      ref={mountRef} 
+    <div
+      ref={mountRef}
       style={{
         ...CANVAS_CONFIG.style,
         display: 'block',
         touchAction: 'none', // Prevent default touch behaviors
-      }} 
+      }}
     />
   );
 }

--- a/src/components/ControlPanel.tsx
+++ b/src/components/ControlPanel.tsx
@@ -156,6 +156,7 @@ export function Pills<T extends string | number>({ label, options, value, onChan
           <button
             key={String(opt.value)}
             className={value === opt.value ? 'cp-active' : ''}
+            aria-pressed={value === opt.value}
             onClick={() => onChange(opt.value)}
           >
             {opt.label}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,8 +3,10 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import Gallery from './chrome/Gallery';
 import { LoadingScreen } from './chrome/LoadingScreen';
+import { RouteBoundary } from './chrome/RouteBoundary';
 import './chrome/theme.css';
 import { applyPersistedSkin } from './chrome/skins';
+import { apps } from './apps';
 
 // Set <html data-theme> before first paint so every route renders skinned.
 applyPersistedSkin();
@@ -52,6 +54,16 @@ function getHash(): string {
   return window.location.hash.replace(/^#/, '') || '/';
 }
 
+// The boot-time title ('animath', or '<branch> · animath' on preview deploys —
+// see the branchTitle plugin in vite.config.ts). Route titles append to it so
+// tabs are tellable apart without losing the preview's branch identity.
+const BASE_TITLE = typeof document !== 'undefined' ? document.title : 'animath';
+
+function routeTitle(path: string): string {
+  const app = apps.find(a => a.hash === path || (path === '/trinary-lab' && a.hash === '/trinary'));
+  return app ? `${app.name} · ${BASE_TITLE}` : BASE_TITLE;
+}
+
 function Router(): JSX.Element {
   const [hash, setHash] = React.useState(getHash());
 
@@ -64,16 +76,23 @@ function Router(): JSX.Element {
   // Routes may carry a `?query` (e.g. the lab's shareable config); match on path.
   const path = hash.split('?')[0];
 
+  // Tab title names the route (a11y: link lists, history, tab bars).
+  React.useEffect(() => { document.title = routeTitle(path); }, [path]);
+
   // The gallery is the landing page and the only cross-app hub; unknown
   // hashes fall back to it. Every app owns its chrome (Workspace + TopBar)
   // and renders bare.
   const Component = routes[path];
   if (path === '/' || !Component) return <Gallery />;
 
+  // Boundary keyed by route: an error is contained to the app that threw it,
+  // and navigating away (or Home from the error panel) always recovers.
   return (
-    <React.Suspense fallback={<LoadingScreen />}>
-      <Component />
-    </React.Suspense>
+    <RouteBoundary key={path}>
+      <React.Suspense fallback={<LoadingScreen />}>
+        <Component />
+      </React.Suspense>
+    </RouteBoundary>
   );
 }
 


### PR DESCRIPTION
Executes the top shared-chrome items from the external product review (GPT sol 5.6). Every change is fix-once in the chrome — **no app files touched**.

## 1. WebGL failure containment

The review's catastrophic finding, reproduced before fixing: with WebGL unavailable, 3D routes threw during renderer creation and left a blank, unrecoverable page (Back stayed blank).

- **`chrome/RouteBoundary.tsx`** — per-route error boundary, keyed by route so navigation always recovers. Named error panel with **Home** (a real link) + **Retry**; recognizes WebGL-flavored errors and explains likely causes (hardware acceleration off, strict privacy modes, remote desktops).
- **`Canvas3D`** — cached `hasWebGL()` capability probe + try/catch around renderer creation. On failure the view body shows a contained "3D view unavailable" notice while the **workspace chrome stays fully alive** (rail, panels, action strip).
- **Per-route `document.title`** ("Trinary System · animath"), appending to the boot title so Cloudflare preview branch names survive.

Verified under `--disable-3d-apis`: Trinary and Solid Worlds render their whole workspace with only the 3D view reporting; Home reachable; no blank pages.

## 2. Accessibility batch

- **ExplainerModal focus trap**: focus enters the dialog on open, Tab cycles inside it, Esc closes, and focus restores to the opener — verified by driving 12 Tab presses headlessly (focus never escaped; close returned it to the "?" button).
- **Real links**: gallery cards and the TopBar Home brand are now `<a href>` (copyable, open-in-new-tab, link-list navigable) instead of hash-mutating buttons, styled identically.
- **`<main>` landmark** on the gallery scroll region.
- **`aria-pressed`** on every Pills segmented button (state was previously CSS-color-only).

## 3. Viewport-clamped layouts

The Argand "Essentials runs 136px below the fold" bug class: authored layouts use absolute positions against a roomy reference viewport, and on shorter stages panels extended into `overflow:hidden` space, becoming unreachable.

- **`clampToViewport()`** in `workspace/layouts.ts` (pure, unit-tested): panels keep their whole card on-stage (a too-tall card pins to the top; its body scrolls), view rects clamp and shrink to fit. `applyLayout` takes an optional viewport; `DesktopWorkspace` passes the stage size at initial load and on every layout pick. Null/degenerate viewports are no-ops, so persisted-state paths and tests are unaffected.

## Verification

- `npm test` → 307 pass (4 new clamp tests) · `npm run build` clean · lint 0 errors
- Headless no-WebGL pass (both 3D route styles) + focus-trap drive + gallery link/landmark checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7qW9gEW5LQ5SCo5G9KEGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7qW9gEW5LQ5SCo5G9KEGg)_