### PR TITLE
Gallery entrance, layered explainers, calmer previews

### DIFF
--- a/docs/sessions/progress/gallery-entrance/2026-07-19-S01-gallery-entrance.md
+++ b/docs/sessions/progress/gallery-entrance/2026-07-19-S01-gallery-entrance.md
@@ -1,0 +1,89 @@
+---
+kind: progress
+session: 2026-07-19-S01
+date: 2026-07-19
+title: Gallery entrance, layered explainers, calmer previews
+branch: claude/gallery-entrance
+slug: gallery-entrance
+status: completed
+build: passed
+followup: null
+pr: null
+app: chrome
+next: Fold in the contrast-audit agent's proposal when it lands; per-app explainer content polish can follow at leisure.
+---
+
+# Gallery entrance, layered explainers, calmer previews
+
+## Session purpose
+
+Execute Dan's answers to the post-review questions (2026-07-18): a quiet
+entrance led by Complex Particles · Trinary System · Polygon Worlds;
+question-led card text; GPU badges (no guided/open-lab chip); the reviewer's
+five categories; layered explainers ("fix it"); keep the moving gallery but
+calm it; keep Observatory as default; no tablet work; contrast pass delegated
+to an agent; Trinary leftovers parked.
+
+## Working notes
+
+### 🟢 code · 13:10 — Catalog + gallery entrance
+**Why:** Dan: Complex Particles leads ("needs a friendly front door"), then
+Trinary, Polygon Worlds; "something quieter" than "New here?"; better card text.
+
+- `catalog.ts`: five categories (Transformations · Iteration & Chaos ·
+  Algorithms & Emergence · Geometry & Topology · Probability & Inference),
+  per-card `question` (the leading line — a question or crisp statement),
+  `starter: 1|2|3`, `gpu: true` on the seven WebGL apps.
+- `Gallery.tsx`: with no filter active, a **Start here** row (the three
+  starters) then **Everything** — both labeled by quiet mono kickers with a
+  hairline, no chatty copy. Filters show everything flat. Cards render the
+  question in place of the registry blurb, with a small GPU badge in the meta
+  row (courtesy, not warning — failure is contained since #252).
+
+### 🟢 code · 13:12 — Layered explainer ("fix it")
+**Why:** The "?" modals ran thousands of pixels and sometimes overflowed.
+
+`splitExplainer()` (fence-aware, unit-tested ×4): the dialog opens on the
+intro + first `##` section; every later section folds behind a native
+`<details>` disclosure styled as a quiet mono summary. **No EXPLAINER.md was
+rewritten** — the attribution blocks ("Possible sources…") survive as their
+own folded layer, per policy. CSS: the dialog never scrolls horizontally
+(pre/table/img contained). Verified live: Trinary's modal is now 726px tall
+with 6 folded sections.
+
+### 🟢 code · 13:13 — Calmer previews
+**Why:** Dan: keep the moving gallery, "reduce the speeds… less frenetic."
+
+Global 0.65× time scale on the shared preview loop (motion stays, slower), and
+`prefers-reduced-motion` now renders the synchronous first frame as a still
+with no loop. Offscreen pause already existed (IntersectionObserver).
+
+### 🟡 milestone · 13:15 — Verified
+Gallery screenshot confirms the entrance (kickers, starters with questions,
+GPU badges, five chips); modal drive confirms 6 folds + no horizontal
+overflow. `npm test` 311 pass (4 new splitter tests) · build clean · lint 0
+errors · sessions-lint 0 errors.
+
+## In flight
+
+A background agent is running the systematic contrast audit (item 8) —
+deliverable is a PROPOSAL (per-skin token adjustments + focus-color strategy),
+to be committed here for Dan's approval when it lands. No tokens changed yet.
+
+## Decisions honored (no action)
+
+Observatory stays default (4) · moving gallery stays (6) · no tablet mode (7)
+· Trinary leftovers parked (9) · no guided/open-lab chip (2).
+
+## Self-reflection
+
+**What went well:** Every answer mapped to a small, testable change; the
+layered explainer needed zero content rewrites because the split is structural.
+
+**What to watch:** The five-category re-bin is my judgment for the edge cases
+(Trees and Nets → Algorithms & Emergence; Argand → Transformations) — cheap to
+move if Dan disagrees. The 0.65× preview scale is uniform; if specific cards
+still read frenetic, a per-kind scale map is the next lever.
+
+**Follow-up value:** LOW — remaining items are the contrast proposal (in
+flight) and optional per-app explainer content polish.

--- a/docs/sessions/progress/gallery-entrance/2026-07-19-plan-contrast-proposal.md
+++ b/docs/sessions/progress/gallery-entrance/2026-07-19-plan-contrast-proposal.md
@@ -1,0 +1,434 @@
+---
+kind: plan
+session: 2026-07-19-S01
+date: 2026-07-19
+title: Contrast & focus-color proposal (agent audit — awaiting Dan's approval)
+branch: claude/gallery-entrance
+slug: gallery-entrance
+status: proposed
+build: n/a
+followup: null
+pr: null
+app: chrome
+next: Dan approves/adjusts per-skin values; then apply as one-line -n/-lt/-dk family edits + the --focus consumed token.
+---
+
+# Contrast audit & per-skin token proposal
+
+**Date:** 2026-07-20 · **Scope:** `src/chrome/theme.css` (all 8 skins x 3 modes, theming v2) · **Status: PROPOSAL — no source files were modified.**
+
+## Method
+
+- Tokens were parsed from the `[data-theme="…"]` blocks and resolved per mode by the
+  family convention: `native` → `--x-n`, `light` → `--x-lt` (fallback `-n`), `dark` → `--x-dk`
+  (fallback `-n`) — exactly what the shared `[data-scheme]` blocks do (theme.css:317–349).
+- `rgba()` values (notably `--panel`) were alpha-composited over `--bg` before measuring,
+  so "vs panel" means the panel surface as actually rendered over the stage.
+- Ratios are WCAG 2.x relative-luminance contrast. Thresholds: **4.5:1** normal text,
+  **3:1** large/bold text, UI components, graphics, and focus indicators.
+- Proposed values keep the token's **hue and saturation** and move only lightness (HSL),
+  by the minimal step that clears the threshold against **every** surface the token sits on
+  (e.g. `--accent` must clear both `--bg` and `--panel`).
+- Modes marked *(= native)* alias the native palette (the skin ships no `-lt`/`-dk`
+  companion), so a fix to the `-n` family member fixes both.
+- Line references are to the 2026-07-20 working tree (a parallel session is appending
+  chrome CSS after line 548; the token blocks at theme.css:84–349 are identical to HEAD,
+  so all measurements hold for both).
+
+### Measured pairs and the roles that justify each threshold
+
+| Pair | Threshold | Why |
+|---|---|---|
+| `--fg` vs `--bg`, `--panel` | 4.5 | Primary text everywhere (`body`, `.am-title`, panel labels) |
+| `--dim` vs `--bg`, `--panel` | 4.5 | Secondary text — `.am-gcard-blurb` (theme.css:627), `.am-hint` 11.5px (theme.css:529), idle `.am-pill` (theme.css:456) |
+| `--dim-2` vs `--panel` | 4.5 | Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt) |
+| `--accent` vs `--bg`, `--panel` | 4.5 | Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037) |
+| `--accent-fg` vs `--accent` | 4.5 | Text/glyphs on accent fills — `.am-pill.am-on` (theme.css:458), `.am-action-btn.am-primary` (theme.css:832), brand mark (theme.css:406), checkbox check (theme.css:507) |
+| `--success`, `--danger` vs `--panel` | 4.5 | Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741) |
+| `--data-1..7` vs `--viz-bg` | 3.0 | Data marks are graphics, not text |
+
+> The external review's Paper measurement reproduces exactly: Paper native `--accent`
+> `#b67d10` = **3.03:1** vs `--bg` and **3.50:1** vs `--panel` — below 4.5 for the
+> 10.5–11.5px text it colors, and marginal as a focus ring on panels.
+
+## Summary — failures per skin x mode
+
+| Skin | Mode | Failing pairs | Worst offender | Focus ring (accent >= 3:1 vs bg & panel) |
+|---|---|---:|---|---|
+| Observatory (`dark`) | native | 1 | `--dim-2` 3.22:1 (need 4.5) | OK (12.46) |
+| Observatory (`dark`) | light | 5 | `--dim-2` 2.50:1 (need 4.5) | **FAIL** (2.88) → `#b3820b` |
+| Observatory (`dark`) | dark *(= native)* | 1 | `--dim-2` 3.22:1 (need 4.5) | OK (12.46) |
+| Paper (`light`) | native | 6 | `--dim-2` 2.97:1 (need 4.5) | OK (3.03) |
+| Paper (`light`) | light *(= native)* | 6 | `--dim-2` 2.97:1 (need 4.5) | OK (3.03) |
+| Paper (`light`) | dark | 1 | `--dim-2` 2.84:1 (need 4.5) | OK (7.56) |
+| Spectrum (`neon`) | native | 1 | `--dim-2` 3.32:1 (need 4.5) | OK (12.32) |
+| Spectrum (`neon`) | light | 6 | `--dim-2` 2.59:1 (need 4.5) | **FAIL** (2.96) → `#0e9c88` |
+| Spectrum (`neon`) | dark *(= native)* | 1 | `--dim-2` 3.32:1 (need 4.5) | OK (12.32) |
+| Blueprint (`blueprint`) | native | 1 | `--dim-2` 3.49:1 (need 4.5) | OK (13.10) |
+| Blueprint (`blueprint`) | light | 4 | `--dim-2` 2.61:1 (need 4.5) | OK (6.29) |
+| Blueprint (`blueprint`) | dark *(= native)* | 1 | `--dim-2` 3.49:1 (need 4.5) | OK (13.10) |
+| Phosphor (`phosphor`) | native | 1 | `--dim-2` 3.24:1 (need 4.5) | OK (13.49) |
+| Phosphor (`phosphor`) | light | 9 | `--dim-2` 2.49:1 (need 4.5) | **FAIL** (2.92) → `#2e7a2e` |
+| Phosphor (`phosphor`) | dark *(= native)* | 1 | `--dim-2` 3.24:1 (need 4.5) | OK (13.49) |
+| Daylight (`daylight`) | native | 4 | `--dim-2` 2.62:1 (need 4.5) | OK (4.18) |
+| Daylight (`daylight`) | light *(= native)* | 4 | `--dim-2` 2.62:1 (need 4.5) | OK (4.18) |
+| Daylight (`daylight`) | dark | 1 | `--dim-2` 2.87:1 (need 4.5) | OK (6.00) |
+| Primary (`primary`) | native | 7 | `--accent` 1.41:1 (need 4.5) | **FAIL** (1.41) → `#a78507` |
+| Primary (`primary`) | light *(= native)* | 7 | `--accent` 1.41:1 (need 4.5) | **FAIL** (1.41) → `#a78507` |
+| Primary (`primary`) | dark | 1 | `--dim-2` 3.13:1 (need 4.5) | OK (12.18) |
+| Mirage (`mirage`) | native | 1 | `--dim-2` 3.29:1 (need 4.5) | OK (9.31) |
+| Mirage (`mirage`) | light | 8 | `--dim-2` 2.54:1 (need 4.5) | **FAIL** (2.62) → `#d16c28` |
+| Mirage (`mirage`) | dark *(= native)* | 1 | `--dim-2` 3.29:1 (need 4.5) | OK (9.31) |
+
+**Systemic finding:** `--dim-2` fails 4.5:1 on the panel surface in **all 24 skin x mode
+combinations** (2.49–3.49:1). It does double duty as real meta text (gallery footer, layout
+group labels) and as disabled/decorative color (where WCAG exempts it). The proposals below
+raise it to 4.5:1; an alternative worth considering is keeping `--dim-2` as the
+disabled/decorative voice and moving the two real-text consumers to `--dim`.
+
+---
+
+## Observatory (`data-theme="dark"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased dark mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#5d667d` | 3.22 | `#747e98` | 4.56 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+### Mode: light (edit the `-lt` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#9aa3b6` | 2.50 | `#697691` | 4.51 | 4.5 |
+| `--accent` | `--bg` | `#b8860b` | 2.88 | `#8e6708` | 4.53 | 4.5 |
+| `--accent` | `--panel` | `#b8860b` | 3.22 | `#8e6708` | 5.07 | 4.5 |
+| `--accent-fg` | `--accent` | `#ffffff` | 3.25 | `#282828` | 4.53 | 4.5 |
+| `--success` | `--panel` | `#2e8d56` | 4.10 | `#2b8551` | 4.53 | 4.5 |
+
+*Knock-on check:* existing `--accent-fg` `#ffffff` on the **proposed** accent `#8e6708` = 5.13:1 — passes, keep it. (The `--accent-fg` row above is only needed if the accent is kept unchanged — adopting the proposed accent supersedes it.)
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--accent-fg`: Text/glyphs on accent fills — `.am-pill.am-on` (theme.css:458), `.am-action-btn.am-primary` (theme.css:832), brand mark (theme.css:406), checkbox check (theme.css:507)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+
+### Mode: dark — identical to native (no `-dk` companions authored); the native fixes apply.
+
+## Paper (`data-theme="light"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased light mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#9c9484` | 2.97 | `#7d7565` | 4.51 | 4.5 |
+| `--accent` | `--bg` | `#b67d10` | 3.03 | `#90630d` | 4.51 | 4.5 |
+| `--accent` | `--panel` | `#b67d10` | 3.50 | `#90630d` | 5.22 | 4.5 |
+| `--accent-fg` | `--accent` | `#fffdf8` | 3.48 | `#2c1f00` | 4.55 | 4.5 |
+| `--success` | `--panel` | `#2e8d56` | 4.10 | `#2b8551` | 4.53 | 4.5 |
+| `--data-3` | `--viz-bg` | `#5a9e2e` | 2.98 | `#599d2e` | 3.01 | 3 |
+
+*Knock-on check:* existing `--accent-fg` `#fffdf8` on the **proposed** accent `#90630d` = 5.20:1 — passes, keep it. (The `--accent-fg` row above is only needed if the accent is kept unchanged — adopting the proposed accent supersedes it.)
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--accent-fg`: Text/glyphs on accent fills — `.am-pill.am-on` (theme.css:458), `.am-action-btn.am-primary` (theme.css:832), brand mark (theme.css:406), checkbox check (theme.css:507)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--data-3`: Discrete data series 3 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: light — identical to native (no `-lt` companions authored); the native fixes apply.
+
+### Mode: dark (edit the `-dk` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#6f6553` | 2.84 | `#92856d` | 4.50 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+## Spectrum (`data-theme="neon"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased dark mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#56648c` | 3.32 | `#6b7aa4` | 4.56 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+### Mode: light (edit the `-lt` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#969fc0` | 2.59 | `#6673a3` | 4.56 | 4.5 |
+| `--accent` | `--bg` | `#0e9e8a` | 2.96 | `#0b7c6c` | 4.51 | 4.5 |
+| `--accent` | `--panel` | `#0e9e8a` | 3.31 | `#0b7c6c` | 5.04 | 4.5 |
+| `--accent-fg` | `--accent` | `#ffffff` | 3.35 | `#262626` | 4.52 | 4.5 |
+| `--success` | `--panel` | `#0e9e6a` | 3.39 | `#0c8559` | 4.60 | 4.5 |
+| `--data-4` | `--viz-bg` | `#c08a1a` | 2.87 | `#ba8619` | 3.04 | 3 |
+
+*Knock-on check:* existing `--accent-fg` `#ffffff` on the **proposed** accent `#0b7c6c` = 5.10:1 — passes, keep it. (The `--accent-fg` row above is only needed if the accent is kept unchanged — adopting the proposed accent supersedes it.)
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--accent-fg`: Text/glyphs on accent fills — `.am-pill.am-on` (theme.css:458), `.am-action-btn.am-primary` (theme.css:832), brand mark (theme.css:406), checkbox check (theme.css:507)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--data-4`: Discrete data series 4 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: dark — identical to native (no `-dk` companions authored); the native fixes apply.
+
+## Blueprint (`data-theme="blueprint"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased dark mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#607fb2` | 3.49 | `#7993be` | 4.54 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+### Mode: light (edit the `-lt` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#8aa0c4` | 2.61 | `#5676aa` | 4.52 | 4.5 |
+| `--success` | `--panel` | `#2e8d56` | 4.08 | `#2b8551` | 4.51 | 4.5 |
+| `--data-3` | `--viz-bg` | `#5a9e2e` | 2.96 | `#599c2d` | 3.03 | 3 |
+| `--data-4` | `--viz-bg` | `#c08a1a` | 2.73 | `#b68319` | 3.02 | 3 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--data-3`: Discrete data series 3 — marks/strokes on the viz background (graphics, 3:1)
+- `--data-4`: Discrete data series 4 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: dark — identical to native (no `-dk` companions authored); the native fixes apply.
+
+## Phosphor (`data-theme="phosphor"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased dark mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#3f7355` | 3.24 | `#4d8d68` | 4.55 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+### Mode: light (edit the `-lt` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim` | `--bg` | `#5a6347` | 3.61 | `#4d543c` | 4.51 | 4.5 |
+| `--dim` | `--panel` | `#5a6347` | 4.46 | `#4d543c` | 5.57 | 4.5 |
+| `--dim-2` | `--panel` | `#8a8a6a` | 2.49 | `#60604a` | 4.52 | 4.5 |
+| `--accent` | `--bg` | `#2f7d2f` | 2.92 | `#225c22` | 4.55 | 4.5 |
+| `--accent` | `--panel` | `#2f7d2f` | 3.60 | `#225c22` | 5.63 | 4.5 |
+| `--accent-fg` | `--accent` | `#f3eed8` | 4.40 | `#f5f1de` | 4.52 | 4.5 |
+| `--success` | `--panel` | `#2f7d2f` | 3.60 | `#296c29` | 4.51 | 4.5 |
+| `--danger` | `--panel` | `#b03a1a` | 4.26 | `#a93819` | 4.52 | 4.5 |
+| `--data-4` | `--viz-bg` | `#a8741a` | 2.56 | `#996918` | 3.02 | 3 |
+
+*Knock-on check:* existing `--accent-fg` `#f3eed8` on the **proposed** accent `#225c22` = 6.88:1 — passes, keep it. (The `--accent-fg` row above is only needed if the accent is kept unchanged — adopting the proposed accent supersedes it.)
+
+**Where these tokens show up:**
+- `--dim`: Secondary text — `.am-gcard-blurb` (theme.css:627), `.am-hint` 11.5px (theme.css:529), idle `.am-pill` (theme.css:456)
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--accent-fg`: Text/glyphs on accent fills — `.am-pill.am-on` (theme.css:458), `.am-action-btn.am-primary` (theme.css:832), brand mark (theme.css:406), checkbox check (theme.css:507)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--danger`: Error/status text — same consumers as success, plus danger buttons
+- `--data-4`: Discrete data series 4 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: dark — identical to native (no `-dk` companions authored); the native fixes apply.
+
+## Daylight (`data-theme="daylight"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased light mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#93a0b4` | 2.62 | `#657792` | 4.51 | 4.5 |
+| `--accent` | `--bg` | `#2f6fe0` | 4.18 | `#2568df` | 4.53 | 4.5 |
+| `--success` | `--panel` | `#2e8d56` | 4.10 | `#2b8551` | 4.54 | 4.5 |
+| `--data-4` | `--viz-bg` | `#e0a82e` | 2.03 | `#ba881c` | 3.00 | 3 |
+
+*Knock-on check:* existing `--accent-fg` `#ffffff` on the **proposed** accent `#2568df` = 5.09:1 — passes, keep it.
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--data-4`: Discrete data series 4 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: light — identical to native (no `-lt` companions authored); the native fixes apply.
+
+### Mode: dark (edit the `-dk` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#5b6678` | 2.87 | `#7a869a` | 4.52 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+## Primary (`data-theme="primary"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased light mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#908d82` | 3.29 | `#79766b` | 4.51 | 4.5 |
+| `--accent` | `--bg` | `#f5c518` | 1.41 | `#846906` | 4.52 | 4.5 |
+| `--accent` | `--panel` | `#f5c518` | 1.62 | `#846906` | 5.20 | 4.5 |
+| `--success` | `--panel` | `#149e57` | 3.44 | `#11874b` | 4.53 | 4.5 |
+| `--danger` | `--panel` | `#e63327` | 4.28 | `#e3271a` | 4.55 | 4.5 |
+| `--data-3` | `--viz-bg` | `#f5c518` | 1.55 | `#b18c08` | 3.01 | 3 |
+| `--data-5` | `--viz-bg` | `#e6731f` | 2.92 | `#e56f1a` | 3.01 | 3 |
+
+*Knock-on:* existing `--accent-fg` on the proposed accent `#846906` = 3.54:1 (< 4.5). Pair the accent change with `--accent-fg` → `#efeee9` (4.51:1).
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--danger`: Error/status text — same consumers as success, plus danger buttons
+- `--data-3`: Discrete data series 3 — marks/strokes on the viz background (graphics, 3:1)
+- `--data-5`: Discrete data series 5 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: light — identical to native (no `-lt` companions authored); the native fixes apply.
+
+### Mode: dark (edit the `-dk` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#6a6760` | 3.13 | `#858178` | 4.55 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+## Mirage (`data-theme="mirage"`)
+
+### Mode: native (edit the `-n` family members (also fixes the aliased dark mode))
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim-2` | `--panel` | `#7d6699` | 3.29 | `#927faa` | 4.54 | 4.5 |
+
+**Where these tokens show up:**
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+
+### Mode: light (edit the `-lt` companions)
+
+| Token | Against | Original | Ratio | Proposed | New ratio | Need |
+|---|---|---|---:|---|---:|---:|
+| `--dim` | `--bg` | `#7d6699` | 4.21 | `#776192` | 4.56 | 4.5 |
+| `--dim-2` | `--panel` | `#ab9ac0` | 2.54 | `#836aa2` | 4.53 | 4.5 |
+| `--accent` | `--bg` | `#d97a3a` | 2.62 | `#a55620` | 4.51 | 4.5 |
+| `--accent` | `--panel` | `#d97a3a` | 3.03 | `#a55620` | 5.21 | 4.5 |
+| `--accent-fg` | `--accent` | `#ffffff` | 3.09 | `#2c2c2c` | 4.52 | 4.5 |
+| `--success` | `--panel` | `#2e9d7c` | 3.31 | `#268368` | 4.55 | 4.5 |
+| `--data-2` | `--viz-bg` | `#d97a3a` | 2.84 | `#d7732f` | 3.02 | 3 |
+| `--data-6` | `--viz-bg` | `#c08a1a` | 2.80 | `#b88419` | 3.04 | 3 |
+
+*Knock-on check:* existing `--accent-fg` `#ffffff` on the **proposed** accent `#a55620` = 5.31:1 — passes, keep it. (The `--accent-fg` row above is only needed if the accent is kept unchanged — adopting the proposed accent supersedes it.)
+
+**Where these tokens show up:**
+- `--dim`: Secondary text — `.am-gcard-blurb` (theme.css:627), `.am-hint` 11.5px (theme.css:529), idle `.am-pill` (theme.css:456)
+- `--dim-2`: Meta text — `.am-gal-foot` 11px (theme.css:630), `.am-lay-group` 10px group labels (theme.css:904); also disabled verbs (theme.css:831) and resize grips (decorative, exempt)
+- `--accent`: Small text — `.am-gcard-cat` 10.5px uppercase (theme.css:624), `.am-row-val` 11.5px slider readout (theme.css:449), `.am-sub` formula (theme.css:441), `.am-gal-kicker` (theme.css:582), markdown links (ControlPanel.css:443); also the 2px focus ring (theme.css:1037)
+- `--accent-fg`: Text/glyphs on accent fills — `.am-pill.am-on` (theme.css:458), `.am-action-btn.am-primary` (theme.css:832), brand mark (theme.css:406), checkbox check (theme.css:507)
+- `--success`: Status text — StableMatching stability metric (stableMatching.css:28–31), Trinary Lyapunov readout (TrinaryStars.tsx:741)
+- `--data-2`: Discrete data series 2 — marks/strokes on the viz background (graphics, 3:1)
+- `--data-6`: Discrete data series 6 — marks/strokes on the viz background (graphics, 3:1)
+
+### Mode: dark — identical to native (no `-dk` companions authored); the native fixes apply.
+
+---
+
+## Per-skin `--focus` token strategy
+
+The global focus ring is `:focus-visible { outline: 2px solid var(--accent); }` (theme.css:1037;
+also the checkbox at theme.css:518). A focus indicator is a UI component: it needs **>= 3:1**
+against the surfaces it appears on (`--bg` and `--panel`). Recommendation: introduce a
+consumed `--focus` token in the shared `[data-scheme]` blocks (`--focus: var(--focus-n)` etc.,
+defaulting to `var(--accent-…)` per mode) and switch the two outline rules to `var(--focus)`.
+Skins whose accent already passes ship **no** `--focus-*` override (the fallback keeps them
+on accent, zero cost); the five failing combos (Primary's aliased light mode rides on its
+`-n`) author one companion each.
+
+| Skin | Mode | Accent vs bg / panel (min) | Verdict |
+|---|---|---:|---|
+| Observatory | native | 12.46 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Observatory | light | 2.88 | **Propose `--focus-lt: #b3820b`** (min 3.04:1) — or adopt the proposed accent above, which also passes |
+| Observatory | dark *(= native)* | 12.46 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Paper | native | 3.03 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Paper | light *(= native)* | 3.03 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Paper | dark | 7.56 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Spectrum | native | 12.32 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Spectrum | light | 2.96 | **Propose `--focus-lt: #0e9c88`** (min 3.03:1) — or adopt the proposed accent above, which also passes |
+| Spectrum | dark *(= native)* | 12.32 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Blueprint | native | 13.10 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Blueprint | light | 6.29 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Blueprint | dark *(= native)* | 13.10 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Phosphor | native | 13.49 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Phosphor | light | 2.92 | **Propose `--focus-lt: #2e7a2e`** (min 3.03:1) — or adopt the proposed accent above, which also passes |
+| Phosphor | dark *(= native)* | 13.49 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Daylight | native | 4.18 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Daylight | light *(= native)* | 4.18 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Daylight | dark | 6.00 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Primary | native | 1.41 | **Propose `--focus-n: #a78507`** (min 3.02:1) — or adopt the proposed accent above, which also passes |
+| Primary | light *(= native)* | 1.41 | **Propose `--focus-lt: #a78507`** (min 3.02:1) — or adopt the proposed accent above, which also passes |
+| Primary | dark | 12.18 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Mirage | native | 9.31 | Accent passes >= 3:1 — reuse it (no override needed) |
+| Mirage | light | 2.62 | **Propose `--focus-lt: #d16c28`** (min 3.03:1) — or adopt the proposed accent above, which also passes |
+| Mirage | dark *(= native)* | 9.31 | Accent passes >= 3:1 — reuse it (no override needed) |
+
+---
+
+## How to apply (the `-n`/`-lt`/`-dk` family convention)
+
+Every proposal above is a one-line edit to an existing family member inside that skin's
+`[data-theme="…"]` block in `src/chrome/theme.css` — the shared `[data-scheme]` blocks
+(theme.css:84–97, 317–349) already fan the families out to the consumed tokens, so **no
+selector changes and no JS changes** are needed for the color fixes:
+
+1. **Native-mode fixes** → edit the `--x-n` member (e.g. Paper's `--accent-n` in
+   `[data-theme="light"]`). Skins that alias a mode to native (no companion authored)
+   inherit the fix in that mode for free.
+2. **Light/dark-companion fixes** → edit the `--x-lt` / `--x-dk` member. All of the
+   failing companions already exist (they are authored values, not fallbacks), so these
+   are edits, not additions.
+3. **`--focus`** is the one addition: add `--focus: var(--focus-n, var(--accent-n))` to the
+   native block at theme.css:84, and the `-lt`/`-dk` equivalents to the two mode blocks;
+   author `--focus-*` only for the failing combos (Observatory `-lt`, Spectrum `-lt`,
+   Phosphor `-lt`, Primary `-n`, Mirage `-lt`), then change theme.css:1037 and :518 to
+   `var(--focus)`.
+4. **Identity trade-offs to review by eye before adopting:**
+   - **Primary (native):** Bauhaus yellow `#f5c518` is unusable as text/focus (1.41:1) but
+     is fine as a *fill* behind dark `--accent-fg` ink (its native pattern). Consider keeping
+     `#f5c518` for fills and adding the darkened `#846906`-family value only where accent is
+     *text* (or as `--focus`), rather than darkening the brand yellow everywhere — the
+     minimal-change proposal in the table darkens the token itself and then needs a light
+     `--accent-fg`, which changes the skin's character most of any proposal here.
+   - **Paper / Observatory-light ambers** darken from `#b67d10`/`#b8860b` to `#90630d`/`#8e6708`:
+     same hue, reads as "deep amber ink"; primary-button fills keep their light `--accent-fg`
+     (now passing 5.1–5.2:1 instead of failing 3.2–3.5:1).
+   - **`--dim-2`**: if the meta-text consumers move to `--dim` instead, the proposed
+     `--dim-2` bumps (16 distinct authored values covering all 24 combos) become optional
+     (disabled/decorative uses are WCAG-exempt).
+5. Data-series fixes (`--data-N`) only matter where apps draw series marks on `--viz-bg`
+   (TreesAndNets weight colormaps, DivisionBells P/Q, readout sparklines); they are all
+   small lightness nudges except Daylight's `--data-4-n` (`#e0a82e` → `#ba881c`, 2.03 → 3.0+).
+
+*Generated by `audit.mjs` + `gen-report.mjs` in this directory (re-runnable against a future
+theme.css). No files under `/home/user/animath` were modified.*

--- a/src/chrome/ExplainerModal.tsx
+++ b/src/chrome/ExplainerModal.tsx
@@ -3,7 +3,17 @@ import { createPortal } from 'react-dom';
 import { Icon } from './icons';
 import { useEscLayer } from './useEscLayer';
 
-const FOCUSABLE = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+// `summary` is natively focusable (it opens/closes the layered-explainer folds)
+// and must be in the trap; conversely, links inside a CLOSED <details> match the
+// selector but aren't reachable, so we filter to visible elements below.
+const FOCUSABLE = 'a[href], button:not([disabled]), textarea, input, select, summary, [tabindex]:not([tabindex="-1"])';
+
+/** Focusable descendants that are actually reachable — excludes anything inside
+ *  a collapsed <details> (display:none ⇒ no layout box ⇒ offsetParent null). */
+function focusableIn(root: HTMLElement): HTMLElement[] {
+  return Array.from(root.querySelectorAll<HTMLElement>(FOCUSABLE))
+    .filter(el => el.offsetParent !== null || el === document.activeElement);
+}
 
 /**
  * Layered explainer: split the markdown at `## ` headings (fence-aware) so the
@@ -42,10 +52,11 @@ function useFocusTrap(ref: React.RefObject<HTMLElement>) {
   useEffect(() => {
     const dlg = ref.current;
     const opener = document.activeElement as HTMLElement | null;
-    dlg?.querySelector<HTMLElement>(FOCUSABLE)?.focus();
+    if (dlg) focusableIn(dlg)[0]?.focus();
     const onKey = (e: KeyboardEvent) => {
       if (e.key !== 'Tab' || !dlg) return;
-      const items = Array.from(dlg.querySelectorAll<HTMLElement>(FOCUSABLE));
+      // Recompute each Tab: opening/closing a fold changes what's reachable.
+      const items = focusableIn(dlg);
       if (!items.length) return;
       const first = items[0], last = items[items.length - 1];
       const active = document.activeElement;

--- a/src/chrome/ExplainerModal.tsx
+++ b/src/chrome/ExplainerModal.tsx
@@ -5,6 +5,36 @@ import { useEscLayer } from './useEscLayer';
 
 const FOCUSABLE = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
 
+/**
+ * Layered explainer: split the markdown at `## ` headings (fence-aware) so the
+ * dialog opens on the essentials — the intro and the first section — with every
+ * later section (derivations, methods, sources, implementation notes) folded
+ * behind a disclosure. Turns the old thousands-of-pixels encyclopedia into a
+ * short read that can still go deep, without rewriting any app's EXPLAINER.md.
+ */
+export function splitExplainer(md: string): { lead: string; sections: { title: string; body: string }[] } {
+  const lines = md.split('\n');
+  const chunks: { title: string | null; lines: string[] }[] = [{ title: null, lines: [] }];
+  let inFence = false;
+  for (const line of lines) {
+    if (/^\s*(```|~~~)/.test(line)) inFence = !inFence;
+    const m = !inFence && /^## +(.+?)\s*$/.exec(line);
+    if (m) chunks.push({ title: m[1], lines: [] });
+    else chunks[chunks.length - 1].lines.push(line);
+  }
+  // Lead = the intro chunk plus the FIRST titled section (kept under its
+  // heading so the text reads unchanged); the rest fold.
+  const intro = chunks[0].lines.join('\n');
+  const titled = chunks.slice(1);
+  if (titled.length === 0) return { lead: intro, sections: [] };
+  const first = titled[0];
+  const lead = `${intro}\n\n## ${first.title}\n${first.lines.join('\n')}`;
+  return {
+    lead,
+    sections: titled.slice(1).map(c => ({ title: c.title as string, body: c.lines.join('\n') })),
+  };
+}
+
 /** Trap Tab inside the dialog while it's open, focus it on open, and restore
  *  focus to the opener on close — without this, Tab kept driving the controls
  *  BEHIND the dialog, and closing dropped keyboard users at the document root. */
@@ -48,6 +78,21 @@ const Readme = React.lazy(() => import('../components/Readme'));
  * Esc goes through the shared layer stack (close the modal first, then the
  * fullscreen view on the next keypress).
  */
+function LayeredExplainer({ markdown }: { markdown: string }) {
+  const { lead, sections } = splitExplainer(markdown);
+  return (
+    <>
+      <Readme markdown={lead} />
+      {sections.map(s => (
+        <details key={s.title} className="am-expl-fold">
+          <summary>{s.title}</summary>
+          <Readme markdown={s.body} />
+        </details>
+      ))}
+    </>
+  );
+}
+
 export function ExplainerModal({ title, markdown, onClose }: {
   title: string;
   markdown: string;
@@ -74,7 +119,7 @@ export function ExplainerModal({ title, markdown, onClose }: {
           </button>
         </div>
         <Suspense fallback={<div className="am-hint">Loading…</div>}>
-          <Readme markdown={markdown} />
+          <LayeredExplainer markdown={markdown} />
         </Suspense>
       </div>
     </div>,

--- a/src/chrome/Gallery.tsx
+++ b/src/chrome/Gallery.tsx
@@ -19,19 +19,29 @@ export default function Gallery() {
   const mode = useThemeModeId();
   // Storeroom cards are out of the main grid and the category filter — parked,
   // but still reachable from the de-emphasized section at the bottom.
-  const cards = CARDS.filter(c => !c.storeroom && (cat === 'All' || c.cat === cat));
+  const visible = CARDS.filter(c => !c.storeroom && (cat === 'All' || c.cat === cat));
+  // The quiet entrance: three starter cards lead when no filter is active;
+  // the rest follow in the main grid. A filter shows everything flat.
+  const starters = cat === 'All'
+    ? visible.filter(c => c.starter).sort((a, b) => (a.starter ?? 9) - (b.starter ?? 9))
+    : [];
+  const cards = cat === 'All' ? visible.filter(c => !c.starter) : visible;
   const stored = CARDS.filter(c => c.storeroom);
   const mainCount = CARDS.filter(c => !c.storeroom).length;
 
   // Cards are real links (not hash-mutating buttons): copyable, open-in-new-tab,
-  // and visible to assistive tech's link navigation.
+  // and visible to assistive tech's link navigation. The leading line is the
+  // QUESTION the app explores (falling back to the registry blurb).
   const renderCard = (a: (typeof CARDS)[number]) => (
     <a key={a.id} className="am-gcard" href={'#' + a.hash}>
       <div className="am-gcard-viz"><Preview kind={a.kind} skin={skin} mode={mode} /></div>
       <div className="am-gcard-body">
-        <div className="am-gcard-cat">{a.cat}</div>
+        <div className="am-gcard-meta">
+          <span className="am-gcard-cat">{a.cat}</span>
+          {a.gpu && <span className="am-gcard-gpu" title="Uses WebGL (GPU) rendering">GPU</span>}
+        </div>
         <div className="am-gcard-name"><span className="am-gcard-glyph">{a.glyph}</span> {a.name}</div>
-        <div className="am-gcard-blurb">{a.blurb}</div>
+        <div className="am-gcard-blurb">{a.question ?? a.blurb}</div>
         <div className="am-gcard-open">Open workspace <Icon name="chevron" size={13} /></div>
       </div>
     </a>
@@ -75,6 +85,15 @@ export default function Gallery() {
             </button>
           ))}
         </div>
+        {starters.length > 0 && (
+          <>
+            <div className="am-gal-kicker">Start here</div>
+            <div className="am-gal-grid">
+              {starters.map(renderCard)}
+            </div>
+            <div className="am-gal-kicker">Everything</div>
+          </>
+        )}
         <div className="am-gal-grid">
           {cards.map(renderCard)}
         </div>

--- a/src/chrome/__tests__/splitExplainer.test.ts
+++ b/src/chrome/__tests__/splitExplainer.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { splitExplainer } from '../ExplainerModal';
+
+const MD = `# Title
+
+Intro paragraph.
+
+## First section
+
+Core explanation.
+
+## Deep dive
+
+Details with code:
+
+\`\`\`js
+// ## not a heading — inside a fence
+const x = 1;
+\`\`\`
+
+## Possible sources & where to go further
+
+Attribution block.
+`;
+
+describe('splitExplainer', () => {
+  it('keeps the intro + first section open and folds the rest', () => {
+    const { lead, sections } = splitExplainer(MD);
+    expect(lead).toContain('Intro paragraph.');
+    expect(lead).toContain('## First section');
+    expect(lead).toContain('Core explanation.');
+    expect(sections.map(s => s.title)).toEqual(['Deep dive', 'Possible sources & where to go further']);
+    expect(sections[1].body).toContain('Attribution block.');
+  });
+
+  it('does not split on ## inside code fences', () => {
+    const { sections } = splitExplainer(MD);
+    const deep = sections[0];
+    expect(deep.body).toContain('// ## not a heading');
+    expect(sections.some(s => s.title.includes('not a heading'))).toBe(false);
+  });
+
+  it('handles markdown with no sections at all', () => {
+    const { lead, sections } = splitExplainer('Just prose.\n\nMore prose.');
+    expect(lead).toContain('Just prose.');
+    expect(sections).toEqual([]);
+  });
+
+  it('ignores ### subheadings (only ## splits)', () => {
+    const { lead, sections } = splitExplainer('Intro\n\n## One\n\n### Sub\n\nbody');
+    expect(lead).toContain('### Sub');
+    expect(sections).toEqual([]);
+  });
+});

--- a/src/chrome/catalog.ts
+++ b/src/chrome/catalog.ts
@@ -4,14 +4,27 @@ import type { PreviewKind } from './previews';
 /**
  * Gallery catalog — the landing-page cards, grouped by topic (DESIGN-SPEC §1).
  * Derives name/glyph/blurb from src/apps.ts (the canonical registry) and adds
- * the gallery-only metadata here: category and preview kind. The card order
- * follows src/apps.ts. An app is shown only if it has a META entry below, so
- * dropping an entry retires its card while keeping the route live:
- * `#/fractals-cpu` (legacy) is intentionally absent.
+ * the gallery-only metadata here: category, preview kind, the card's leading
+ * question, starter rank and GPU badge. The card order follows src/apps.ts.
+ * An app is shown only if it has a META entry below, so dropping an entry
+ * retires its card while keeping the route live: `#/fractals-cpu` (legacy) is
+ * intentionally absent.
  */
-export type Category = 'Complex' | 'Fractal' | 'Dynamics' | 'Algorithm';
+export type Category =
+  | 'Transformations'
+  | 'Iteration & Chaos'
+  | 'Algorithms & Emergence'
+  | 'Geometry & Topology'
+  | 'Probability & Inference';
 
-export const CATEGORIES: Array<'All' | Category> = ['All', 'Complex', 'Fractal', 'Dynamics', 'Algorithm'];
+export const CATEGORIES: Array<'All' | Category> = [
+  'All',
+  'Transformations',
+  'Iteration & Chaos',
+  'Algorithms & Emergence',
+  'Geometry & Topology',
+  'Probability & Inference',
+];
 
 export interface AppCard {
   /** Stable id (hash without the leading slash) — also the workspace appId. */
@@ -22,25 +35,75 @@ export interface AppCard {
   blurb: string;
   cat: Category;
   kind: PreviewKind;
+  /** The card's leading line: the question the app explores (or a crisp
+   *  statement of what it does). Shown in place of the registry blurb. */
+  question?: string;
+  /** Rank in the quiet "start here" row (1..3). Absent = regular card. */
+  starter?: number;
+  /** Needs WebGL — shown as a small courtesy badge (failure is contained
+   *  since the chrome-hardening pass, so this is information, not a warning). */
+  gpu?: boolean;
   /** Parked/retired: shown only in the gallery's de-emphasized Storeroom section
    *  (out of the main grid and the category filter), but the route stays live. */
   storeroom?: boolean;
 }
 
-const META: Record<string, { cat: Category; kind: PreviewKind; storeroom?: boolean }> = {
-  '/complex-particles': { cat: 'Complex', kind: 'particles' },
-  '/plane-transform': { cat: 'Complex', kind: 'plane' },
-  '/fractals': { cat: 'Fractal', kind: 'fractal' },
-  '/correspondence': { cat: 'Fractal', kind: 'julia' },
-  '/trinary': { cat: 'Dynamics', kind: 'trinary' },
-  '/agentic-sorting': { cat: 'Algorithm', kind: 'sorting' },
-  '/stable-matching': { cat: 'Algorithm', kind: 'matrix' },
-  '/polygon-worlds': { cat: 'Dynamics', kind: 'polygon' },
-  '/trees-and-nets': { cat: 'Algorithm', kind: 'treenet' },
-  '/solid-worlds': { cat: 'Dynamics', kind: 'solid' },
-  '/argand': { cat: 'Complex', kind: 'plane' },
-  '/counting-the-ways': { cat: 'Algorithm', kind: 'skellam' },
-  '/division-bells': { cat: 'Algorithm', kind: 'divergence', storeroom: true },
+const META: Record<string, {
+  cat: Category; kind: PreviewKind;
+  question?: string; starter?: number; gpu?: boolean; storeroom?: boolean;
+}> = {
+  '/complex-particles': {
+    cat: 'Transformations', kind: 'particles', starter: 1, gpu: true,
+    question: 'What does a complex function look like — all of it at once? Fly around its 4D graph as a living cloud of particles.',
+  },
+  '/plane-transform': {
+    cat: 'Transformations', kind: 'plane', gpu: true,
+    question: 'What does f(z) do to the whole plane at once? Watch a colored grid bend under the map.',
+  },
+  '/fractals': {
+    cat: 'Iteration & Chaos', kind: 'fractal', gpu: true,
+    question: 'How does z² + c, repeated forever, draw an infinite coastline? Zoom until floating-point itself runs out.',
+  },
+  '/correspondence': {
+    cat: 'Iteration & Chaos', kind: 'julia', gpu: true,
+    question: 'Every point of the Mandelbrot set seeds its own Julia set — which ones bloom, and which shatter?',
+  },
+  '/trinary': {
+    cat: 'Iteration & Chaos', kind: 'trinary', starter: 2, gpu: true,
+    question: 'Can a planet with three suns know its own future? Watch a swarm of near-identical worlds agree — then scatter.',
+  },
+  '/agentic-sorting': {
+    cat: 'Algorithms & Emergence', kind: 'sorting',
+    question: 'What happens when a crowd of agents, each with its own strategy, tries to sort itself?',
+  },
+  '/stable-matching': {
+    cat: 'Algorithms & Emergence', kind: 'matrix',
+    question: 'When two sides rank each other, who wins the matching game — and does proposing first pay?',
+  },
+  '/polygon-worlds': {
+    cat: 'Geometry & Topology', kind: 'polygon', starter: 3, gpu: true,
+    question: 'Glue the edges of one square and step inside: which world are you walking in — torus, Klein bottle, sphere?',
+  },
+  '/trees-and-nets': {
+    cat: 'Algorithms & Emergence', kind: 'treenet',
+    question: 'How do you turn a table of distances back into the tree that made it — and what if it never was a tree?',
+  },
+  '/solid-worlds': {
+    cat: 'Geometry & Topology', kind: 'solid', gpu: true,
+    question: 'What is it like to live inside a closed universe made of one room? Walk through a wall and come back mirrored.',
+  },
+  '/argand': {
+    cat: 'Transformations', kind: 'plane',
+    question: 'What does multiplying look like? A spiral. Adding? A slide. Build y = mx + b for the plane and watch it move.',
+  },
+  '/counting-the-ways': {
+    cat: 'Probability & Inference', kind: 'skellam',
+    question: 'Why does a Bessel function appear when two Poisson counts race? Count the ways, one diagonal rung at a time.',
+  },
+  '/division-bells': {
+    cat: 'Probability & Inference', kind: 'divergence', storeroom: true,
+    question: 'How far apart are two bell curves, really? Two rulers — Mahalanobis and KL — measure the gap differently.',
+  },
 };
 
 export const CARDS: AppCard[] = apps

--- a/src/chrome/previews.tsx
+++ b/src/chrome/previews.tsx
@@ -41,12 +41,19 @@ function useCanvas(draw: DrawFn, deps: React.DependencyList) {
     // Paint one frame synchronously so cards are never blank on first render
     // (and screenshots capture content even with rAF throttled off-screen).
     try { draw(ctx, cv.width, cv.height, 0); } catch { /* ignore */ }
+    // Reduced motion: the synchronous frame above IS the preview — a still of
+    // each world — and the animation loop never starts.
+    if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+      return () => { ro.disconnect(); };
+    }
     let visible = true;
     const loop = (t: number) => {
       if (!running || !visible) { raf = 0; return; }
       // rAF timestamps can precede the t0 captured above (they are vsync
       // times) — clamp so draw never sees a negative t (JS % keeps sign).
-      draw(ctx, cv.width, cv.height, Math.max(0, (t - t0) / 1000));
+      // The global 0.65 scale calms the whole wall of previews — twelve live
+      // canvases at full tempo read as frenetic; the motion stays, slower.
+      draw(ctx, cv.width, cv.height, Math.max(0, (t - t0) / 1000) * 0.65);
       raf = requestAnimationFrame(loop);
     };
     // Pause scrolled-away cards — ten always-running canvases jank the

--- a/src/chrome/theme.css
+++ b/src/chrome/theme.css
@@ -548,7 +548,26 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 
 /* ============ Explainer modal ============ */
 .am-modal-scrim { position: fixed; inset: 0; z-index: var(--z-modal); background: rgba(0,0,0,0.45); display: flex; align-items: center; justify-content: center; cursor: pointer; touch-action: manipulation; }
-.am-modal { width: min(560px, 92%); max-height: 86%; overflow-y: auto; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow); padding: 22px 24px; animation: am-pop .2s var(--ease); }
+.am-modal { width: min(560px, 92%); max-height: 86%; overflow-y: auto; overflow-x: hidden; background: var(--panel-solid); border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow); padding: 22px 24px; animation: am-pop .2s var(--ease); }
+/* Wide content (code, tables, formulas) scrolls inside its own box — the
+   dialog itself never scrolls horizontally. */
+.am-modal .markdown-body pre { overflow-x: auto; max-width: 100%; }
+.am-modal .markdown-body table { display: block; overflow-x: auto; max-width: 100%; }
+.am-modal .markdown-body img { max-width: 100%; }
+/* Layered explainer folds: every section after the first collapses behind a
+   quiet disclosure — the dialog opens on the essentials and can still go deep. */
+.am-expl-fold { border-top: 1px solid var(--border); margin-top: 14px; }
+.am-expl-fold summary {
+  cursor: pointer; padding: 11px 2px; list-style: none;
+  font-family: var(--font-mono); font-size: 11.5px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase; color: var(--dim);
+  display: flex; align-items: center; gap: 8px;
+}
+.am-expl-fold summary::-webkit-details-marker { display: none; }
+.am-expl-fold summary::before { content: "▸"; font-size: 10px; transition: transform .15s var(--ease); }
+.am-expl-fold[open] summary::before { transform: rotate(90deg); }
+.am-expl-fold summary:hover { color: var(--fg); }
+.am-expl-fold[open] summary { color: var(--fg); }
 .am-modal h2 { margin: 0 0 12px; font-size: 19px; }
 .am-modal-head { display: flex; align-items: center; gap: 10px; }
 .am-modal-head h2 { flex: 1; }
@@ -581,6 +600,22 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
 .am-chip { padding: 7px 14px; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--dim); font: inherit; font-size: 12.5px; font-weight: 700; cursor: pointer; }
 .am-chip.am-on { background: var(--accent); color: var(--accent-fg); border-color: var(--accent); }
 .am-gal-grid { padding: 18px 40px 48px; display: grid; grid-template-columns: repeat(auto-fill, minmax(248px, 1fr)); gap: 16px; }
+/* Quiet section labels for the entrance (Start here · Everything): typography
+   does the work — mono, small caps, a hairline — no chatty copy. */
+.am-gal-kicker {
+  padding: 20px 40px 0; display: flex; align-items: center; gap: 12px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  letter-spacing: .12em; text-transform: uppercase; color: var(--dim);
+}
+.am-gal-kicker::after { content: ""; flex: 1; height: 1px; background: var(--border); }
+.am-gal-kicker + .am-gal-grid { padding-top: 12px; padding-bottom: 8px; }
+/* Card meta row: category left, badges right. */
+.am-gcard-meta { display: flex; align-items: baseline; justify-content: space-between; gap: 8px; }
+.am-gcard-gpu {
+  font-family: var(--font-mono); font-size: 9px; font-weight: 600; letter-spacing: .1em;
+  color: var(--dim-2); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px;
+  flex-shrink: 0;
+}
 .am-gcard { text-align: left; font: inherit; color: inherit; text-decoration: none; border: 1px solid var(--border); border-radius: 14px; overflow: hidden; background: var(--panel-2); cursor: pointer; transition: transform .18s var(--ease), border-color .18s, box-shadow .18s; display: flex; flex-direction: column; padding: 0; }
 .am-gcard:hover { transform: translateY(-3px); border-color: var(--border-strong); box-shadow: var(--shadow); }
 .am-gcard-viz { height: 132px; position: relative; background: #000; }
@@ -984,6 +1019,7 @@ input[type="checkbox"]:focus-visible { outline: 2px solid var(--accent); outline
   .am-gal-tag { font-size: 14px; }
   .am-gal-filters { padding: 14px 20px 4px; }
   .am-gal-grid { grid-template-columns: 1fr; padding: 14px 20px 30px; gap: 14px; }
+  .am-gal-kicker { padding: 16px 20px 0; }
   .am-gal-foot { padding: 0 20px 28px; }
   .am-gal-storeroom { margin: 0 20px 30px; }
   .am-titlewrap .am-sub { display: none; }


### PR DESCRIPTION
Executes Dan's answers to the post-review product questions (all chrome; no app logic touched).

## 1–3 · The gallery entrance
- A quiet **Start here** row — Complex Particles → Trinary System → Polygon Worlds — then **Everything**, both labeled by small mono kickers with a hairline (typography, not chatty copy).
- Cards now lead with **the question each app explores** (new per-card `question` in `catalog.ts`) instead of the registry blurb.
- **GPU courtesy badge** on the seven WebGL apps (info, not warning — failure is contained since #252). No guided/open-lab chip, per Dan.
- Categories re-binned to the reviewer's five: **Transformations · Iteration & Chaos · Algorithms & Emergence · Geometry & Topology · Probability & Inference**.

## 5 · Layered explainers ("fix it")
The "?" dialog opens on the intro + first section; every later section folds behind a quiet `<details>` disclosure (`splitExplainer()`, fence-aware, unit-tested ×4). **No `EXPLAINER.md` content rewritten** — attribution blocks survive as their own folded layer. The dialog can no longer scroll horizontally (pre/table/img contained). Trinary's modal went from thousands of pixels to 726px with 6 folds.

## 6 · Calmer previews
Global 0.65× time scale on the shared preview loop (the moving gallery stays, less frenetic), and `prefers-reduced-motion` renders a still first frame with no loop. Offscreen pause already existed.

## Honored without change
Observatory stays the default theme (4); moving gallery kept (6); no tablet mode (7); Trinary leftovers parked (9).

## Also included (docs only)
The **contrast & focus-color audit** (item 8, run by a background agent) is committed as a `status: proposed` plan doc — **no tokens changed**; awaiting Dan's approval on the per-skin values.

## Verification
`npm test` → 311 pass (4 new splitter tests) · build clean · lint 0 · sessions-lint clean · gallery + modal verified with headless screenshots/driving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X7qW9gEW5LQ5SCo5G9KEGg

---
_Generated by [Claude Code](https://claude.ai/code/session_01X7qW9gEW5LQ5SCo5G9KEGg)_